### PR TITLE
Fix elasticsearch CORS settings and docker Vagrantfile

### DIFF
--- a/docker/Vagrantfile
+++ b/docker/Vagrantfile
@@ -6,6 +6,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Boot 2 Docker
     config.vm.define "b2d" do |target|
         target.vm.box = "dduportal/boot2docker"
+        target.vm.box_version = "1.10.0"
 
         target.vm.provider "virtualbox" do |v|
             v.memory = 4096

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -133,12 +133,14 @@ services:
   # ELK services
 
   elasticsearch: # 9200, 9300
-    command: elasticsearch -Des.network.host=0.0.0.0
+    command: elasticsearch
     depends_on:
       - rabbitmq
     image: elasticsearch:latest
     network_mode: "host"
     privileged: true
+    volumes:
+      - "./elasticsearch/config:/usr/share/elasticsearch/config"
 
   logstash: # 5000
     command: logstash -f /etc/logstash/conf.d/logstash.conf

--- a/docker/elasticsearch/config/elasticsearch.yml
+++ b/docker/elasticsearch/config/elasticsearch.yml
@@ -1,0 +1,4 @@
+network.host: 0.0.0.0
+
+http.cors.enabled: true
+http.cors.allow-origin: "*"

--- a/docker/elasticsearch/config/logging.yml
+++ b/docker/elasticsearch/config/logging.yml
@@ -1,0 +1,15 @@
+# you can override this using by setting a system property, for example -Des.logger.level=DEBUG
+es.logger.level: INFO
+rootLogger: ${es.logger.level}, console
+logger:
+  # log action execution errors for easier debugging
+  action: DEBUG
+  # reduce the logging for aws, too much is logged under the default INFO
+  com.amazonaws: WARN
+
+appender:
+  console:
+    type: console
+    layout:
+      type: consolePattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"

--- a/docker/monorail/config.json
+++ b/docker/monorail/config.json
@@ -16,22 +16,22 @@
     "gatewayaddr": "172.31.128.1",
     "httpDocsRoot": "./build/apidoc",
     "httpEndpoints": [
-        {
-            "address": "0.0.0.0",
-            "port": 9090,
-            "httpsEnabled": false,
-            "proxiesEnabled": true,
-            "authEnabled": false,
-            "routers": "northbound-api-router"
-        },
-        {
-            "address": "0.0.0.0",
-            "port": 9080,
-            "httpsEnabled": false,
-            "proxiesEnabled": true,
-            "authEnabled": false,
-            "routers": "southbound-api-router"
-        }
+      {
+          "address": "0.0.0.0",
+          "port": 9090,
+          "httpsEnabled": false,
+          "proxiesEnabled": true,
+          "authEnabled": false,
+          "routers": "northbound-api-router"
+      },
+      {
+          "address": "0.0.0.0",
+          "port": 9080,
+          "httpsEnabled": false,
+          "proxiesEnabled": true,
+          "authEnabled": false,
+          "routers": "southbound-api-router"
+      }
     ],
     "httpFileServiceRoot": "./static/files",
     "httpFileServiceType": "FileSystem",
@@ -40,6 +40,11 @@
         "localPath": "/coreos",
         "server": "http://stable.release.core-os.net",
         "remotePath": "/amd64-usr/current/"
+      },
+      {
+        "localPath": "/centos",
+        "server": "http://mirror.centos.org/",
+        "remotePath": "/centos/"
       }
     ],
     "httpStaticRoot": "/opt/monorail/static/http",

--- a/docker/reload_docker_vm.bash
+++ b/docker/reload_docker_vm.bash
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Copyright 2016, EMC, Inc.
+
+# Reload boot2docker.iso VM using Vagrant
+
+# export B2D_NFS_SYNC=1
+export B2D_DISABLE_PRIVATE_NETWORK=1
+vagrant reload b2d


### PR DESCRIPTION
These changes configure Elasticsearch to enable CORS headers for "*" domains. This allows the UI to make API calls to Elasticsearch.