### PR TITLE
Add dhcpd.conf example to request profile without proxy.

### DIFF
--- a/packer/ansible/roles/isc-dhcp-server/files/dhcpd.conf.noproxy
+++ b/packer/ansible/roles/isc-dhcp-server/files/dhcpd.conf.noproxy
@@ -1,0 +1,149 @@
+#
+# Sample configuration file for ISC dhcpd for Debian
+#
+#
+
+# The ddns-updates-style parameter controls whether or not the server will
+# attempt to do a DNS update when a lease is confirmed. We default to the
+# behavior of the version 2 packages ('none', since DHCP v2 didn't
+# have support for DDNS.)
+ddns-update-style none;
+
+# option definitions common to all supported networks...
+option domain-name "example.org";
+option domain-name-servers ns1.example.org, ns2.example.org;
+
+default-lease-time 600;
+max-lease-time 7200;
+
+# If this DHCP server is the official DHCP server for the local
+# network, the authoritative directive should be uncommented.
+#authoritative;
+
+# Use this to send dhcp log messages to a different log file (you also
+# have to hack syslog.conf to complete the redirection).
+log-facility local7;
+
+# No service will be given on this subnet, but declaring it helps the 
+# DHCP server to understand the network topology.
+
+#subnet 10.152.187.0 netmask 255.255.255.0 {
+#}
+
+# This is a very basic subnet declaration.
+
+#subnet 10.254.239.0 netmask 255.255.255.224 {
+#  range 10.254.239.10 10.254.239.20;
+#  option routers rtr-239-0-1.example.org, rtr-239-0-2.example.org;
+#}
+
+# This declaration allows BOOTP clients to get dynamic addresses,
+# which we don't really recommend.
+
+#subnet 10.254.239.32 netmask 255.255.255.224 {
+#  range dynamic-bootp 10.254.239.40 10.254.239.60;
+#  option broadcast-address 10.254.239.31;
+#  option routers rtr-239-32-1.example.org;
+#}
+
+# A slightly different configuration for an internal subnet.
+#subnet 10.5.5.0 netmask 255.255.255.224 {
+#  range 10.5.5.26 10.5.5.30;
+#  option domain-name-servers ns1.internal.example.org;
+#  option domain-name "internal.example.org";
+#  option routers 10.5.5.1;
+#  option broadcast-address 10.5.5.31;
+#  default-lease-time 600;
+#  max-lease-time 7200;
+#}
+
+# Hosts which require special configuration options can be listed in
+# host statements.   If no address is specified, the address will be
+# allocated dynamically (if possible), but the host-specific information
+# will still come from the host declaration.
+
+#host passacaglia {
+#  hardware ethernet 0:0:c0:5d:bd:95;
+#  filename "vmunix.passacaglia";
+#  server-name "toccata.fugue.com";
+#}
+
+# Fixed IP addresses can also be specified for hosts.   These addresses
+# should not also be listed as being available for dynamic assignment.
+# Hosts for which fixed IP addresses have been specified can boot using
+# BOOTP or DHCP.   Hosts for which no fixed address is specified can only
+# be booted with DHCP, unless there is an address range on the subnet
+# to which a BOOTP client is connected which has the dynamic-bootp flag
+# set.
+#host fantasia {
+#  hardware ethernet 08:00:07:26:c0:a5;
+#  fixed-address fantasia.fugue.com;
+#}
+
+# You can declare a class of clients and then do address allocation
+# based on that.   The example below shows a case where all clients
+# in a certain class get addresses on the 10.17.224/24 subnet, and all
+# other clients get addresses on the 10.0.29/24 subnet.
+
+#class "foo" {
+#  match if substring (option vendor-class-identifier, 0, 4) = "SUNW";
+#}
+
+#shared-network 224-29 {
+#  subnet 10.17.224.0 netmask 255.255.255.0 {
+#    option routers rtr-224.example.org;
+#  }
+#  subnet 10.0.29.0 netmask 255.255.255.0 {
+#    option routers rtr-29.example.org;
+#  }
+#  pool {
+#    allow members of "foo";
+#    range 10.17.224.10 10.17.224.250;
+#  }
+#  pool {
+#    deny members of "foo";
+#    range 10.0.29.10 10.0.29.230;
+#  }
+#}
+
+# RackHD added lines
+deny duplicates;
+
+ignore-client-uids true;
+
+option arch-type code 93 = unsigned integer 16;
+
+subnet 172.31.128.0 netmask 255.255.252.0 {
+ range 172.31.128.2 172.31.131.254;
+ # Use this option to signal to the PXE client that we are doing proxy DHCP
+ # option vendor-class-identifier "PXEClient";
+
+ # Register leased hosts with RackHD
+ if ((exists user-class) and (option user-class = "MonoRail")) {
+    filename "http://172.31.128.1:9080/api/common/profiles?mac=${net0/mac}&&ip=${net0/ip}";
+  } else {
+    if option arch-type = 00:09 {
+      filename "monorail-efi64-snponly.efi";
+    } elsif option arch-type = 00:07 {
+      filename "monorail-efi64-snponly.efi";
+    } elsif option arch-type = 00:06 {
+      filename "monorail-efi32-snponly.efi";
+    } else {
+      filename "monorail.ipxe"; 
+    }
+  }
+
+# Example register static entry lookup with RackHD
+#
+#  host Quanta-T51_SNXYZ {
+#    hardware ethernet 00:0c:29:1f:35:90;
+#    fixed-address 172.31.128.120;
+#    option routers 172.31.128.1;
+#    if ((exists user-class) and (option user-class = "MonoRail")) {
+#      filename "http://172.31.128.1:9080/api/common/profiles?mac=${net0/mac}&&ip=${net0/ip}";
+#    }   else {
+#      filename "monorail.ipxe";
+#    }
+#  }
+
+}


### PR DESCRIPTION
Example to allow DHCP server to send bootfile request with mac/ip query.
Static host entry example
Handle option 93 arch type check

@RackHD/corecommitters @geoff-reid @keedya @zyoung51 @uppalk1 @tannoa2 