### PR TITLE
Add OS installer regression tests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -8,7 +8,7 @@
     virtualenv .venv
     source .venv/bin/activate
     sudo pip install -r requirements.txt
-
+    
 ## Running the tests
 
 Run Vagrant environment
@@ -36,15 +36,15 @@ Run regression tests
 
     python run.py --group=regression-tests
 
-## Optional settings
+## Optional Environment Variables
 
 Log levels
-
+    
     NOTE: CRITICAL < ERROR < WARNING < INFO < DEBUG
 
     export RACKHD_TEST_LOGLVL=[CRITICAL|ERROR|WARNING|INFO|DEBUG default=WARNING]
 
-API host/port
+API host/port 
 
     export RACKHD_HOST=[host ip default=localhost]
     export RACKHD_PORT=[host port default=9090]
@@ -53,7 +53,26 @@ AMQP URL
 
     export RACKHD_AMQP_URL=[amqp://<url>:<port> default=amqp://localhost:9091]
 
-Specify test groups
+OS Installer locations
+
+    Specify specific OS repository path:
+
+    export RACKHD_CENTOS_REPO_PATH=[location to http mirror for all CentOS images]
+    export RACKHD_ESXI_REPO_PATH=[location to http mirror for all ESXi images]
+    export RACKHD_UBUNTU_REPO_PATH=[location to http mirror for all Ubuntu images]
+    export RACKHD_SUSE_REPO_PATH=[location to http mirror for all SUSE images]
+
+    Example: export RACKHD_CENTOS_REPO_PATH=http://ip:port/repo/centos
+
+HTTP proxy configuration (optional):
+
+To define HTTP proxies for accessing remote OS image repositories, see the [RackHD Configuration howto](http://rackhd.readthedocs.io/en/latest/rackhd/configuration.html?highlight=httpProxies#rackhd-configuration)
+
+Specifying test groups
+    
+    To display the entire test plan and available test groups run:
+
+    python run.py --show-plan
 
     Use the nosetest --group option to test a specific group:
 
@@ -66,7 +85,7 @@ Specify test groups
     Run only Redfish 1.0 compliant API related tests:
     python run.py --group=api-redfish-1.0
 
-To reset the default target BMC user/password
+To reset the default target BMC user/password 
 
     NOTE: only prompts for user/password when .passwd file is missing
 

--- a/test/tests/api/redfish_1_0/chassis_tests.py
+++ b/test/tests/api/redfish_1_0/chassis_tests.py
@@ -14,7 +14,8 @@ from json import loads,dumps
 
 LOG = Log(__name__)
 
-@test(groups=['redfish.chassis.tests'], depends_on_groups=['obm.tests'])
+@test(groups=['redfish.chassis.tests'], \
+    depends_on_groups=['obm.tests', 'amqp.tests'])
 class ChassisTests(object):
 
     def __init__(self):

--- a/test/tests/api/v1_1/amqp_tests.py
+++ b/test/tests/api/v1_1/amqp_tests.py
@@ -15,7 +15,7 @@ from json import dumps,loads
 
 LOG = Log(__name__)
 
-@test(groups=['amqp.tests'])
+@test(groups=['amqp.tests'], depends_on_groups=['obm.tests'])
 class AMQPTests(object):
 
     def __init__(self):
@@ -48,8 +48,7 @@ class AMQPTests(object):
                 task.worker.stop()
                 task.running = False
 
-    @test(groups=['amqp.tests.sel'], \
-          depends_on_groups=['check-obm'])
+    @test(groups=['amqp.tests.sel'])
     def check_sel_task(self):
         """ Testing AMQP on.task.ipmi.sel.result """
         Nodes().nodes_get()
@@ -70,8 +69,7 @@ class AMQPTests(object):
         for task in self.__tasks:
             assert_false(task.timeout, message='timeout waiting for task {0}'.format(task.id))
 
-    @test(groups=['amqp.tests.sdr'], \
-          depends_on_groups=['amqp.tests.sel'])
+    @test(groups=['amqp.tests.sdr'])
     def check_sdr_task(self):
         """ Testing AMQP on.task.ipmi.sdr.result """
         Nodes().nodes_get()
@@ -92,8 +90,7 @@ class AMQPTests(object):
         for task in self.__tasks:
             assert_false(task.timeout, message='timeout waiting for task {0}'.format(task.id))
         
-    @test(groups=['amqp.tests.chassis'], \
-          depends_on_groups=['amqp.tests.sdr'])
+    @test(groups=['amqp.tests.chassis'])
     def check_chassis_task(self):
         """ Testing AMQP on.task.ipmi.chassis.result """
         Nodes().nodes_get()

--- a/test/tests/api/v1_1/nodes_tests.py
+++ b/test/tests/api/v1_1/nodes_tests.py
@@ -296,7 +296,8 @@ class NodesTests(object):
         rsp = self.__client.last_response
         assert_equal(204, rsp.status, message=rsp.reason)
 
-    @test(groups=['catalog_nodes'], depends_on_groups=['delete-whitelist-node'])
+    @test(groups=['catalog_nodes', 'check-nodes-catalogs.test'], \
+        depends_on_groups=['nodes.discovery.test'])
     def test_node_catalogs(self):
         """ Testing GET id:/catalogs """
         resps = []
@@ -324,7 +325,7 @@ class NodesTests(object):
             assert_equal(200,resp.status, message=resp.reason)
         assert_raises(rest.ApiException, Nodes().nodes_identifier_catalogs_source_get, 'fooey','bmc')
 
-    @test(groups=['node_workflows'], depends_on_groups=['catalog_source'])
+    @test(groups=['node_workflows'], depends_on_groups=['nodes.discovery.test'])
     def test_node_workflows_get(self):
         """Testing node GET:id/workflows"""
         resps = []

--- a/test/tests/api/v1_1/obm_tests.py
+++ b/test/tests/api/v1_1/obm_tests.py
@@ -22,29 +22,32 @@ class OBMTests(object):
     def __init__(self):
         self.__client = config.api_client 
 
-    @test(groups=['obm.tests', 'set-ipmi-obm'], depends_on_groups=['nodes.tests'])
+    @test(groups=['set-ipmi-obm'], 
+        depends_on_groups=['check-nodes-catalogs.test'])
     def setup_ipmi_obm(self):
         """ Setup IPMI OBM settings with PATCH:/nodes """
         assert_equal(len(obmSettings().setup_nodes(service_type='ipmi-obm-service')), 0)
 
-    @test(groups=['obm.tests', 'check-obm'], depends_on_groups=['set-ipmi-obm'])
+    @test(groups=['check-ipmi-obm'], depends_on_groups=['set-ipmi-obm'])
     def check_ipmi_obm_settings(self):
         """ Checking IPMI OBM settings GET:/nodes """
         assert_equal(len(obmSettings().check_nodes(service_type='ipmi-obm-service')), 0, 
                 message='there are missing IPMI OBM settings!')
     
-    @test(groups=['obm.tests', 'set-snmp-obm'], depends_on_groups=['nodes.tests'])
+    @test(groups=['set-snmp-obm'], \
+        depends_on_groups=['check-nodes-catalogs.test'])
     def setup_snmp_obm(self):
         """ Setup SNMP OBM settings with PATCH:/nodes """
         assert_equal(len(obmSettings().setup_nodes(service_type='snmp-obm-service')), 0)
 
-    @test(groups=['obm.tests', 'check-obm'], depends_on_groups=['set-snmp-obm'])
+    @test(groups=['check-snmp-obm'], depends_on_groups=['set-snmp-obm'])
     def check_snmp_obm_settings(self):
         """ Checking SNMP OBM settings GET:/nodes """
         assert_not_equal(len(obmSettings().check_nodes(service_type='snmp-obm-service')), 0,
                 message='there are missing SNMP OBM settings!')
    
-    @test(groups=['obm.tests', 'create-node-id-obm-identify'], depends_on_groups=['check-obm'])
+    @test(groups=['create-node-id-obm-identify'], \
+        depends_on_groups=['check-ipmi-obm', 'check-snmp-obm'])
     def test_node_id_obm_identify_create(self):
         """ Testing POST:/nodes/:id/obm/identify """
         Nodes().nodes_get()
@@ -61,7 +64,7 @@ class OBMTests(object):
             assert_equal(200, c.status, message=c.reason)
         assert_raises(rest.ApiException, Nodes().nodes_identifier_obm_identify_post, 'fooey', data)
 
-    @test(groups=['obm.tests', 'test-obms'])
+    @test(groups=['test-obm-library.tests'])
     def test_obm_library(self):
         """ Testing GET:/obms/library """
         Obms().obms_library_get()
@@ -70,7 +73,7 @@ class OBMTests(object):
         assert_equal(200, self.__client.last_response.status)
         assert_not_equal(0, len(obms), message='OBM list was empty!')
 
-    @test(groups=['obm.tests', 'test-obms-identifier'])
+    @test(groups=['test-obms-identifier.tests'])
     def test_obm_library_identifier(self):
         """ Testing GET:/obms/library/:id """
         Obms().obms_library_get()

--- a/test/tests/api/v1_1/os_install_tests.py
+++ b/test/tests/api/v1_1/os_install_tests.py
@@ -1,27 +1,162 @@
 from config.api1_1_config import *
-from obm_settings import obmSettings
+from config.settings import *
+from modules.logger import Log
 from on_http_api1_1 import NodesApi as Nodes
 from on_http_api1_1 import rest
-from modules.logger import Log
+from workflows_tests import WorkflowsTests as workflows
 from datetime import datetime
 from proboscis.asserts import assert_equal
 from proboscis.asserts import assert_false
 from proboscis.asserts import assert_raises
 from proboscis.asserts import assert_true
 from proboscis.asserts import assert_not_equal
+from proboscis.asserts import assert_is_not_none
 from proboscis import SkipTest
 from proboscis import test
+from proboscis import after_class
+from proboscis import before_class
 from json import dumps, loads
+import os
 
 LOG = Log(__name__)
 
-@test(groups=['os-install.v1.1.tests'])
+@test(groups=['os-install.v1.1.tests'], \
+    depends_on_groups=['amqp.tests'])
 class OSInstallTests(object):
 
     def __init__(self):
-        self.__client = config.api_client 
-
-    @test(groups=['suse-install.v1.1.test'])
-    def test_install_suse(self):
-        """ Testing SUSE OS Installer Workflow """
+        self.__client = config.api_client
+        self.__base = os.getenv('RACKHD_BASE_REPO_URL', \
+            'http://{0}:{1}'.format(HOST_IP, HOST_PORT))
+            
+    @before_class()
+    def setup(self):
         pass
+        
+    @after_class(always_run=True)
+    def teardown(self):
+        self.__format_drives()  
+    
+    def __get_data(self):
+        return loads(self.__client.last_response.data)
+    
+    def __post_workflow(self, graph_name, nodes, body):
+        workflows().post_workflows(graph_name, timeout_sec=3600, nodes=nodes, data=body)         
+
+    def __format_drives(self):
+        # Clear disk MBR and partitions
+        command = 'for disk in `lsblk | grep disk | awk \'{print $1}\'`; do '
+        command = command + 'sudo dd if=/dev/zero of=/dev/$disk bs=512 count=1 ; done'
+        body = {
+            'options': {
+                'shell-commands': {
+                    'commands': [ 
+                        { 'command': command } 
+                    ]
+                }
+            }
+        }
+        self.__post_workflow('Graph.ShellCommands', [], body) 
+
+    @test(enabled=False, groups=['format-drives.v1.1.test'])
+    def test_format_drives(self):
+        """ Drive Format Test """
+        self.__format_drives()  
+        
+    def install_centos(self, version, nodes=[], options=None):
+        graph_name = 'Graph.InstallCentOS'
+        os_repo = os.getenv('RACKHD_CENTOS_REPO_PATH', \
+            self.__base + '/repo/centos/{0}'.format(version))
+        body = options
+        if body == None:
+            body = {
+                'options': {
+                    'defaults': {
+                        'kvm': 'undefined', 
+                        'version':version,
+                        'repo': os_repo
+                    }
+                }
+            } 
+        self.__post_workflow(graph_name, nodes, body)
+        
+    def install_esxi(self, version, nodes=[], options=None):
+        graph_name = 'Graph.InstallEsx'
+        os_repo = os.getenv('RACKHD_ESXI_REPO_PATH', \
+            self.__base + '/repo/esxi/{0}'.format(version))
+        body = options
+        if body == None:
+            body = {
+                'options': {
+                    'defaults': {
+                        'installDisk': 'firstdisk',
+                        'version': version, 
+                        'repo': os_repo
+                    }
+                }
+            }
+        self.__post_workflow(graph_name, nodes, body)  
+        
+    def install_suse(self, version, nodes=[], options=None):
+        graph_name = 'Graph.InstallSUSE'
+        os_repo = os.getenv('RACKHD_SUSE_REPO_PATH', \
+            self.__base + '/repo/suse/{0}/'.format(version))
+        body = options
+        if body == None:
+            body = {
+                'options': {
+                    'defaults': {
+                        'kvm': 'undefined', 
+                        'version':version,
+                        'repo': os_repo
+                    }
+                }
+            }
+        self.__post_workflow(graph_name, nodes, body)
+        
+    def install_ubuntu(self, version, nodes=[], options=None):
+        graph_name = 'Graph.InstallUbuntu'
+        os_repo = os.getenv('RACKHD_UBUNTU_REPO_PATH', \
+            self.__base + '/repo/ubuntu')
+        body = options
+        if body == None:
+            body = {
+                'options': {
+                    'defaults': {
+                        'kvm': 'undefined', 
+                        'version':version,
+                        'repo': os_repo
+                    }
+                }
+            }
+        self.__post_workflow(graph_name, nodes, body)
+
+    @test(enabled=True, groups=['centos-6-5-install.v1.1.test'])
+    def test_install_centos_6(self):
+        """ Testing CentOS 6.5 Installer Workflow """
+        self.install_centos('6.5')
+        
+    @test(enabled=True, groups=['centos-7-install.v1.1.test'])
+    def test_install_centos_7(self, nodes=[], options=None):
+        """ Testing CentOS 7 Installer Workflow """
+        self.install_centos('7.0')
+
+    @test(enabled=True, groups=['ubuntu-install.v1.1.test'])
+    def test_install_ubuntu(self, nodes=[], options=None):
+        """ Testing Ubuntu 14.04 Installer Workflow """
+        self.install_ubuntu('trusty')
+        
+    @test(enabled=True, groups=['suse-install.v1.1.test'])
+    def test_install_suse(self, nodes=[], options=None):
+        """ Testing OpenSuse Leap 42.1 Installer Workflow """
+        self.install_suse('42.1')
+        
+    @test(enabled=True, groups=['esxi-5-5-install.v1.1.test'])
+    def test_install_esxi_5_5(self, nodes=[], options=None):
+        """ Testing ESXi 5.5 Installer Workflow """
+        self.install_esxi('5.5')
+        
+    @test(enabled=True, groups=['esxi-6-install.v1.1.test'])
+    def test_install_esxi_6(self, nodes=[], options=None):
+        """ Testing ESXi 6 Installer Workflow """
+        self.install_esxi('6.0')


### PR DESCRIPTION
- Adds OS installer test cases for CentOS, Ubuntu, ESXi, and SUSE OS installer workflows for 1.1 API.  Runs concurrently across all discovered nodes.
- Adds workflow to remove disk MBR and partitions on each node (runs concurrently)
- Some cleanup around group naming and priorities (mainly in API1.1 AMQP and OBM tests). 
- Some POST workflow refactoring under workflows_test module.

@RackHD/corecommitters @keedya @zyoung51 @tannoa2 @uppalk1 @iceiilin  