### PR TITLE
packer vagrant box using node 4 and based on ubuntu 16.04

### DIFF
--- a/packer/README.md
+++ b/packer/README.md
@@ -17,7 +17,13 @@ enable:
 
 ## To build locally (using code from source)
 
-    packer build -only=virtualbox-iso template.json
+### Build vagrant box based on Ubuntu 14.04
+
+    packer build -only=virtualbox-iso template-ubuntu-14.04.json
+
+### Build vagrant box based on Ubuntu 16.04
+
+    packer build -only=virtualbox-iso template-ubuntu-16.04.json
 
 ## To build locally (using pre-built debian packages)
 

--- a/packer/ansible/rackhd_local.yml
+++ b/packer/ansible/rackhd_local.yml
@@ -8,7 +8,7 @@
     - git
     - rabbitmq
     - mongodb
-    - node-legacy
+    - node
     - isc-dhcp-server
     - monorail
     - snmptool
@@ -21,5 +21,3 @@
   vars:
 # branch of https://github.com/rackhd/rackhd to be used
     - branch: "master"
-# version of Node.js to use
-    - node_version: "0.10.41"

--- a/packer/ansible/roles/isc-dhcp-server/files/systemd-control.cfg
+++ b/packer/ansible/roles/isc-dhcp-server/files/systemd-control.cfg
@@ -1,0 +1,5 @@
+# CONTROL lan
+auto enp0s8
+iface enp0s8 inet static
+address 172.31.128.1
+netmask 255.255.252.0

--- a/packer/ansible/roles/isc-dhcp-server/files/systemd-isc-dhcp-server
+++ b/packer/ansible/roles/isc-dhcp-server/files/systemd-isc-dhcp-server
@@ -1,0 +1,21 @@
+# Defaults for isc-dhcp-server initscript
+# sourced by /etc/init.d/isc-dhcp-server
+# installed at /etc/default/isc-dhcp-server by the maintainer scripts
+
+#
+# This is a POSIX shell fragment
+#
+
+# Path to dhcpd's config file (default: /etc/dhcp/dhcpd.conf).
+#DHCPD_CONF=/etc/dhcp/dhcpd.conf
+
+# Path to dhcpd's PID file (default: /var/run/dhcpd.pid).
+#DHCPD_PID=/var/run/dhcpd.pid
+
+# Additional options to start dhcpd with.
+#	Don't use options -cf or -pf here; use DHCPD_CONF/ DHCPD_PID instead
+#OPTIONS=""
+
+# On what interfaces should the DHCP server (dhcpd) serve DHCP requests?
+#	Separate multiple interfaces with spaces, e.g. "eth0 eth1".
+INTERFACES="enp0s8"

--- a/packer/ansible/roles/isc-dhcp-server/tasks/main.yml
+++ b/packer/ansible/roles/isc-dhcp-server/tasks/main.yml
@@ -8,6 +8,17 @@
 - name: Copy isc-dhcp-server file to guest
   copy: src=isc-dhcp-server dest=/etc/default/isc-dhcp-server
   sudo: yes
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_version | int < 16
+
+- name: Copy systemd control network interface file to guest
+  copy: src=systemd-control.cfg dest=/etc/network/interfaces.d/control.cfg
+  sudo: yes
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_version | int >= 16
+
+- name: Copy systemd isc-dhcp-server file to guest
+  copy: src=systemd-isc-dhcp-server dest=/etc/default/isc-dhcp-server
+  sudo: yes
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_version | int >= 16
 
 - name: Copy dhcpd.conf file to guest
   copy: src=dhcpd.conf dest=/etc/dhcp/dhcpd.conf

--- a/packer/ansible/roles/node/tasks/main.yml
+++ b/packer/ansible/roles/node/tasks/main.yml
@@ -1,15 +1,10 @@
 ---
-- name: Download n Installer
-  get_url: url=http://git.io/n-install dest=/tmp/n-install mode=0755
-  register: download_n
-  sudo: yes
 
