### PR TITLE
Modify footprint benchmark parser.py

### DIFF
--- a/test/benchmark/utils/parser.py
+++ b/test/benchmark/utils/parser.py
@@ -18,6 +18,7 @@ filename_mongo_disk_summary_js = "db_disk_summary.js"
 filename_mongo_document_js = "db_document.js"
 filename_caseinfo_js = "case_info.js"
 filename_compare_list_js = "compare_list.js"
+filename_process_list_js = "process_list.js"
 
 # The column line definition on the atop log file
 ATOP_LINE_COL = [
@@ -627,12 +628,12 @@ def parse_atop(filename, proc_list):
 # output will be look like:
 # 20160323_032739_compare_list =
 # {
-#     ["20160323_032739",
-#      "20160323_032812",
-#      "20160323_032923"]
+#     "20160323_032739" : ["case1", "case2"],
+#     "20160323_032812" : ["case1", "case2"],
+#     "20160323_032923" : ["case1", "case2"]
 # }
 def write_compare_list_to_js(log_dir_str, case_information, output_filename):
-    result_list = {"result list": []}
+    result_list = {}
     timestamp = case_information["log path"].replace('-', '_')
 
     # scan compare list
@@ -641,11 +642,24 @@ def write_compare_list_to_js(log_dir_str, case_information, output_filename):
     for name in os.listdir(path_par_par):
         pathname = os.path.join(path_par_par, name)
         if not os.path.isfile(pathname):
-            result_list["result list"].append(name)
+            result_list[name] = []
+            # further scan each folder to get a list of test cases
+            for case_name in os.listdir(pathname):
+                case_pathname = os.path.join(pathname, case_name)
+                if not os.path.isfile(pathname):
+                    result_list[name].append(case_name)
 
     with open(output_filename, 'w') as f:
         f.write('var ' + 'compare_list_' + timestamp + ' = \n')
         json_str = json.dumps(result_list, indent=4)
+        f.write(json_str)
+    pass
+
+def write_process_list_to_js(pro_list, case_information, output_filename):
+    timestamp = case_information["log path"].replace('-', '_')
+    with open(output_filename, 'w') as f:
+        f.write('var ' + 'process_list_' + timestamp + ' = \n')
+        json_str = json.dumps(pro_list, indent=4)
         f.write(json_str)
     pass
 
@@ -676,6 +690,10 @@ def parse(log_dir):
     # parse process list
     pathname_process = os.path.join(log_dir, filename_process)
     process_list = parse_process_list(pathname_process)
+
+    # print to js log file
+    pathname_process_list_js = os.path.join(output_dir, filename_process_list_js)
+    write_process_list_to_js(process_list, case_info, pathname_process_list_js)
 
     # parse atop log file
     pathname_atop = os.path.join(log_dir, filename_atop)


### PR DESCRIPTION
Modify footprint benchmark parser.py to: 

1. further scan log folder to show not only time stamp but also case name
2. Write process list to log file for use by front end html pages

@RackHD/corecommitters @iceiilin @WangWinson 