### PR TITLE
bintray changed their download URIs, fixes #253

### DIFF
--- a/packer/ansible/roles/images/tasks/main.yml
+++ b/packer/ansible/roles/images/tasks/main.yml
@@ -19,7 +19,7 @@
    - vmlinuz-3.16.0-25-generic
 
 - name: retrieve the latest bootloaders from bintray
-  get_url: url="https://dl.bintray.com/rackhd/binary/builds/:{{ item }}"
+  get_url: url="https://dl.bintray.com/rackhd/binary/ipxe/:{{ item }}"
            dest="{{ tftp_static_directory }}/{{ item }}"
            validate_certs=no
            force=yes
@@ -30,7 +30,7 @@
    - monorail-efi64-snponly.efi
 
 - name: retrieve the latest syslinux bootloader from bintray
-  get_url: url="https://dl.bintray.com/rackhd/binary/builds/:{{ item }}"
+  get_url: url="https://dl.bintray.com/rackhd/binary/syslinux/:{{ item }}"
            dest="{{ tftp_static_directory }}/{{ item }}"
            validate_certs=no
            force=yes

--- a/packer/ansible/roles/images/tasks/main.yml
+++ b/packer/ansible/roles/images/tasks/main.yml
@@ -8,7 +8,7 @@
   sudo: yes
 
 - name: retrieve microkernel and overlays from bintray
-  get_url: url="https://bintray.com/artifact/download/rackhd/binary/builds/{{ item }}"
+  get_url: url="https://dl.bintray.com/rackhd/binary/builds/:{{ item }}"
            dest="{{ http_static_directory }}/common/{{ item }}"
            validate_certs=no
            force=yes
@@ -19,7 +19,7 @@
    - vmlinuz-3.16.0-25-generic
 
 - name: retrieve the latest bootloaders from bintray
-  get_url: url="https://bintray.com/artifact/download/rackhd/binary/ipxe/{{ item }}"
+  get_url: url="https://dl.bintray.com/rackhd/binary/builds/:{{ item }}"
            dest="{{ tftp_static_directory }}/{{ item }}"
            validate_certs=no
            force=yes
@@ -30,7 +30,7 @@
    - monorail-efi64-snponly.efi
 
 - name: retrieve the latest syslinux bootloader from bintray
-  get_url: url="https://bintray.com/artifact/download/rackhd/binary/syslinux/{{ item }}"
+  get_url: url="https://dl.bintray.com/rackhd/binary/builds/:{{ item }}"
            dest="{{ tftp_static_directory }}/{{ item }}"
            validate_certs=no
            force=yes


### PR DESCRIPTION
bintray appears to have changed their download URI structures, so the base paths in Ansible need some tweaking to make this work.

@rolandpoulter do I need to make any relevant changes in the docker pieces to grab the relevant files from these new locations? If so, can you point me in the right direction.

FYI @StevenLee1