### PR TITLE
removed all but one apt-get update from roles

### DIFF
--- a/example/dev.yml
+++ b/example/dev.yml
@@ -3,6 +3,7 @@
   hosts: all
   sudo: no
   roles:
+    - apt
     - build
     - git
     - rabbitmq

--- a/example/roles/apt/tasks/main.yml
+++ b/example/roles/apt/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Update apt
+  apt: update-cache=yes
+  sudo: yes

--- a/example/roles/build/tasks/main.yml
+++ b/example/roles/build/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install Build Tools
-  apt: pkg={{ item }} state=installed update-cache=yes
+  apt: pkg={{ item }} state=installed
   with_items:
     - build-essential
     - genisoimage

--- a/example/roles/git/tasks/main.yml
+++ b/example/roles/git/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install Git
-  apt: pkg={{ item }} state=installed update-cache=yes
+  apt: pkg={{ item }} state=installed
   with_items:
     - git
   sudo: yes

--- a/example/roles/ipmitool/tasks/main.yml
+++ b/example/roles/ipmitool/tasks/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: Install ipmitool
-  apt: pkg=ipmitool state=installed update-cache=yes
+  apt: pkg=ipmitool state=installed
   sudo: yes

--- a/example/roles/isc-dhcp-server/tasks/main.yml
+++ b/example/roles/isc-dhcp-server/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install isc-dhcp-server
-  apt: pkg={{ item }} state=installed update-cache=yes 
+  apt: pkg={{ item }} state=installed
   with_items:
     - isc-dhcp-server
   sudo: yes
@@ -9,9 +9,9 @@
 - name: Copy isc-dhcp-server file to guest
   copy: src=isc-dhcp-server dest=/etc/default/isc-dhcp-server
   sudo: yes
-  
+
 - name: Copy dhcpd.conf file to guest
-  copy: src=dhcpd.conf dest=/etc/dhcp/dhcpd.conf  
+  copy: src=dhcpd.conf dest=/etc/dhcp/dhcpd.conf
   sudo: yes
 
 - name: Start isc-dhcp-server

--- a/example/roles/mongodb/tasks/main.yml
+++ b/example/roles/mongodb/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install MongoDB
-  apt: pkg={{ item }} state=installed update-cache=yes
+  apt: pkg={{ item }} state=installed
   with_items:
     - mongodb
   sudo: yes

--- a/example/roles/rabbitmq/tasks/main.yml
+++ b/example/roles/rabbitmq/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install RabbitMQ
-  apt: pkg={{ item }} state=installed update-cache=yes
+  apt: pkg={{ item }} state=installed
   with_items:
     - rabbitmq-server
   sudo: yes

--- a/example/roles/snmptool/tasks/main.yml
+++ b/example/roles/snmptool/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install Build Tools
-  apt: pkg={{ item }} state=installed update-cache=yes
+  apt: pkg={{ item }} state=installed
   with_items:
     - snmp
   sudo: yes


### PR DESCRIPTION
It was suggested to only run apt-get update on the first role we run to elevate repetitive actions. I have made the fix. @heckj @benbp   