### PR TITLE
Assert 400 error on duplicate lookup entry creation

### DIFF
--- a/test/tests/api/v1_1/lookups_tests.py
+++ b/test/tests/api/v1_1/lookups_tests.py
@@ -105,7 +105,7 @@ class LookupsTests(object):
         try:
             Lookups().lookups_post(self.lookup)
         except Exception,e:
-           assert_equal(500,e.status, message = 'status should be 505')
+           assert_equal(400,e.status, message = 'status should be 400')
 
     @test(groups=['check-patch-lookup'],depends_on_groups=['check-lookups-query','check-post-lookup','check-post-lookup-negativeTesting'])
     def patch_lookup(self):


### PR DESCRIPTION
This is a bad request, not an internal server error. Now that we properly handle the error, return the right response code.

Requires https://github.com/RackHD/on-core/pull/99, passing locally.

@RackHD/corecommitters @zyoung51 @tldavies 