### PR TITLE
Fix workflow related API tests

### DIFF
--- a/test/tests/api/v1_1/nodes_tests.py
+++ b/test/tests/api/v1_1/nodes_tests.py
@@ -10,6 +10,7 @@ from proboscis.asserts import assert_equal
 from proboscis.asserts import assert_false
 from proboscis.asserts import assert_raises
 from proboscis.asserts import assert_not_equal
+from proboscis.asserts import assert_is_not_none
 from proboscis.asserts import assert_true
 from proboscis import SkipTest
 from proboscis import test
@@ -331,14 +332,14 @@ class NodesTests(object):
     @test(groups=['node_workflows_del_active'], depends_on_groups=['node_workflows_active'])
     def test_node_workflows_del_active(self):
         """Testing node DELETE:id/workflows/active"""
-        resps = []
         Nodes().api1_1_nodes_get()
         nodes = loads(self.__client.last_response.data)
         for n in nodes:
             if n.get('type') == 'compute':
-                Nodes().api1_1_nodes_identifier_workflows_active_delete(n.get('id'))
-                resps.append(self.__client.last_response.data)
-        for resp in resps:
-            assert_not_equal(0, len(loads(resp)), message='No active Workflows found for Node')
+                id = n.get('id')
+                assert_is_not_none(id)
+                Nodes().api1_1_nodes_identifier_workflows_active_delete(id)
+                assert_equal(0, len(self.__client.last_response.data), 
+                        message='No active Workflows found for Node {0}'.format(id))
         assert_raises(rest.ApiException, Nodes().api1_1_nodes_identifier_workflows_active_delete, 'fooey')
 

--- a/test/tests/api/v1_1/workflowTasks_tests.py
+++ b/test/tests/api/v1_1/workflowTasks_tests.py
@@ -23,7 +23,13 @@ class WorkflowTasksTests(object):
 
     def __init__(self):
         self.__client = config.api_client
-        self.workflowTaskDict ={"friendlyName": "fn_1","injectableName": "in_1"}
+        self.workflowTaskDict ={
+            "friendlyName": "fn_1",
+            "injectableName": "in_1",
+            "implementsTask": "im_1",
+            "options": {},
+            "properties": {}
+        }
 
 
     @test(groups=['workflowTasks.tests', 'workflowTasks_library_get'])
@@ -53,8 +59,6 @@ class WorkflowTasksTests(object):
                 self.workflowTaskDict['friendlyName']= fnameList[0]+ '_' + str(suffix)
                 inameList = str (rawj[i].get('injectableName')).split('_')
                 self.workflowTaskDict['injectableName']= inameList[0]+ '_' + str(suffix)
-
-
 
         #adding a workflow task
         LOG.info ("Adding workflow task : " +  str(self.workflowTaskDict))


### PR DESCRIPTION
See https://github.com/RackHD/on-http/pull/145 for more information. Requires https://github.com/RackHD/on-http/pull/145/files as well.

A lot of these tests have been returning false positives because the on-http server was incorrectly returning 200 status codes when it should have been returning 400 and 404 status codes. Recent updates to on-http now return proper error status codes, which is now breaking these tests.

@RackHD/corecommitters @VulpesArtificem @heckj 