### PR TITLE
ammending procfile to capture logs

### DIFF
--- a/packer/ansible/roles/foreman/files/Procfile
+++ b/packer/ansible/roles/foreman/files/Procfile
@@ -2,8 +2,8 @@
 
 # SUDO must be enabled in the terminal before running nf start (or run sudo nf start)
 # See .env for environment variable definitions
-graph: /bin/bash -c "echo running $TASKGRAPHDIR/index.js; cd $TASKGRAPHDIR && exec sudo node index.js"
-http: /bin/bash -c "echo running $HTTPDIR/index.js; cd $HTTPDIR && exec sudo node index.js"
-dhcp: /bin/bash -c "echo running $DHCPDIR/index.js; cd $DHCPDIR && exec sudo node index.js"
-tftp: /bin/bash -c "echo running $TFTPDIR/index.js; cd $TFTPDIR && exec sudo node index.js"
-syslog: /bin/bash -c "echo running $SYSLOGDIR/index.js; cd $SYSLOGDIR && exec sudo node index.js"
+graph: /bin/bash -c "echo running $TASKGRAPHDIR/index.js; cd $TASKGRAPHDIR && exec sudo node index.js | tee /tmp/taskgraph.log"
+http: /bin/bash -c "echo running $HTTPDIR/index.js; cd $HTTPDIR && exec sudo node index.js | tee /tmp/http.log"
+dhcp: /bin/bash -c "echo running $DHCPDIR/index.js; cd $DHCPDIR && exec sudo node index.js | tee /tmp/dhcp-proxy.log"
+tftp: /bin/bash -c "echo running $TFTPDIR/index.js; cd $TFTPDIR && exec sudo node index.js | tee /tmp/tftp.log"
+syslog: /bin/bash -c "echo running $SYSLOGDIR/index.js; cd $SYSLOGDIR && exec sudo node index.js | tee /tmp/syslog.log"


### PR DESCRIPTION
Per slack conversation on 1/8 #RackHD, debugging Pasu's issues
really needed to see the logs - and what was missing from them,
so I thought it might be beneficial to capture them in the procfile
setup on a per-run basis, hence this update.