### PR TITLE
updating microkernel and bootloader for ESX

### DIFF
--- a/packer/ansible/roles/images/tasks/main.yml
+++ b/packer/ansible/roles/images/tasks/main.yml
@@ -19,7 +19,6 @@
    - monorail.ipxe
    - monorail-efi32-snponly.efi
    - monorail-efi64-snponly.efi
-   - undionly.kpxe
 
 - name: retrieve the latest syslinux bootloader from bintray
   get_url: url="https://bintray.com/artifact/download/rackhd/binary/syslinux/{{ item }}"

--- a/packer/ansible/roles/images/tasks/main.yml
+++ b/packer/ansible/roles/images/tasks/main.yml
@@ -5,10 +5,10 @@
            validate_certs=no
            force=yes
   with_items:
-   - base.trusty.3.13.0-32-generic.squashfs.img
    - discovery.overlay.cpio.gz
-   - initrd.img-3.13.0-32-generic
-   - vmlinuz-3.13.0-32-generic
+   - base.trusty.3.16.0-25-generic.squashfs.img
+   - initrd.img-3.16.0-25-generic
+   - vmlinuz-3.16.0-25-generic
 
 - name: retrieve the latest bootloaders from bintray
   get_url: url="https://bintray.com/artifact/download/rackhd/binary/ipxe/{{ item }}"
@@ -20,3 +20,11 @@
    - monorail-efi32-snponly.efi
    - monorail-efi64-snponly.efi
    - undionly.kpxe
+
+- name: retrieve the latest syslinux bootloader from bintray
+  get_url: url="https://bintray.com/artifact/download/rackhd/binary/syslinux/{{ item }}"
+           dest="/home/vagrant/src/on-tftp/static/tftp/{{ item }}"
+           validate_certs=no
+           force=yes
+  with_items:
+   - undionly.kkpxe


### PR DESCRIPTION
 - updating microkernel versions to 3.16.0-25 to match on-http code
   updates
 - adding undionly.kkpxe bootloader pull from syslinux

Attempted to do the vagrant demo run-through with a fresh built VM from master, and the Ansible roles in packer still had references to the older kernel files for setting this up.

Also looks like we never included in the syslinux undionly.kkpxe bootloader in there