### PR TITLE
Update 1.1 API tests to use latest python client library

### DIFF
--- a/test/config/api1_1_config.py
+++ b/test/config/api1_1_config.py
@@ -1,8 +1,8 @@
 from settings import * 
-from on_http import Configuration, ApiClient
+from on_http_api1_1 import Configuration, ApiClient
 
 config = Configuration() 
-config.host = 'http://{0}:{1}'.format(HOST_IP,HOST_PORT)
+config.host = 'http://{0}:{1}/api/1.1'.format(HOST_IP,HOST_PORT)
 config.verify_ssl = False
 config.api_client = ApiClient(host=config.host)
 config.debug = False

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -5,5 +5,5 @@ logging==0.4.9.6
 proboscis==1.2.6.0
 requests==2.9.0
 nose==1.3.7
-on-http>=1.0.0
+on-http_api1_1>=1.0.0
 on_http_redfish_1_0>=1.0.0

--- a/test/tests/api/v1_1/amqp_tests.py
+++ b/test/tests/api/v1_1/amqp_tests.py
@@ -3,8 +3,8 @@ from config.api1_1_config import *
 from modules.amqp import AMQPWorker
 from modules.worker import WorkerThread, WorkerTasks
 from modules.logger import Log
-from on_http import NodesApi as Nodes
-from on_http import PollersApi as Pollers
+from on_http_api1_1 import NodesApi as Nodes
+from on_http_api1_1 import PollersApi as Pollers
 from threading import Thread
 from datetime import datetime
 from proboscis.asserts import assert_is_not_none
@@ -35,7 +35,7 @@ class AMQPTests(object):
             if task.id == id:
                 workId = body['value'].get('workItemId')
                 assert_is_not_none(workId)
-                Pollers().api1_1_pollers_identifier_get(workId)
+                Pollers().pollers_identifier_get(workId)
                 poller = loads(self.__client.last_response.data)
                 config = poller.get('config')
                 assert_is_not_none(config)
@@ -51,7 +51,7 @@ class AMQPTests(object):
           depends_on_groups=['check-obm'])
     def check_sel_task(self):
         """ Testing AMQP on.task.ipmi.sel.result """
-        Nodes().api1_1_nodes_get()
+        Nodes().nodes_get()
         nodes = loads(self.__client.last_response.data)
         self.__tasks = []
         for node in nodes:
@@ -71,7 +71,7 @@ class AMQPTests(object):
           depends_on_groups=['amqp.tests.sel'])
     def check_sdr_task(self):
         """ Testing AMQP on.task.ipmi.sdr.result """
-        Nodes().api1_1_nodes_get()
+        Nodes().nodes_get()
         nodes = loads(self.__client.last_response.data)
         self.__tasks = []
         for node in nodes:
@@ -91,7 +91,7 @@ class AMQPTests(object):
           depends_on_groups=['amqp.tests.sdr'])
     def check_chassis_task(self):
         """ Testing AMQP on.task.ipmi.chassis.result """
-        Nodes().api1_1_nodes_get()
+        Nodes().nodes_get()
         nodes = loads(self.__client.last_response.data)
         self.__tasks = []
         for node in nodes:

--- a/test/tests/api/v1_1/config_tests.py
+++ b/test/tests/api/v1_1/config_tests.py
@@ -1,8 +1,8 @@
 from config.api1_1_config import *
 from modules.logger import Log
-from on_http import ConfigApi as Config
-from on_http import NodesApi as Nodes
-from on_http import rest
+from on_http_api1_1 import ConfigApi as Config
+from on_http_api1_1 import NodesApi as Nodes
+from on_http_api1_1 import rest
 from datetime import datetime
 from proboscis.asserts import assert_equal
 from proboscis.asserts import assert_false
@@ -24,7 +24,7 @@ class ConfigTests(object):
     @test(groups=['config.tests', 'check-config'])
     def check_server_config(self):
         """Testing GET:/config to get server configuration"""
-        Config().api1_1_config_get()
+        Config().config_get()
         rsp = self.__client.last_response
         assert_equal(200, rsp.status, message=rsp.reason)
 
@@ -33,15 +33,15 @@ class ConfigTests(object):
         """Testing PATCH:/config to patch a specific configuration item"""
         test_pwd = {"PWD": "/this/is/a/test/for/patch_config"}
         LOG.info("Patch PWD with a test path")
-        Config().api1_1_config_patch(body=test_pwd)
+        Config().config_patch(body=test_pwd)
         server_config = loads(self.__client.last_response.data)
         assert_equal(server_config.get('PWD'),'/this/is/a/test/for/patch_config', 'Oops patch config failed')
         LOG.info("Doing a check config with test PWD")