-- name: Install n
-  shell: "yes | N_PREFIX={{ ansible_env.HOME }}/n /tmp/n-install"
-  sudo: yes
-  when: download_n|changed
+- name: Setup nodejs source for installing node v4 
+  shell: curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
 
-- name: Install node
-  shell: "{{ ansible_env.HOME }}/n/bin/n {{ node_version | default('0.10.37') }}"
+- name: Install node v4
+  apt: pkg={{ item }} state=installed
+  with_items:
+    - nodejs
   sudo: yes
-  when: download_n|changed

--- a/packer/ansible/roles/swagger/tasks/main.yml
+++ b/packer/ansible/roles/swagger/tasks/main.yml
@@ -1,11 +1,21 @@
 ---
-- name: Install Maven and Swagger build Tools
+- name: Install Maven and Swagger build Tools with openjdk-7-jdk
   apt: pkg={{ item }} state=installed
   with_items:
     - openjdk-7-jdk
     - maven
     - libkrb5-dev
   sudo: yes
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_version | int < 16
+
+- name: Install Maven and Swagger build Tools with openjdk-8-jdk
+  apt: pkg={{ item }} state=installed
+  with_items:
+    - openjdk-8-jdk
+    - maven
+    - libkrb5-dev
+  sudo: yes
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_version | int >= 16
 
 - name: Grab Swagger CodeGen Tooling
   shell: git clone --branch v2.1.5 https://github.com/swagger-api/swagger-codegen.git

--- a/packer/template-ubuntu-14.04.json
+++ b/packer/template-ubuntu-14.04.json
@@ -68,6 +68,7 @@
         " keyboard-configuration/variant=USA<wait>",
         " locale=en_US<wait>",
         " netcfg/get_hostname=rackhd-demo<wait>",
+        " netcfg/hostname=rackhd-demo<wait>",
         " noapic<wait>",
         " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg<wait>",
         " -- <wait>",

