### PR TITLE
Fix functional tests to work with new api 2.0 library version 1.0.2

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -7,5 +7,5 @@ requests==2.9.0
 nose==1.3.7
 pexpect==3.3
 on-http_api1_1>=1.0.0
-on-http_api2_0>=1.0.0
+on-http_api2_0>=1.0.2
 on_http_redfish_1_0>=1.0.0

--- a/test/tests/api/v2_0/catalogs_tests.py
+++ b/test/tests/api/v2_0/catalogs_tests.py
@@ -22,7 +22,7 @@ class CatalogsTests(object):
     @test(groups=['catalogs_api2.tests', 'api2_check-catalogs'])
     def test_catalogs(self):
         """Testing GET:api/2.0/catalogs to get list of catalogs"""
-        Api().get_catalog()
+        Api().catalogs_get()
         rsp = self.__client.last_response
         assert_not_equal(404, rsp.status, message=rsp.reason)
         assert_equal(200, rsp.status, message=rsp.reason)
@@ -31,16 +31,16 @@ class CatalogsTests(object):
     @test(groups=['catalogs_api2.tests'], depends_on_groups=['api2_check-catalogs'])
     def test_catalogs_id(self):
         """Testing GET:api/2.0/catalogs/id to get specific catalog details"""
-        Api().get_catalog()
+        Api().catalogs_get()
         catalogs = loads(self.__client.last_response.data)
         codes = []
         for n in catalogs:
             id = n.get('id')
             assert_is_not_none(id)
-            Api().get_catalog_by_id(identifier=id)
+            Api().catalogs_id_get(identifier=id)
             rsp = self.__client.last_response
             assert_not_equal(404, rsp.status, message=rsp.reason)
             codes.append(rsp)
         for c in codes:
             assert_equal(200, c.status, message=c.reason)
-        assert_raises(rest.ApiException, Api().get_catalog_by_id, 'fooey')
+        assert_raises(rest.ApiException, Api().catalogs_id_get, 'fooey')

--- a/test/tests/api/v2_0/config_tests.py
+++ b/test/tests/api/v2_0/config_tests.py
@@ -21,7 +21,7 @@ class ConfigTests(object):
     @test(groups=['config_api2.tests', 'api2_check-config'])
     def check_server_config(self):
         """Testing GET:api/2.0/config to get server configuration"""
-        Api().get_config()
+        Api().config_get()
         rsp = self.__client.last_response
         assert_equal(200, rsp.status, message=rsp.reason)
 
@@ -30,15 +30,15 @@ class ConfigTests(object):
         """Testing PATCH:api/2.0/config to patch a specific configuration item"""
         test_pwd = {"PWD": "/this/is/a/test/for/patch_config"}
         LOG.info("Patch PWD with a test path")
-        Api().patch_config(config = test_pwd)
+        Api().config_patch(config = test_pwd)
         server_config = loads(self.__client.last_response.data)
         assert_equal(server_config.get('PWD'),'/this/is/a/test/for/patch_config', 'Oops patch config failed')
         LOG.info("Doing a check config with test PWD")
-        Api().get_config()
+        Api().config_get()
         rsp = self.__client.last_response
         assert_equal(200, rsp.status, message=rsp.reason)
         LOG.info("Restoring PWD config after patch test")
-        Api().patch_config(config = {"PWD": "/var/renasar/on-http"})
+        Api().config_patch(config = {"PWD": "/var/renasar/on-http"})
         rsp = self.__client.last_response
         assert_equal(200, rsp.status, message=rsp.reason)
 


### PR DESCRIPTION
Fixed the catalogs and config tests to work with the new api 2.0 library version 1.0.2.  This is a required fix before PR#160 can be merged.  