-        Config().api1_1_config_get()
+        Config().config_get()
         rsp = self.__client.last_response
         assert_equal(200, rsp.status, message=rsp.reason)
         LOG.info("Restoring PWD config after patch test")
-        Config().api1_1_config_patch(body = {"PWD": "/var/renasar/on-http"})
+        Config().config_patch(body = {"PWD": "/var/renasar/on-http"})
         rsp = self.__client.last_response
         assert_equal(200, rsp.status, message=rsp.reason)
 

--- a/test/tests/api/v1_1/lookups_tests.py
+++ b/test/tests/api/v1_1/lookups_tests.py
@@ -1,6 +1,6 @@
 from config.api1_1_config import *
-from on_http import LookupsApi as Lookups
-from on_http import NodesApi as Nodes
+from on_http_api1_1 import LookupsApi as Lookups
+from on_http_api1_1 import NodesApi as Nodes
 from modules.logger import Log
 from datetime import datetime
 from proboscis.asserts import assert_equal
@@ -31,7 +31,7 @@ class LookupsTests(object):
     @test(groups=['lookups.tests', 'check-lookups-query'], depends_on_groups=['nodes.tests'])
     def check_lookups_query(self):
         """ Testing GET:/lookups?q=term """
-        Nodes().api1_1_nodes_get()
+        Nodes().nodes_get()
         nodes = loads(self.__client.last_response.data)
         assert_not_equal(0, len(nodes), message='Node list was empty!')
         obms = [ n.get('obmSettings') for n in nodes if n.get('obmSettings') is not None ]
@@ -41,7 +41,7 @@ class LookupsTests(object):
                 hosts.append(c.get('config').get('host'))
         assert_not_equal(0, len(hosts), message='No OBM hosts were found!')
         for host in hosts:
-            Lookups().api1_1_lookups_get(q=host)
+            Lookups().lookups_get(q=host)
             rsp = self.__client.last_response
             assert_equal(200, rsp.status, message=rsp.reason)
             assert_not_equal(0, len(rsp.data))
@@ -49,7 +49,7 @@ class LookupsTests(object):
     @test(groups=['check-lookup-id'],depends_on_groups=['check-lookups-query'])
     def check_lookup_id(self):
         """ Testing GET:/lookups/:id """
-        Nodes().api1_1_nodes_get()
+        Nodes().nodes_get()
         nodes = loads(self.__client.last_response.data)
         assert_not_equal(0, len(nodes), message='Node list was empty!')
         obms = [ n.get('obmSettings') for n in nodes if n.get('obmSettings') is not None ]
@@ -58,14 +58,14 @@ class LookupsTests(object):
         for obm in obms:
             for cfg in obm:
                 host = cfg.get('config').get('host')
-                Lookups().api1_1_lookups_get(q=host)
+                Lookups().lookups_get(q=host)
                 list = loads(self.__client.last_response.data)
                 entries.append(list)
 
         assert_not_equal(0, len(entries), message='No lookup entries found!')
         for entry in entries:
             for id in entry:
-                Lookups().api1_1_lookups_id_get(id.get('id'))
+                Lookups().lookups_id_get(id.get('id'))
                 rsp = self.__client.last_response
                 assert_equal(200, rsp.status, message=rsp.reason)
 
@@ -74,25 +74,25 @@ class LookupsTests(object):
         """ Testing POST /"""
 
         #Validate that the lookup has not been posted from a previous test
-        Lookups().api1_1_lookups_get(self.lookup.get("macAddress"))
+        Lookups().lookups_get(q=self.lookup.get("macAddress"))
         rsp = loads(self.__client.last_response.data)
         listLen =len(rsp)
         for i, val in enumerate (rsp):
             if ( self.lookup.get("macAddress") ==  str (rsp[i].get('macAddress'))  ):
                     LOG.info("Deleting the lookup with the same info before we post again")
                     deleteID= str (rsp[i].get('id'))
-                    Lookups().api1_1_lookups_id_delete(deleteID)
+                    Lookups().lookups_id_delete(deleteID)
 
 
         #Add a lookup
-        Lookups().api1_1_lookups_post(self.lookup)
+        Lookups().lookups_post(self.lookup)
         rsp = self.__client.last_response
         assert_equal(200, rsp.status, message=rsp.reason)
         self.id = str (loads(rsp.data).get('id'))
         LOG.info("ID is "+ self.id)
 
         #Validate the content