--- a/packer/template-ubuntu-16.04.json
+++ b/packer/template-ubuntu-16.04.json
@@ -1,0 +1,168 @@
+{
+    "push": {
+      "name": "",
+      "vcs": true
+    },
+    "variables": {
+        "atlas_username": "{{ env `ATLAS_USERNAME` }}",
+        "atlas_name": "{{ env `ATLAS_NAME` }}"
+    },
+    "provisioners": [
+        {
+            "type": "shell",
+            "script": "scripts/base.sh",
+            "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'"
+        },
+        {
+            "type": "shell",
+            "script": "scripts/virtualbox.sh",
+            "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'",
+            "only": ["virtualbox-iso"]
+        },
+        {
+            "type": "shell",
+            "script": "scripts/vmware.sh",
+            "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'",
+            "only": ["vmware-iso"]
+        },
+        {
+            "type": "shell",
+            "scripts": [
+                "scripts/vagrant.sh",
+                "scripts/dep.sh"
+            ],
+            "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'"
+        },
+        {
+            "type": "ansible-local",
+            "inventory_groups": "local",
+            "playbook_file": "ansible/rackhd_local.yml",
+            "playbook_dir": "ansible"
+        },
+        {
+            "type": "shell",
+            "scripts": [
+                "scripts/cleanup.sh",
+                "scripts/zerodisk.sh"
+            ],
+            "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'"
+        }
+    ],
+  "builders": [
+    {
+      "type": "virtualbox-iso",
+      "boot_command": [
+        "<enter><wait><f6><esc><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "/install/vmlinuz<wait>",
+        " auto<wait>",
+        " console-setup/ask_detect=false<wait>",
+        " console-setup/layoutcode=us<wait>",
+        " console-setup/modelcode=pc105<wait>",
+        " debian-installer=en_US<wait>",
+        " fb=false<wait>",
+        " initrd=/install/initrd.gz<wait>",
+        " kbd-chooser/method=us<wait>",
+        " keyboard-configuration/layout=USA<wait>",
+        " keyboard-configuration/variant=USA<wait>",
+        " locale=en_US<wait>",
+        " netcfg/get_hostname=rackhd-demo<wait>",
+        " netcfg/hostname=rackhd-demo<wait>",
+        " noapic<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg<wait>",
+        " -- <wait>",
+        "<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 40960,
+      "guest_os_type": "Ubuntu_64",
+      "http_directory": "http",
+      "iso_checksum": "23e97cd5d4145d4105fbf29878534049",
+      "iso_checksum_type": "md5",
+      "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04-server-amd64.iso",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "echo 'shutdown -P now' > /tmp/shutdown.sh; echo 'vagrant'|sudo -S sh '/tmp/shutdown.sh'",
+      "vboxmanage": [
+        [ "modifyvm", "{{.Name}}", "--memory", "512" ],
+        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+      ]
+      },
+      {
+        "type": "vmware-iso",
+        "boot_command": [
+          "<enter><wait><f6><esc><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+          "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+          "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+          "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+
+          "/install/vmlinuz<wait>",
+          " auto<wait>",
+          " console-setup/ask_detect=false<wait>",
+          " console-setup/layoutcode=us<wait>",
+          " console-setup/modelcode=pc105<wait>",
+          " debian-installer=en_US<wait>",
+          " fb=false<wait>",
+          " initrd=/install/initrd.gz<wait>",
+          " kbd-chooser/method=us<wait>",
+          " keyboard-configuration/layout=USA<wait>",
+          " keyboard-configuration/variant=USA<wait>",
+          " locale=en_US<wait>",
+          " netcfg/get_hostname=rackhd-demo<wait>",
+          " noapic<wait>",
+          " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg<wait>",
+          " -- <wait>",
+          "<enter><wait>"
+        ],
+        "boot_wait": "10s",
+        "disk_size": 40960,
+        "guest_os_type": "linux",
+        "http_directory": "http",
+        "iso_checksum": "23e97cd5d4145d4105fbf29878534049",
+        "iso_checksum_type": "md5",
+        "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04-server-amd64.iso",
+        "ssh_username": "vagrant",
+        "ssh_password": "vagrant",
+        "ssh_port": 22,
+        "ssh_wait_timeout": "10000s",
+        "shutdown_command": "echo 'shutdown -P now' > /tmp/shutdown.sh; echo 'vagrant'|sudo -S sh '/tmp/shutdown.sh'",
+        "vmx_data": {
+          "memsize": "512",
+          "numvcpus": "1",
+          "cpuid.coresPerSocket": "1"
+        }
+      }
+  ],
+  "post-processors": [
+    [{
+        "type": "vagrant",
+        "keep_input_artifact": false
+    },
+    {
+        "type": "atlas",
+        "only": ["virtualbox-iso"],
+        "artifact": "{{user `atlas_username`}}/{{user `atlas_name`}}",
+        "artifact_type": "vagrant.box",
+        "metadata": {
+            "provider": "virtualbox"
+        }
+    }],
+    [{
+        "type": "vagrant",
+        "keep_input_artifact": false
+    },
+    {
+        "type": "atlas",
+        "only": ["vmware-iso"],
+        "artifact": "{{user `atlas_username`}}/{{user `atlas_name`}}",
+        "artifact_type": "vagrant.box",
+        "metadata": {
+            "provider": "vmware_desktop"
+        }
+    }]
+  ]
+}


### PR DESCRIPTION
1. Ubuntu 16.04 is released recently. update packer scripts for ubuntu 16.04. refer to https://github.com/chef/bento/blob/master/ubuntu-16.04-amd64.json
2. upgrade node 0.10 to the latest node 4 for both ubuntu  14.04 and 16.04. 
3. Adjust control network interface from 'eth1' to 'enp0s8'  for Ubuntu 16.04 (default name for virtualbox second NIC).  vagrant don't support systemd biosdevname setting(only support 'eth1'/...), workaround it using config file.

Updated

@RackHD/corecommitters @heckj @benbp @iceiilin 