### PR TITLE
Fix OBM tests

### DIFF
--- a/test/tests/nodes_tests.py
+++ b/test/tests/nodes_tests.py
@@ -11,6 +11,7 @@ from proboscis.asserts import assert_true
 from proboscis import SkipTest
 from proboscis import test
 from json import dumps, loads
+
 LOG = Log(__name__)
 
 
@@ -71,23 +72,6 @@ class NodesTests(object):
         assert_equal(200, self.__client.last_response.status)
         assert_not_equal(0, len(nodes), message='Node list was empty!')
 
-    @test(groups=['create-node-id-obm-identify'], depends_on_groups=['nodes.test', 'test-nodes'])
-    def test_node_id_obm_identify_create(self):
-        """ Testing POST:/nodes/:id/obm/identify """
-        Nodes().api1_1_nodes_get()
-        nodes = loads(self.__client.last_response.data)
-        codes = []
-        data = {"value": True}
-        for n in nodes:
-            if n.get('type') == 'compute':
-                uuid = n.get('id')
-                Nodes().api1_1_nodes_identifier_obm_identify_post(uuid, data)
-                rsp = self.__client.last_response
-                codes.append(rsp)
-        for c in codes:
-            assert_equal(200, c.status, message=c.reason)
-        assert_raises(rest.ApiException, Nodes().api1_1_nodes_identifier_obm_identify_post, 'fooey', data)
-
     @test(groups=['test-node-id'], depends_on_groups=['test-nodes'])
     def test_node_id(self):
         """ Testing GET:/nodes/:id """
@@ -123,27 +107,6 @@ class NodesTests(object):
         for c in codes:
             assert_equal(200, c.status, message=c.reason)
         assert_raises(rest.ApiException, Nodes().api1_1_nodes_identifier_obm_get, 'fooey')
-
-    @test(groups=['create-node-id-obm'], depends_on_groups=['test-nodes', 'create-node'])
-    def test_node_id_obm_create(self):
-        """ Testing POST:/nodes/:id/obm """
-        Nodes().api1_1_nodes_get()
-        nodes = loads(self.__client.last_response.data)
-        codes = []
-        data = {
-                    "config": {"host": "00:00:00:00:00:00", "password": "good", "user": "verygood"},
-                    "service": "ipmi-obm-service"
-        }
-        for n in nodes:
-            if n.get('name') == 'test_compute_node':
-                uuid = n.get('id')
-                Nodes().api1_1_nodes_identifier_obm_post(uuid, data)
-                rsp = self.__client.last_response
-                codes.append(rsp)
-        assert_not_equal(0, len(codes), message='Failed to find compute node Ids')
-        for c in codes:
-            assert_equal(201, c.status, message=c.reason)
-        assert_raises(rest.ApiException, Nodes().api1_1_nodes_identifier_obm_post, 'fooey', data)
 
     @test(groups=['create-node'], depends_on_groups=['test-nodes'])
     def test_node_create(self):
@@ -297,3 +260,4 @@ class NodesTests(object):
         for resp in resps:
             assert_not_equal(0, len(loads(resp)), message='No active Workflows found for Node')
         assert_raises(rest.ApiException, Nodes().api1_1_nodes_identifier_workflows_active_delete, 'fooey')
+


### PR DESCRIPTION
- Delete redundant test_node_id_obm_create()
- Move OBM identify test into OBMTests() and set check-obm dependency

@RackHD/corecommitters @zyoung51 @tannoa2 @keedya @uppalk1 