-        Lookups().api1_1_lookups_get(self.lookup.get("macAddress"))
+        Lookups().lookups_get(q=self.lookup.get("macAddress"))
         rsp = loads(self.__client.last_response.data)
         assert_equal(str(rsp[0].get("ipAddress")),str(self.lookup.get("ipAddress")))
         assert_equal(str(rsp[0].get("macAddress")),str(self.lookup.get("macAddress")))
@@ -103,17 +103,17 @@ class LookupsTests(object):
         """ Negative Testing POST / """
         #Validate that a POST for a lookup with same id as an existing one gets rejected
         try:
-            Lookups().api1_1_lookups_post(self.lookup)
+            Lookups().lookups_post(self.lookup)
         except Exception,e:
            assert_equal(500,e.status, message = 'status should be 505')
 
     @test(groups=['check-patch-lookup'],depends_on_groups=['check-lookups-query','check-post-lookup','check-post-lookup-negativeTesting'])
     def patch_lookup(self):
         """ Testing PATCH /:id"""
-        Lookups().api1_1_lookups_id_patch(self.id,self.patchedNode)
+        Lookups().lookups_id_patch(self.id,body=self.patchedNode)
 
         #validate that the node element has been updated
-        Lookups().api1_1_lookups_get(self.lookup.get("macAddress"))
+        Lookups().lookups_get(q=self.lookup.get("macAddress"))
         rsp = loads(self.__client.last_response.data)
         assert_equal(str(rsp[0].get("node")),self.patchedNode.get("node") )
 
@@ -121,18 +121,18 @@ class LookupsTests(object):
     def delete_lookup(self):
         """ Testing DELETE /:id """
         #Validate that the lookup is there before it is deleted
-        Lookups().api1_1_lookups_id_get(self.id)
+        Lookups().lookups_id_get(self.id)
         rsp = self.__client.last_response
         assert_equal(200, rsp.status, message=rsp.reason)
 
         #delete the lookup
         LOG.info("The lookup ID to be deleted is "+ self.id)
-        Lookups().api1_1_lookups_id_delete(self.id)
+        Lookups().lookups_id_delete(self.id)
         rsp = self.__client.last_response
         assert_equal(200, rsp.status, message=rsp.reason)
 
         #Validate that the lookup has been deleted and the returned value is an empty list
         try:
-            Lookups().api1_1_lookups_id_get(self.id)
+            Lookups().lookups_id_get(self.id)
         except Exception,e:
            assert_equal(404,e.status)

--- a/test/tests/api/v1_1/obm_settings.py
+++ b/test/tests/api/v1_1/obm_settings.py
@@ -1,6 +1,6 @@
 from config.api1_1_config import *
-from on_http import NodesApi as Nodes
-from on_http import rest
+from on_http_api1_1 import NodesApi as Nodes
+from on_http_api1_1 import rest
 from modules.logger import Log
 from json import dumps, loads
 
@@ -20,13 +20,13 @@ class obmSettings(object):
     def _set_ipmi(self, uid):
         user, passwd = get_bmc_cred()
         mac = None
-        Nodes().api1_1_nodes_identifier_catalogs_source_get(uid,'bmc')
+        Nodes().nodes_identifier_catalogs_source_get(uid,'bmc')
         rsp = self.__client.last_response
         bmc = loads(rsp.data)
         if 'data' in bmc:
             mac = bmc['data'].get('MAC Address')
         else:
-            Nodes().api1_1_nodes_identifier_catalogs_source_get(uid,'rmm')
+            Nodes().nodes_identifier_catalogs_source_get(uid,'rmm')
             rsp = self.__client.last_response
             rmm = loads(rsp.data)
             if 'data' in rmm:
@@ -45,7 +45,7 @@ class obmSettings(object):
             }
             LOG.info('Creating ipmi obm-settings for node {0} \n {1}'.format(uid,setting))
             try:
-                Nodes().api1_1_nodes_identifier_patch(uid,setting)
+                Nodes().nodes_identifier_patch(uid,setting)
             except rest.ApiException as e:
                 LOG.error(e)
                 return False
@@ -55,7 +55,7 @@ class obmSettings(object):
 
     def setup_nodes(self, service_type, uuid=None):
         err = []
-        Nodes().api1_1_nodes_get()
+        Nodes().nodes_get()
         nodes = loads(self.__client.last_response.data)
         for n in nodes:
             node_type = n.get('type')
@@ -79,7 +79,7 @@ class obmSettings(object):
 
     def check_nodes(self, service_type, uuid=None):
         retval = []
-        Nodes().api1_1_nodes_get()
+        Nodes().nodes_get()
         nodes = loads(self.__client.last_response.data)
         for n in nodes:
             node_type = n.get('type')

