### PR TITLE
adding file replication from builds into bintray

### DIFF
--- a/example/dev.yml
+++ b/example/dev.yml
@@ -13,4 +13,4 @@
     - snmptool
     - ipmitool
     - foreman
-    - repos 
+    - repos

--- a/example/roles/repos/tasks/main.yml
+++ b/example/roles/repos/tasks/main.yml
@@ -54,7 +54,7 @@
    - base.trusty.3.13.0-32-generic.squashfs.img
    - discovery.overlay.cpio.gz
    - initrd.img-3.13.0-32-generic
-   - vmlinux-3.13.0-32-generic
+   - vmlinuz-3.13.0-32-generic
 
 - name: retrieve bootloaders from bintray
   get_url: url=https://bintray.com/artifact/download/rackhd/binary/ipxe/{{ item }}

--- a/example/roles/repos/tasks/main.yml
+++ b/example/roles/repos/tasks/main.yml
@@ -46,3 +46,19 @@
   shell: 'npm run apidoc'
   args:
     chdir: /home/vagrant/src/on-http
+
+- name: retrieve microkernel and overlays from bintray
+  get_url: url=https://bintray.com/artifact/download/rackhd/binary/builds/{{ item }}
+           dest=/home/vagrant/src/on-http/static/http/common/{{ item }}
+  with_items:
+   - base.trusty.3.13.0-32-generic.squashfs.img
+   - discovery.overlay.cpio.gz
+   - initrd.img-3.13.0-32-generic
+   - vmlinux-3.13.0-32-generic
+
+- name: retrieve bootloaders from bintray
+  get_url: url=https://bintray.com/artifact/download/rackhd/binary/ipxe/{{ item }}
+           dest=/home/vagrant/src/on-tftp/static/tftp/{{ item }}
+  with_items:
+   - ipxe.ipxe
+   - undionly.ipxe

--- a/example/roles/repos/tasks/main.yml
+++ b/example/roles/repos/tasks/main.yml
@@ -60,5 +60,5 @@
   get_url: url=https://bintray.com/artifact/download/rackhd/binary/ipxe/{{ item }}
            dest=/home/vagrant/src/on-tftp/static/tftp/{{ item }}
   with_items:
-   - ipxe.ipxe
-   - undionly.ipxe
+   - ipxe.pxe
+   - undionly.kpxe


### PR DESCRIPTION
NOTE: names of these files vary around a bit, we may need to massage the
default workflows to match the relevant filenames for the demo setup

Total "vagrant up" time with bintray downloads enable = 20 min (from my coffee shop & laptop)