### PR TITLE
Adds alternative scripts to docker-compose, and update README

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -20,7 +20,7 @@ $ docker-compose up           # Run RackHD and ELK.
 
 **Prerequisites:**
   * docker v1.10
-  * docker-compose v1.6
+  * ~~docker-compose v1.6~~ (Recommended but not required.)
 
 ```
 $ cd RackHD/docker
@@ -78,5 +78,35 @@ $ docker-compose kill dhcp    # Stop the DHCP server.
 
 The `rackhd/files` image shares `on-http` and `on-tftp` file downloads with the host machine. **Experimental**
 
-## Using docker on the EMC network:
+## Using Docker on the EMC network:
+If you're trying to run this example inside the EMC see:
 https://github.com/emccode/training/tree/master/docker-workshops/docker-platform-intro/lab1-your-first-container#for-emc-employees-only
+
+## Discovering a VirtualBox VM in RackHD.
+
+This example is meant to run on Mac OS X or if you're using VirtualBox to run RackHD on Docker.
+
+```
+$ NAME=pxe-1 ./create_pxe_vm.bash   # Creates PXE VM in VirtualBox.
+```
+
+Now start `pxe-1` from VirtualBox. You should see it boot and auto automatically get discovered and catalogs by RackHD.
+
+If the VM boots and is not discovered make sure you used './docker_vm_up.bash' to setup your `boot2docker.iso` VM. Otherwise it will not discover your PXE VM.
+
+## Troubleshoot common Vagrant issues.
+  If running `./docker_vm_up.bash` fails:
+    * By default the b2d vagrant vm exposes all related ports. Some of which are only necessary for development and debugging. You can disable any ports you do not wish to use, or change the which port on the host they map too.
+    * Ensure you have the right version of Vagrant for VirtualBox. Later versions of VirtualBox require a more recent version of Vagrant.
+
+## Running this example without `docker-compose`.
+
+For convenience there are alternative scripts you can use instead of `docker-compose`.
+
+```
+$ ./scripts/compose_services.bash    # Run all RackHD/ELK docker containers.
+$ ./scripts/follow_services.bash     # Follow all RackHD/ELK logs.
+$ ./scripts/restart_services.bash    # Restart all RackHD/ELK docker containers.
+$ ./scripts/stop_services.bash       # Stop all RackHD/ELK docker containers.
+$ ./scripts/remove_services.bash     # Remove all RackHD/ELK docker containers
+```

--- a/docker/create_pxe_vm.bash
+++ b/docker/create_pxe_vm.bash
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Copyright 2016, EMC, Inc.
+
+# Create PXE VM for VirtualBox
+
+if [[ ! -e $NAME.vdi ]]; then # check to see if PXE vm already exists
+    echo "Creating PXE VM: $NAME"
+    VBoxManage createvm --name $NAME --register;
+    VBoxManage createhd --filename $NAME --size 8192;
+    VBoxManage storagectl $NAME --name "SATA Controller" --add sata --controller IntelAHCI
+    VBoxManage storageattach $NAME --storagectl "SATA Controller" --port 0 --device 0 --type hdd --medium $NAME.vdi
+    VBoxManage modifyvm $NAME --ostype Ubuntu --boot1 net --memory 768;
+    VBoxManage modifyvm $NAME --nic1 intnet --intnet1 closednet --nicpromisc1 allow-all;
+    VBoxManage modifyvm $NAME --nictype1 82540EM --macaddress1 auto;
+fi

--- a/docker/docker_vm_up.bash
+++ b/docker/docker_vm_up.bash
@@ -2,6 +2,8 @@
 
 # Copyright 2016, EMC, Inc.
 
+# Create boot2docker.iso VM using Vagrant
+
 # export B2D_NFS_SYNC=1
 export B2D_DISABLE_PRIVATE_NETWORK=1
 vagrant up b2d

--- a/docker/monorail/config.json
+++ b/docker/monorail/config.json
@@ -37,11 +37,6 @@
     "httpFileServiceType": "FileSystem",
     "httpProxies": [
       {
-          "localPath": "/common",
-          "server": "https://bintray.com",
-          "remotePath": "/artifact/download/rackhd/binary/builds/"
-      },
-      {
         "localPath": "/coreos",
         "server": "http://stable.release.core-os.net",
         "remotePath": "/amd64-usr/current/"

--- a/docker/scripts/compose_services.bash
+++ b/docker/scripts/compose_services.bash
@@ -1,0 +1,277 @@
+#!/bin/bash
+#
+# Copyright 2016, EMC, Inc.
+#
+# Start the RackHD containers, satisfying the dependencies as they
+# are specified in the docker-compose.yml file. Use this script
+# in those circumstances where docker-compose is not available
+# or desired. Be careful to keep this script up-to-date with any
+# changes made to docker-compose.yml.
+#
+# Related scripts:
+#	follow_services.bash, stop_services.bash, restart_services.bash,
+#	remove_services.bash
+#
+
+# enable to see script debug output
+#set -x
+
+#
+#volumes:
+#  dhcp-leases:
+#    external: false
+#
+
+echo "Creating shared volumes..."
+docker volume create --name docker_dhcp-leases
+
+echo "Starting..."
+
+#
+#  files:
+#    build: "./files"
+#    image: "rackhd/files"
+#    network_mode: "host"
+#    privileged: true
+#    volumes:
+#      - "./files/mount:/RackHD/files"
+#
+echo "    files..."
+docker run --privileged=true --net="host" --name docker_files_1 -d -v /RackHD/docker/files/mount:/RackHD/files rackhd/files > /dev/null
+if [ $? -ne 0 ]; then
+	echo "Failed"
+	exit
+fi
+
+#
+#  dhcp: # 67/udp
+#    image: rackhd/isc-dhcp-server
+#    build: "./dhcp"
+#    network_mode: "host"
+#    privileged: true
+#    volumes:
+#      - "dhcp-leases:/var/lib/dhcp"
+#      - "./dhcp/config:/etc/dhcp"
+#      - "./dhcp/defaults:/etc/defaults"
+#
+echo "    isc-dhcp-server..."
+docker run --privileged=true --net="host" --name docker_isc-dhcp-server_1 -d -v docker_dhcp-leases:/var/lib/dhcp -v /RackHD/docker/dhcp/config:/etc/dhcp -v /RackHD/docker/dhcp/defaults:/etc/defaults rackhd/isc-dhcp-server > /dev/null
+if [ $? -ne 0 ]; then
+	echo "Failed"
+	exit
+fi
+
+#
+#  mongo: # 27017
+#    image: mongo:latest
+#    network_mode: "host"
+#    privileged: true
+#
+echo "    mongo..."
+docker run --privileged=true --net="host" --name docker_mongo_1 -d mongo:latest > /dev/null
+if [ $? -ne 0 ]; then
+	echo "Failed"
+	exit
+fi
+
+#
+#  rabbitmq: # 5672, 15672
+#    image: rabbitmq:management
+#    network_mode: "host"
+#    privileged: true
+#
+echo "    rabbitmq..."
+docker run --privileged=true --net="host" --name docker_rabbitmq_1 -d rabbitmq:management > /dev/null
+if [ $? -ne 0 ]; then
+	echo "Failed"
+	exit
+fi
+
+#
+#  elasticsearch: # 9200, 9300
+#    command: elasticsearch -Des.network.host=0.0.0.0
+#    depends_on:
+#      - rabbitmq
+#    image: elasticsearch:latest
+#    network_mode: "host"
+#    privileged: true
+#
+echo "    elasticsearch..."
+docker run --privileged=true --net="host" --name docker_elasticsearch_1 -d elasticsearch:latest elasticsearch -Des.network.host=0.0.0.0 > /dev/null
+if [ $? -ne 0 ]; then
+	echo "Failed"
+	exit
+fi
+
+#
+#  kibana: # 5601
+#    depends_on:
+#      - elasticsearch
+#    image: kibana:latest
+#    network_mode: "host"
+#    privileged: true
+#    volumes:
+#      - "./kibana/config:/opt/kibana/config"
+#
+echo "    kibana..."
+docker run --privileged=true --net="host" --name docker_kibana_1 -d -v /RackHD/docker/kibana/config:/opt/kibana/config kibana:latest > /dev/null
+if [ $? -ne 0 ]; then
+	echo "Failed"
+	exit
+fi
+
+#
+#  logstash: # 5000
+#    command: logstash -f /etc/logstash/conf.d/logstash.conf
+#    depends_on:
+#      - elasticsearch
+#      - rabbitmq
+#    image: logstash:latest
+#    network_mode: "host"
+#    privileged: true
+#    volumes:
+#      - "./logstash/config:/etc/logstash/conf.d"
+#
+echo "    logstash..."
+docker run --privileged=true --net="host" --name docker_logstash_1 -d -v /RackHD/docker/logstash/config:/etc/logstash/conf.d logstash:latest logstash -f /etc/logstash/conf.d/logstash.conf > /dev/null
+if [ $? -ne 0 ]; then
+	echo "Failed"
+	exit
+fi
+
+#
+#  statsd: # 8125/udp
+#    build: "../on-statsd"
+#    depends_on:
+#      - elasticsearch
+#      - logstash
+#      - mongo
+#      - rabbitmq
+#    image: rackhd/on-statsd:latest
+#    network_mode: "host"
+#    privileged: true
+#    volumes:
+#      - "./monorail:/opt/monorail"
+#
+echo "    on-statsd..."
+docker run --privileged=true --net="host" --name docker_on-statsd_1 -d -v /RackHD/docker/monorail:/opt/monorail rackhd/on-statsd > /dev/null
+if [ $? -ne 0 ]; then
+	echo "Failed"
+	exit
+fi
+
+#
+#  http: # 9090, 9080
+#    build: "../on-http"
+#    depends_on:
+#      - files
+#      - logstash
+#      - mongo
+#      - rabbitmq
+#      - statsd
+#    image: rackhd/on-http:latest
+#    network_mode: "host"
+#    privileged: true
+#    volumes:
+#      - "./files/mount/common:/RackHD/on-http/static/http/common"
+#      - "./monorail:/opt/monorail"
+#
+echo "    on-http..."
+docker run --privileged=true --net="host" --name docker_on-http_1 -d -v /RackHD/docker/files/mount/common:/RackHD/on-http/static/http/common -v /RackHD/docker/monorail:/opt/monorail rackhd/on-http:latest > /dev/null
+if [ $? -ne 0 ]; then
+	echo "Failed"
+	exit
+fi
+
+#
+#  dhcp-proxy: # 68/udp, 4011
+#    build: "../on-dhcp-proxy"
+#    depends_on:
+#      - dhcp
+#      - logstash
+#      - mongo
+#      - rabbitmq
+#      - statsd
+#    image: rackhd/on-dhcp-proxy:latest
+#    network_mode: "host"
+#    privileged: true
+#    volumes:
+#      - "./monorail:/opt/monorail"
+#
+echo "    on-dhcp-proxy..."
+docker run --privileged=true --net="host" --name docker_on-dhcp-proxy_1 -d -v /RackHD/docker/monorail:/opt/monorail rackhd/on-dhcp-proxy:latest > /dev/null
+if [ $? -ne 0 ]; then
+	echo "Failed"
+	exit
+fi
+
+#
+#  syslog: # 514/udp
+#    build: "../on-syslog"
+#    depends_on:
+#      - mongo
+#      - logstash
+#      - rabbitmq
+#      - statsd
+#    image: rackhd/on-syslog:latest
+#    network_mode: "host"
+#    privileged: true
+#    volumes:
+#      - "./monorail:/opt/monorail"
+#
+echo "    on-syslog..."
+docker run --privileged=true --net="host" --name docker_on-syslog_1 -d -v /RackHD/docker/monorail:/opt/monorail rackhd/on-syslog:latest > /dev/null
+if [ $? -ne 0 ]; then
+	echo "Failed"
+	exit
+fi
+
+#
+#  tftp: # 69/udp
+#    build: "../on-tftp"
+#    depends_on:
+#      - files
+#      - logstash
+#      - mongo
+#      - rabbitmq
+#      - statsd
+#      - syslog
+#    image: rackhd/on-tftp:latest
+#    network_mode: "host"
+#    privileged: true
+#    volumes:
+#      - "./files/mount:/RackHD/on-tftp/static/tftp"
+#      - "./monorail:/opt/monorail"
+#
+echo "    on-tftp..."
+docker run --privileged=true --net="host" --name docker_on-tftp_1 -d -v /RackHD/docker/files/mount:/RackHD/on-tftp/static/tftp -v /RackHD/docker/monorail:/opt/monorail rackhd/on-tftp:latest > /dev/null
+if [ $? -ne 0 ]; then
+	echo "Failed"
+	exit
+fi
+
+#
+#  taskgraph:
+#    build: "../on-taskgraph"
+#    depends_on:
+#      - dhcp
+#      - logstash
+#      - mongo
+#      - rabbitmq
+#      - syslog
+#      - statsd
+#    image: rackhd/on-taskgraph:latest
+#    network_mode: "host"
+#    privileged: true
+#    volumes:
+#      - "dhcp-leases:/var/lib/dhcp"
+#      - "./monorail:/opt/monorail"
+#
+echo "    on-taskgraph..."
+docker run --privileged=true --net="host" --name docker_on-taskgraph_1 -d -v docker_dhcp-leases:/var/lib/dhcp -v /RackHD/docker/monorail:/opt/monorail rackhd/on-taskgraph:latest > /dev/null
+if [ $? -ne 0 ]; then
+	echo "Failed"
+	exit
+fi
+
+echo "Done."

--- a/docker/scripts/follow_services.bash
+++ b/docker/scripts/follow_services.bash
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Copyright 2016, EMC, Inc.
+#
+# Follow the logs of each of the RackHD containers.
+#
+
+# enable to see script debug output
+#set -x
+
+for i in docker_mongo_1 docker_rabbitmq_1 docker_elasticsearch_1 docker_logstash_1 docker_kibana_1 docker_isc-dhcp-server_1 docker_files_1 docker_on-statsd_1 docker_on-syslog_1 docker_on-tftp_1 docker_on-dhcp-proxy_1 docker_on-http_1 docker_on-taskgraph_1
+do
+	docker logs -t -f $i &
+done

--- a/docker/scripts/remove_services.bash
+++ b/docker/scripts/remove_services.bash
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Copyright 2016, EMC, Inc.
+#
+# Remove each of the RackHD containers.
+#
+
+# enable to see script debug output
+#set -x
+
+echo "Removing..."
+
+for i in docker_mongo_1 docker_rabbitmq_1 docker_elasticsearch_1 docker_logstash_1 docker_kibana_1 docker_isc-dhcp-server_1 docker_files_1 docker_on-statsd_1 docker_on-syslog_1 docker_on-tftp_1 docker_on-dhcp-proxy_1 docker_on-http_1 docker_on-taskgraph_1
+do
+	docker rm $i
+done

--- a/docker/scripts/restart_services.bash
+++ b/docker/scripts/restart_services.bash
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Copyright 2016, EMC, Inc.
+#
+# Restart each of the RackHD containers.
+#
+
+# enable to see script debug output
+#set -x
+
+echo "Restarting..."
+
+for i in docker_mongo_1 docker_rabbitmq_1 docker_elasticsearch_1 docker_logstash_1 docker_kibana_1 docker_isc-dhcp-server_1 docker_files_1 docker_on-statsd_1 docker_on-syslog_1 docker_on-tftp_1 docker_on-dhcp-proxy_1 docker_on-http_1 docker_on-taskgraph_1
+do
+	docker restart $i
+done

--- a/docker/scripts/stop_services.bash
+++ b/docker/scripts/stop_services.bash
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Copyright 2016, EMC, Inc.
+#
+# Stop each of the RackHD containers.
+#
+
+# enable to see script debug output
+#set -x
+
+echo "Stopping..."
+
+for i in docker_mongo_1 docker_rabbitmq_1 docker_elasticsearch_1 docker_logstash_1 docker_kibana_1 docker_isc-dhcp-server_1 docker_files_1 docker_on-statsd_1 docker_on-syslog_1 docker_on-tftp_1 docker_on-dhcp-proxy_1 docker_on-http_1 docker_on-taskgraph_1
+do
+	docker stop $i
+done


### PR DESCRIPTION
* Adds scripts that can be used as an alternative to `docker-compose`
* Adds `create_pxe_vm.bash`
* Update README to help troubleshoot common issues, and document new scripts.