### PR TITLE
Run discovery handler in worker thread

### DIFF
--- a/test/tests/api/v1_1/nodes_tests.py
+++ b/test/tests/api/v1_1/nodes_tests.py
@@ -2,6 +2,7 @@ from config.api1_1_config import *
 from config.amqp import *
 from modules.logger import Log
 from modules.amqp import AMQPWorker
+from modules.worker import WorkerThread, WorkerTasks
 from on_http_api1_1 import NodesApi as Nodes
 from on_http_api1_1 import WorkflowApi as Workflows
 from on_http_api1_1 import rest
@@ -25,7 +26,7 @@ class NodesTests(object):
 
     def __init__(self):
         self.__client = config.api_client
-        self.__worker = None
+        self.__task = None
         self.__discovery_duration = None
         self.__discovered = 0
         self.__test_nodes = [
@@ -114,8 +115,15 @@ class NodesTests(object):
             return
         self.__discovery_duration = datetime.now()
         LOG.info('Wait start time: {0}'.format(self.__discovery_duration))
-        self.__worker = AMQPWorker(queue=QUEUE_GRAPH_FINISH,callbacks=[self.handle_graph_finish])
-        self.__worker.start()
+        self.__task = WorkerThread(AMQPWorker(queue=QUEUE_GRAPH_FINISH, \
+                                              callbacks=[self.handle_graph_finish]), 'discovery')
+        def start(worker,id):
+            worker.start()
+        tasks = WorkerTasks(tasks=[self.__task], func=start)
+        tasks.run()
+        tasks.wait_for_completion(timeout_sec=1200)
+        assert_false(self.__task.timeout, \
+            message='timeout waiting for task {0}'.format(self.__task.id))
 
     def handle_graph_finish(self,body,message):
         routeId = message.delivery_info.get('routing_key').split('graph.finished.')[1]
@@ -139,8 +147,8 @@ class NodesTests(object):
                         break
         check = self.check_compute_count()
         if check and check == self.__discovered:
-            self.__worker.stop()
-            self.__worker = None
+            self.__task.worker.stop()
+            self.__task.running = False
             self.__discovered = 0
 
     @test(groups=['test-nodes'], depends_on_groups=['nodes.discovery.test'])


### PR DESCRIPTION
Discovery waits for task completion and fails test on a timeout to avoid waiting forever. 

@RackHD/corecommitters @uppalk1 @zyoung51 @tannoa2 @geoff-reid @keedya 