### PR TITLE
partial fix to demo setup

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -18,7 +18,7 @@ installed onto your system in order to use this script.
 
 [ansible roles](https://github.com/RackHD/RackHD/tree/master/example/roles)
 
-We also rely on the this projects structure of submodules to link the source
+We also rely on the projects structure of submodules to link the source
 into the VM (through vagrant). The ansible roles are written to expect the
 source to be autoloaded on the virtual machine with directory mappings
 configured in Vagrantfile:
@@ -141,6 +141,7 @@ with a default SSH key that's included in our repositories. From the `example`
 directory, you should be able to log in using:
 
 `vagrant ssh`
+
     cp ~/src/on-http/data/rackhd_rsa ~/.ssh/id_rsa
     chmod 400 ~/.ssh/id_rsa
     ssh -i ~/src/on-http/data/rackhd_rsa core@172.32.128.2
@@ -160,7 +161,8 @@ for rebooting the `pxe-1` virtual machine.
 
 ### UNPACKING AN OS INSTALL ISO
 
-For example, you can [manually download the ESXi installation ISO](https://www.vmware.com/go/download-vspherehypervisor) or download a [CentOS 7 LiveCD](http://buildlogs.centos.org/centos/7/isos/x86_64/CentOS-7-livecd-x86_64.iso).
+For example, you can [manually download the ESXi installation ISO](https://www.vmware.com/go/download-vspherehypervisor)
+or download a [CentOS 7 LiveCD](http://buildlogs.centos.org/centos/7/isos/x86_64/CentOS-7-livecd-x86_64.iso).
 
 Copy it into the `examples` directory and then you can unpack it in vagrant:
 
@@ -177,14 +179,10 @@ Copy it into the `examples` directory and then you can unpack it in vagrant:
     sudo python ~/src/on-http/data/templates/setup_iso.py /vagrant/Cent*.iso \
     /var/mirrors --link=/home/vagrant/src
 
-
-
-
-
 ## HACKING THESE SCRIPTS
 
-If you're having on this script or the [ansible roles](https://github.com/RackHD/RackHD/tree/master/example/roles) to change the
-functionality, you can shortcut some of this process by just invoking
+If you're having on this script or the [ansible roles](https://github.com/RackHD/RackHD/tree/master/example/roles)
+to change the functionality, you can shortcut some of this process by just invoking
 `vagrant provision` to use ansible to update the VM that's already been created.
 
 

--- a/example/README.md
+++ b/example/README.md
@@ -11,8 +11,12 @@ to connect DHCP and TFTP from RackHD to the PXE clients.
 
 ## PRE-REQS / SCRIPT EXPECTATIONS
 
-We expect the latest version of git, Vagrant, and Ansible installed onto your
-system in order to use this script.
+We expect the latest version of git, [Vagrant](https://www.vagrantup.com/downloads.html),
+and [Ansible](http://docs.ansible.com/ansible/intro_installation.html)
+installed onto your system in order to use this script.
+
+
+[ansible roles](https://github.com/RackHD/RackHD/tree/master/example/roles)
 
 We also rely on the this projects structure of submodules to link the source
 into the VM (through vagrant). The ansible roles are written to expect the
@@ -42,15 +46,18 @@ Change into the directory `example`, create config and run the setup command:
     $ cp ./monorail_rack.cfg.example ./monorail_rack.cfg
     $ popd
 
+
 Edits can be made to this new file to adjust the number of pxe clients created.
 
     $ pushd bin/
     $ ./monorail_rack
 
+
 Now ssh into the RackHD server and start the services
 
     $ vagrant ssh
     $ sudo nf start
+
 
 ## TESTING
 
@@ -62,10 +69,14 @@ You can also interact with the APIs using curl from the command line of your
 local machine.
 
 To view the list of nodes that has been discovered:
+
     $ curl http://localhost:9090/api/1.1/nodes | python -m json.tool
 
+
 View the list of catalogs logged into RackHD:
+
     $ curl http://localhost:9090/api/1.1/catalogs | python -m json.tool
+
 
 (both of these should result in empty lists in a brand new installation)
 
@@ -84,6 +95,7 @@ of workflows:
     -X PUT --data @samples/virtualbox_install_coreos.json \
     http://localhost:9090/api/1.1/workflows
 
+
 To enable that workflow, we also need to include a SKU definition that includes
 the option of another workflow to run once the SKU has been identified. This
 takes advantage of the `Graph.SKU.Discovery` workflow, which will attempt to
@@ -96,29 +108,82 @@ identify a SKU and run another workflow if specified.
     -X POST --data @samples/virtualbox_sku.json \
     http://localhost:9090/api/1.1/skus
 
+
 View the current SKU definitions:
 
-    $ curl http://localhost:9090/api/1.1/skus | python -m json.tool
+`curl http://localhost:9090/api/1.1/skus | python -m json.tool`
+
     [
-    {
-        "createdAt": "2015-11-21T00:46:04.068Z",
-        "discoveryGraphName": "Graph.DefaultVirtualBox.InstallCoreOS",
-        "discoveryGraphOptions": {},
-        "id": "564fbecc1dee9e7d2f1d33ca",
-        "name": "Noop OBM settings for VirtualBox nodes",
-        "rules": [
-            {
-                "equals": "VirtualBox",
-                "path": "dmi.System Information.Product Name"
-            }
-        ],
-        "updatedAt": "2015-11-21T00:46:04.068Z"
-    }
-]
+        {
+            "createdAt": "2015-11-21T00:46:04.068Z",
+            "discoveryGraphName": "Graph.DefaultVirtualBox.InstallCoreOS",
+            "discoveryGraphOptions": {},
+            "id": "564fbecc1dee9e7d2f1d33ca",
+            "name": "Noop OBM settings for VirtualBox nodes",
+            "rules": [
+                {
+                    "equals": "VirtualBox",
+                    "path": "dmi.System Information.Product Name"
+                }
+            ],
+            "updatedAt": "2015-11-21T00:46:04.068Z"
+        }
+    ]
+
+Once you've added those definitions, you can start up the test "PXE-1" virtual machine
+using the command:
+
+    vboxmanage startvm pxe-1 --type gui
+
+You should see the VM PXE boot, get discovered, and ultimately get CoreOS
+installed. The installation workflow included in the RackHD system installs
+with a default SSH key that's included in our repositories. From the `example`
+directory, you should be able to log in using:
+
+`vagrant ssh`
+    cp ~/src/on-http/data/rackhd_rsa ~/.ssh/id_rsa
+    chmod 400 ~/.ssh/id_rsa
+    ssh -i ~/src/on-http/data/rackhd_rsa core@172.32.128.2
+
+
+## USING OTHER WORKFLOWS
+
+There are a number of workflows loaded by default in RackHD. Many of those
+workflows rely on files or directories we don't package in this demonstration
+in order to keep the setup times and resource usage small (or because we can't
+legally redistribute some of the vendor specific tooling).
+
+If you want to try some of the other workflows, especially related to installing
+an OS, you'll need to add those files, and you'll need to work around the current
+limitation that the vagrant demonstration doesn't have any out-of-band mechanism
+for rebooting the `pxe-1` virtual machine.
+
+### UNPACKING AN OS INSTALL ISO
+
+For example, you can [manually download the ESXi installation ISO](https://www.vmware.com/go/download-vspherehypervisor) or download a [CentOS 7 LiveCD](http://buildlogs.centos.org/centos/7/isos/x86_64/CentOS-7-livecd-x86_64.iso).
+
+Copy it into the `examples` directory and then you can unpack it in vagrant:
+
+`vagrant ssh`:
+
+    sudo mkdir /var/mirrors
+    sudo python ~/src/on-http/data/templates/setup_iso.py \
+    /vagrant/VMware-VMvisor-Installer-*.x86_64.iso \
+    /var/mirrors --link=/home/vagrant/src
+
+`mv ~/Downloads/CentOS*.iso ~/src/rackhd/example/`
+`vagrant ssh`:
+
+    sudo python ~/src/on-http/data/templates/setup_iso.py /vagrant/Cent*.iso \
+    /var/mirrors --link=/home/vagrant/src
+
+
+
+
 
 ## HACKING THESE SCRIPTS
 
-If you're having on this script or the ansible roles to change the
+If you're having on this script or the [ansible roles](https://github.com/RackHD/RackHD/tree/master/example/roles) to change the
 functionality, you can shortcut some of this process by just invoking
 `vagrant provision` to use ansible to update the VM that's already been created.
 
@@ -166,9 +231,11 @@ variable for the ansible provisioner. A commented out line exists in
 The monorail_rack script doesn't currently have the capability to shut down or
 remove anything. To get rid of the RackHD server you can use:
 
-    $ vagrant destroy
+    vagrant destroy
 
-Any PXE client VMs you created will need to be removed by hand.
+And you can remove the PXE vm(s) using the `vboxmanage` command, such as:
+
+    vboxmanage unregistervm --delete pxe-1
 
 ## Running the web UI
 

--- a/example/roles/build/tasks/main.yml
+++ b/example/roles/build/tasks/main.yml
@@ -3,4 +3,5 @@
   apt: pkg={{ item }} state=installed update-cache=yes
   with_items:
     - build-essential
+    - genisoimage
   sudo: yes

--- a/example/roles/repos/tasks/main.yml
+++ b/example/roles/repos/tasks/main.yml
@@ -93,7 +93,7 @@
 
 - name: retrieve CoreOS kernel and initrd
   get_url: url=http://stable.release.core-os.net/amd64-usr/current/{{ item }}
-           dest=/home/vagrant/src/on-http/static/http/coreos/766.5.0/{{ item }}
+           dest=/home/vagrant/src/on-http/static/http/coreos/835.8.0/{{ item }}
            force=yes
   with_items:
    - coreos_production_image.bin.bz2

--- a/scripts/reset_submodules.bash
+++ b/scripts/reset_submodules.bash
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# enable to see script debug output
+#set -x
+
+SCRIPT_DIR=$(cd $(dirname $0) && pwd)
+echo "Resetting all submodules to latest master branch"
+
+REPOS="on-core on-tasks on-dhcp-proxy on-http on-syslog on-tftp on-taskgraph"
+for repo in ${REPOS}; do
+    pushd "${SCRIPT_DIR}/../${repo}"
+    git fetch --all --prune
+    git reset --hard origin/master
+    popd
+done


### PR DESCRIPTION
functional, but partial fix to demo setup. Updated instructions rely on
https://github.com/RackHD/on-http/pull/56 and
https://github.com/RackHD/on-http/pull/57, and the on-http submodule to
be updated to include both of those commits.

 - resets the default SSH key for remote access (note: CoreOS SSH login not
   working per these instructions - not sure what I'm missing and haven't
   debugged login yet)

 - adding instructions and quick-links to download and unpack ESXi and
   CentOS7 iso images, and link them into the vagrant install

 - in support of the annotations in
   https://github.com/RackHD/docs/pull/203 to point readers to this
   local README for quick-setup instructions

 - adds a script to make it easier to update the submodules to 'master' for 
   demo work