--- a/test/tests/api/v1_1/obm_tests.py
+++ b/test/tests/api/v1_1/obm_tests.py
@@ -1,8 +1,8 @@
 from config.api1_1_config import *
 from obm_settings import obmSettings
-from on_http import ObmsApi as Obms
-from on_http import NodesApi as Nodes
-from on_http import rest
+from on_http_api1_1 import ObmsApi as Obms
+from on_http_api1_1 import NodesApi as Nodes
+from on_http_api1_1 import rest
 from modules.logger import Log
 from datetime import datetime
 from proboscis.asserts import assert_equal
@@ -47,24 +47,24 @@ class OBMTests(object):
     @test(groups=['obm.tests', 'create-node-id-obm-identify'], depends_on_groups=['check-obm'])
     def test_node_id_obm_identify_create(self):
         """ Testing POST:/nodes/:id/obm/identify """
-        Nodes().api1_1_nodes_get()
+        Nodes().nodes_get()
         nodes = loads(self.__client.last_response.data)
         codes = []
         data = {"value": "true"}
         for n in nodes:
             if n.get('type') == 'compute':
                 uuid = n.get('id')
-                Nodes().api1_1_nodes_identifier_obm_identify_post(uuid, data)
+                Nodes().nodes_identifier_obm_identify_post(uuid, data)
                 rsp = self.__client.last_response
                 codes.append(rsp)
         for c in codes:
             assert_equal(200, c.status, message=c.reason)
-        assert_raises(rest.ApiException, Nodes().api1_1_nodes_identifier_obm_identify_post, 'fooey', data)
+        assert_raises(rest.ApiException, Nodes().nodes_identifier_obm_identify_post, 'fooey', data)
 
     @test(groups=['obm.tests', 'test-obms'])
     def test_obm_library(self):
         """ Testing GET:/obms/library """
-        Obms().api1_1_obms_library_get()
+        Obms().obms_library_get()
         obms = loads(self.__client.last_response.data)
         services = [t.get('service') for t in obms]
         assert_equal(200, self.__client.last_response.status)
@@ -73,12 +73,12 @@ class OBMTests(object):
     @test(groups=['obm.tests', 'test-obms-identifier'])
     def test_obm_library_identifier(self):
         """ Testing GET:/obms/library/:id """
-        Obms().api1_1_obms_library_get()
+        Obms().obms_library_get()
         obms = loads(self.__client.last_response.data)
         codes = []
         services = [t.get('service') for t in obms]
         for n in services:
-            Obms().api1_1_obms_library_identifier_get(n)
+            Obms().obms_library_identifier_get(n)
             codes.append(self.__client.last_response)
         assert_not_equal(0, len(obms), message='OBM list was empty!')
         for c in codes:

--- a/test/tests/api/v1_1/profiles_tests.py
+++ b/test/tests/api/v1_1/profiles_tests.py
@@ -1,8 +1,8 @@
 
 import json
 from config.api1_1_config import *
-from on_http import ProfilesApi as Profiles
-from on_http import rest
+from on_http_api1_1 import ProfilesApi as Profiles
+from on_http_api1_1 import rest
 from modules.logger import Log
 from datetime import datetime
 from proboscis.asserts import assert_equal
@@ -31,7 +31,7 @@ class ProfilesTests(object):
     @test(groups=['profiles.tests', 'profile_library_get'])
     def test_profiles_library_get(self):
         """ Testing GET:/library"""
-        Profiles().api1_1_profiles_library_get()
+        Profiles().profiles_library_get()
         assert_equal(200,self.__client.last_response.status)
         assert_not_equal(0, len(json.loads(self.__client.last_response.data)), message='Profile list was empty!')
 
@@ -40,7 +40,7 @@ class ProfilesTests(object):
     def test_profiles_put(self):
         """ Testing PUT:/nodes """
         #Get the number of profiles before we add one
-        Profiles().api1_1_profiles_library_get()
+        Profiles().profiles_library_get()
         profilesBefore = len(json.loads(self.__client.last_response.data))
 
         #Make sure that there is no profile with the same name from previous test runs
@@ -62,12 +62,12 @@ class ProfilesTests(object):
 
         #add a profile
         LOG.info('Adding a profile named= {0}'.format(self.addedName))
-        Profiles().api1_1_profiles_library_identifier_put(self.addedName,body=self.addedContents)
+        Profiles().profiles_library_identifier_put(self.addedName,body=self.addedContents)
         resp= self.__client.last_response
         assert_equal(200,resp.status)
 
         #Get the number of profiles after we added one
-        Profiles().api1_1_profiles_library_get()
+        Profiles().profiles_library_get()
         profilesAfter = len(json.loads(self.__client.last_response.data))
         resp= self.__client.last_response
         assert_equal(200,resp.status, message=resp.reason)
