### PR TITLE
2.0 API pollers test bug fix.

### DIFF
--- a/test/tests/api/v2_0/pollers_tests.py
+++ b/test/tests/api/v2_0/pollers_tests.py
@@ -74,8 +74,8 @@ class PollersTests(object):
             data = loads(self.__client.last_response.data)
 
             assert_equal(200, result.status, message=result.reason)
-            assert_equal(data, poller)
-
+            for key in ['pollInterval', 'paused', 'type', 'config']:
+                assert_equal(data[key], poller[key])
         try:
             Api().pollers_id_get(identifier='does_not_exist')
         except ApiException as e:


### PR DESCRIPTION
* Fix issue caused by poller run during test.
* Check only a subset of keys in returned data.

This PR fixes an issue where pollers_get_by_id test fails if pollers run during the test.