### PR TITLE
OS installer timeout option and reformat default AMQP output

### DIFF
--- a/test/modules/amqp.py
+++ b/test/modules/amqp.py
@@ -37,10 +37,12 @@ class AMQPWorker(ConsumerMixin):
         return [consumer(self.__queue, callbacks=self.__callbacks)]
 
     def on_message(self, body, message):
-        out =  'Received message: %r' % dumps(body)
-        out += ' properties: %s' % dumps(message.properties)
-        out += '  delivery_info: %s' % dumps(message.delivery_info)
-        LOG.info(out,json=True)
+        out = {
+            'message':body, 
+            'properties':message.properties, 
+            'delivery_info': message.delivery_info
+        }
+        LOG.info(out, json=True)
         message.ack()
 
     def on_conn_retry(self):

--- a/test/tests/api/v1_1/os_install_tests.py
+++ b/test/tests/api/v1_1/os_install_tests.py
@@ -19,6 +19,7 @@ from json import dumps, loads
 import os
 
 LOG = Log(__name__)
+DEFAULT_TIMEOUT = 5400
 
 @test(groups=['os-install.v1.1.tests'], \
     depends_on_groups=['amqp.tests'])
@@ -44,7 +45,7 @@ class OSInstallTests(object):
         return loads(self.__client.last_response.data)
     
     def __post_workflow(self, graph_name, nodes, body):
-        workflows().post_workflows(graph_name, timeout_sec=3600, nodes=nodes, data=body)         
+        workflows().post_workflows(graph_name, timeout_sec=DEFAULT_TIMEOUT, nodes=nodes, data=body)         
 
     def __format_drives(self):
         # Clear disk MBR and partitions
@@ -78,12 +79,18 @@ class OSInstallTests(object):
             body = {
                 'options': {
                     'defaults': {
+                        'installDisk': '/dev/sda',
                         'kvm': 'undefined', 
-                        'version':version,
+                        'version': version,
                         'repo': os_repo
                     },
                     'set-boot-pxe': self.__obm_options,
-                    'reboot': self.__obm_options
+                    'reboot': self.__obm_options,
+                    'install-os': {
+                        'schedulerOverrides': {
+                            'timeout': 3600000
+                        }
+                    }
                 }
             } 
         self.__post_workflow(graph_name, nodes, body)
@@ -102,7 +109,12 @@ class OSInstallTests(object):
                         'repo': os_repo
                     },
                     'set-boot-pxe': self.__obm_options,
-                    'reboot': self.__obm_options
+                    'reboot': self.__obm_options,
+                    'install-os': {
+                        'schedulerOverrides': {
+                            'timeout': 3600000
+                        }
+                    }
                 }
             }
         self.__post_workflow(graph_name, nodes, body)  
@@ -116,12 +128,18 @@ class OSInstallTests(object):
             body = {
                 'options': {
                     'defaults': {
+                        'installDisk': '/dev/sda',
                         'kvm': 'undefined', 
-                        'version':version,
+                        'version': version,
                         'repo': os_repo
                     },
                     'set-boot-pxe': self.__obm_options,
-                    'reboot': self.__obm_options
+                    'reboot': self.__obm_options,
+                    'install-os': {
+                        'schedulerOverrides': {
+                            'timeout': 3600000
+                        }
+                    }
                 }
             }
         self.__post_workflow(graph_name, nodes, body)
@@ -135,12 +153,18 @@ class OSInstallTests(object):
             body = {
                 'options': {
                     'defaults': {
+                        'installDisk': '/dev/sda',
                         'kvm': 'undefined', 
-                        'version':version,
+                        'version': version,
                         'repo': os_repo
                     },
                     'set-boot-pxe': self.__obm_options,
-                    'reboot': self.__obm_options
+                    'reboot': self.__obm_options,
+                    'install-ubuntu': {
+                        'schedulerOverrides': {
+                            'timeout': 3600000
+                        }
+                    }
                 }
             }
         self.__post_workflow(graph_name, nodes, body)


### PR DESCRIPTION
- Set explicit timeout option per OS install test
- Set explicit installDisk
- Cleanup log output in default AMQP handler (format json)