@@ -89,7 +89,7 @@ class ProfilesTests(object):
     def test_profiles_library_identifier_get_putdependent(self):
         """ Testing GET:/library/:id"""
 
-        Profiles().api1_1_profiles_library_identifier_get(self.addedName)
+        Profiles().profiles_library_identifier_get(self.addedName)
         readDict=  json.loads(self.__client.last_response.data)
         readContents  = readDict.get('contents')
         LOG.info('Reading the profile that was added,  {0}'.format(self.addedName))
@@ -98,7 +98,7 @@ class ProfilesTests(object):
     @test(groups=['profiles_library_identifier'])
     def test_profiles_library_identifier_get(self):
         """ Testing GET:/library/:id"""
-        Profiles().api1_1_profiles_library_identifier_get( "boilerplate.ipxe")
+        Profiles().profiles_library_identifier_get( "boilerplate.ipxe")
         readDict=  json.loads(self.__client.last_response.data)
         readName  = readDict.get('name')
         LOG.info('Reading the profile that was added,  {0}'.format(readName))
@@ -108,7 +108,7 @@ class ProfilesTests(object):
     def test_profiles_library_identifier_negative_get(self):
         """ Negative Testing GET:/library/:id"""
         try:
-            Profiles().api1_1_profiles_library_identifier_get('wrongProfileName')
+            Profiles().profiles_library_identifier_get('wrongProfileName')
         except Exception,e:
            assert_equal(404,e.status, message = 'status should be 404')
 

--- a/test/tests/api/v1_1/workflowTasks_tests.py
+++ b/test/tests/api/v1_1/workflowTasks_tests.py
@@ -1,8 +1,7 @@
-
 import json
 from config.api1_1_config import *
-from on_http import WorkflowTasksApi as WorkflowTasks
-from on_http import rest
+from on_http_api1_1 import WorkflowApi as WorkflowTasks
+from on_http_api1_1 import rest
 from modules.logger import Log
 from datetime import datetime
 from proboscis.asserts import assert_equal
@@ -23,6 +22,7 @@ class WorkflowTasksTests(object):
 
     def __init__(self):
         self.__client = config.api_client
+        self.__workflows = None
         self.workflowTaskDict ={
             "friendlyName": "fn_1",
             "injectableName": "in_1",
@@ -32,10 +32,10 @@ class WorkflowTasksTests(object):
         }
 
 
-    @test(groups=['workflowTasks.tests', 'workflowTasks_library_get'])
+    @test(groups=['workflowTasks_library_get'])
     def test_workflowTasks_library_get(self):
         """ Testing GET:/tasks/library"""
-        WorkflowTasks().api1_1_workflows_tasks_library_get()
+        WorkflowTasks().workflows_tasks_library_get()
         assert_equal(200,self.__client.last_response.status)
         assert_not_equal(0, len(json.loads(self.__client.last_response.data)), message='Workflow tasks list was empty!')
 
@@ -44,7 +44,7 @@ class WorkflowTasksTests(object):
     def test_workflowTasks_put(self):
         """ Testing PUT:/workflowTasks """
         #Get the number of workflowTasks before we add one
-        WorkflowTasks().api1_1_workflows_tasks_library_get()
+        WorkflowTasks().workflows_tasks_library_get()
         workflowTasksBefore = len(json.loads(self.__client.last_response.data))
 
         #Making sure that there is no workflowTask with the same name from previous test runs
@@ -62,12 +62,12 @@ class WorkflowTasksTests(object):
 
         #adding a workflow task
         LOG.info ("Adding workflow task : " +  str(self.workflowTaskDict))
-        WorkflowTasks().api1_1_workflows_tasks_put(body=self.workflowTaskDict)
+        WorkflowTasks().workflows_tasks_put(body=self.workflowTaskDict)
         resp= self.__client.last_response
         assert_equal(200,resp.status)
 
         #Getting the number of profiles after we added one
-        WorkflowTasks().api1_1_workflows_tasks_library_get()
+        WorkflowTasks().workflows_tasks_library_get()
         workflowTasksAfter = len(json.loads(self.__client.last_response.data))
         resp= self.__client.last_response
         assert_equal(200,resp.status, message=resp.reason)


### PR DESCRIPTION
This uses the latest api1.1 client library ```pip install on_http_api1_1``` generated off monorail.yml (with auth settings).   Keeps library imports consistent with redfish 1.0 and 2.0 api's. 
 
@RackHD/corecommitters @zyoung51 @WangWinson @uppalk1 @keedya @geoff-reid @brianparry 

