### PR TITLE
remove 'current' from proxy config in CoreOS demo proxy setup

### DIFF
--- a/packer/ansible/roles/monorail/files/config.json
+++ b/packer/ansible/roles/monorail/files/config.json
@@ -33,7 +33,7 @@
     "httpProxies": [{
         "localPath": "/coreos",
         "server": "http://stable.release.core-os.net",
-        "remotePath": "/amd64-usr/current/"
+        "remotePath": "/amd64-usr"
     }],
     "httpStaticRoot": "/opt/monorail/static/http",
     "minLogLevel": 3,


### PR DESCRIPTION
 - partial resolution for https://github.com/RackHD/RackHD/issues/146
 - to work with https://github.com/RackHD/on-http/pull/187