### PR TITLE
Add AMQP listener mode utility

### DIFF
--- a/test/config/amqp.py
+++ b/test/config/amqp.py
@@ -14,9 +14,15 @@ QUEUE_SDR_RESULT        = Queue('ipmi.command.sdr.result',
 QUEUE_CHASSIS_RESULT    = Queue('ipmi.command.chassis.result',
                                 EXCHANGE_TASK,
                                 routing_key='ipmi.command.chassis.result.*')
-
+                                
 # Event exchange queues
 EXCHANGE_EVENT          = Exchange('on.events', type='topic')
 QUEUE_GRAPH_FINISH      = Queue('graph.finished',
                                 EXCHANGE_EVENT,
                                 routing_key='graph.finished.*')
+                                
+def make_queue_obj(exchange, queue, routing_key, type='topic'):
+    return Queue(queue, \
+           Exchange(exchange, type=type), \
+           routing_key=routing_key)
+

--- a/test/run.py
+++ b/test/run.py
@@ -1,6 +1,7 @@
 from proboscis import register
 from proboscis import TestProgram
 import modules.httpd as httpd
+import modules.amqp as amqp
 import argparse
 import sys
 
@@ -18,12 +19,21 @@ def run_tests():
 
 if __name__ == '__main__':
     # avoid eating valid proboscis args
-    if len(sys.argv) > 1 and sys.argv[1] == '--httpd': 
+    if len(sys.argv) > 1:
         parser = argparse.ArgumentParser()
-        parser.add_argument('--httpd', action='store_const', const=True)
-        parser.add_argument('-a', '--address', default='0.0.0.0', required=False)
-        parser.add_argument('-p', '--port', default=80, required=False)
-        args = parser.parse_args()
-        httpd.run_server(args.address,args.port)
-        sys.exit(0)
+        if sys.argv[1] == '--httpd': 
+            parser.add_argument('--httpd', action='store_const', const=True)
+            parser.add_argument('-a', '--address', default='0.0.0.0', required=False)
+            parser.add_argument('-p', '--port', default=80, required=False)
+            args = parser.parse_args()
+            httpd.run_server(args.address,args.port)
+            sys.exit(0)
+        if sys.argv[1] == '--amqp':
+            parser.add_argument('--amqp', action='store_const', const=True)
+            parser.add_argument('-e', '--exchange', default='on.events', required=False)
+            parser.add_argument('-q', '--queue', default='poller.alert', required=False)
+            parser.add_argument('-r', '--key', default='poller.alert.#', required=False)
+            args = parser.parse_args()
+            amqp.run_listener(amqp.make_queue_obj(args.exchange,args.queue,args.key))
+            sys.exit(0)
     run_tests()


### PR DESCRIPTION
Pass --amqp option with exchange/queue parameters to listen continuously on exchange

Optional tool.  Take it or leave it.

@RackHD/corecommitters @zyoung51 @uppalk1 @tannoa2 @geoff-reid @keedya 