### PR TITLE
an new ansiable playbook: to install RackHD throughly from latest source( build deb/microkernel)

### DIFF
--- a/packer/ansible/rackhd_install_from_src.yml
+++ b/packer/ansible/rackhd_install_from_src.yml
@@ -1,0 +1,18 @@
+---
+- name: RackHD Throughly Installation Server
+  hosts: local
+  sudo: no
+  roles:
+    - apt
+    - build
+    - git
+    - rabbitmq
+    - mongodb
+    - node-legacy
+    - rackhd-deb-from_src
+    - isc-dhcp-server
+    - monorail
+    - snmptool
+    - ipmitool
+    - images_from_src
+    - integrationtest

--- a/packer/ansible/roles/images_from_src/tasks/main.yml
+++ b/packer/ansible/roles/images_from_src/tasks/main.yml
@@ -1,0 +1,71 @@
+---
+- name: set HTTP static directory for RackHD
+  set_fact: http_static_directory="/var/renasar/on-http/static/http"
+
+- name: set TFTP static directory for RackHD
+  set_fact: tftp_static_directory="/var/renasar/on-tftp/static/tftp"
+
+
+
+- name: Update git repos with latest
+  shell: git fetch --all --prune
+  args:
+    chdir: "{{ ansible_env.HOME }}/src/on-imagebuilder"
+
+- name: Reset to the mater branch by default
+  shell: git reset --hard master
+  args:
+    chdir: "{{ ansible_env.HOME }}/src/on-imagebuilder"
+
+
+- name: Reset to the branch specified
+  shell: git reset --hard {{ branch }}
+  when: branch is defined
+  args:
+    chdir: "{{ ansible_env.HOME }}/src/on-imagebuilder"
+
+- name: Clean the on-imagebuilder artifact folder 
+  shell: rm /tmp/on-imagebuilder -rf
+  sudo:  yes
+
+- name: Build the overlay FS artifacts(kernel/overlay/iPXE/syslinux)
+  shell:  ./build_all.sh
+  args:
+    chdir: "{{ ansible_env.HOME }}/src/on-imagebuilder"
+  sudo: yes
+
+- file: path="{{ http_static_directory }}/common" state=directory
+        owner="{{ ansible_env.USER }}" mode=0755
+  sudo: yes
+
+- file: path="{{ tftp_static_directory }}" state=directory
+        owner="{{ ansible_env.USER }}" mode=0755
+  sudo: yes
+
+
+- name: set on-imagebuilder artifacts location
+  set_fact: artifacts_dir="/tmp/on-imagebuilder/"
+
+
+- name: moving microkernel and overlays files to http static folder
+  shell: cp {{artifacts_dir}}/builds/{{ item }} {{ http_static_directory }}/common/
+  with_items:
+  - base.*.squashfs.img
+  - discovery.overlay.cpio.gz
+  - initrd.img-*
+  - vmlinuz-*
+
+- name: moving  bootloaders to tftp static folder
+  copy:    src= {{artifacts_dir}}/ipxe/{{ item }}
+           dest={{ tftp_static_directory }}{{ item }}
+  with_items:
+   - monorail.ipxe
+   - monorail-undionly.kpxe
+   - monorail-efi32-snponly.efi
+   - monorail-efi64-snponly.efi
+
+- name: moving the syslinux bootloader to syslinux static folder
+  copy:   src= {{artifacts_dir}}/syslinux/{{ item }}
+          dest="{{ tftp_static_directory }}/{{ item }}"
+  with_items:
+   - undionly.kkpxe

--- a/packer/ansible/roles/rackhd-deb-from_src/tasks/main.yml
+++ b/packer/ansible/roles/rackhd-deb-from_src/tasks/main.yml
@@ -1,0 +1,78 @@
+---
+- name: Get RackHD from source
+  git: repo=https://github.com/rackhd/rackhd
+       dest="{{ ansible_env.HOME }}/src"
+       accept_hostkey=true
+       version="{{ branch | default('master') }}"
+
+- name: Install debuild & dch
+  apt: pkg={{ item }} state=installed
+  with_items:
+    - devscripts
+    - debhelper
+  sudo: yes
+
+
+- name: Update git repos with latest
+  shell: git fetch --all --prune
+  args:
+    chdir: "{{ ansible_env.HOME }}/src/{{ item }}"
+  with_items:
+    - on-http
+    - on-tftp
+    - on-dhcp-proxy
+    - on-taskgraph
+    - on-syslog
+
+- name: Reset to the branch specified
+  shell: git reset --hard {{ branch }}
+  when: branch is defined
+  args:
+    chdir: "{{ ansible_env.HOME }}/src/{{ item }}"
+  with_items:
+    - on-http
+    - on-tftp
+    - on-dhcp-proxy
+    - on-taskgraph
+    - on-syslog
+
+- name: Build Deb Package via HWIMO-BUILD script
+  shell: ./HWIMO-BUILD
+  args:
+      chdir: "{{ ansible_env.HOME }}/src/{{ item }}"
+  with_items:
+    - on-http
+    - on-tftp
+    - on-dhcp-proxy
+    - on-taskgraph
+    - on-syslog
+
+
+- name: Install the Debian packages build
+  shell: dpkg -i ./{{item}}*.deb
+  args:
+      chdir: "{{ ansible_env.HOME }}/src/{{ item }}"
+  with_items:
+    - on-http
+    - on-tftp
+    - on-dhcp-proxy
+    - on-taskgraph
+    - on-syslog
+  sudo:  yes
+
+
+
+- file: path="/etc/default/{{ item }}" state=touch
+  with_items:
+    - on-dhcp-proxy
+    - on-http
+    - on-taskgraph
+    - on-tftp
+    - on-syslog
+  sudo: yes
+
+- name: set HTTP static directory for RackHD
+  set_fact: http_static_directory="/var/renasar/on-http/static/http"
+
+- name: set TFTP static directory for RackHD
+  set_fact: tftp_static_directory="/var/renasar/on-tftp/static/tftp"


### PR DESCRIPTION
comparing with the rackhd_package.yml, it will do below special: 
(1) build deb package from source code, and dpkg install it
(2) build micro-kernel/ipxe image from source code(/on-imagebuilder/), instead of downloading from bintray

===================
*Things Left before merge*  update /RackHD/on-imagebuilder pointer to latest head of on-imagebuilder repo

===================
Test -> I download a 14.04 Ubuntu vagrant box, and run this yml with below. it runs well.
`sudo  ansible-playbook -i "local," -c local rackhd_install_from_src.yml`