### PR TITLE
Adds Dockerfile to python tests

### DIFF
--- a/test/.dockerignore
+++ b/test/.dockerignore
@@ -1,0 +1,2 @@
+.venv
+README.md

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2016, EMC, Inc.
+
+FROM frolvlad/alpine-python2:latest
+
+RUN apk add --update build-base gcc abuild binutils python-dev py-pip libffi-dev openssl-dev \
+  && pip install --upgrade pip
+
+COPY . /RackHD/test/
+WORKDIR /RackHD/test
+
+RUN cd /RackHD/test \
+  && pip install -r requirements.txt
+
+ENV RACKHD_TEST_LOGLVL ${RACKHD_TEST_LOGLVL:-DEBUG}
+ENV RACKHD_HOST ${RACKHD_HOST:-127.0.0.1}
+ENV RACKHD_PORT ${RACKHD_PORT:-9090}
+ENV RACKHD_AMQP_URL ${RACKHD_AMQP_URL:-amqp://127.0.0.1:5672}
+
+CMD [ "python", "/RackHD/test/run.py" ]


### PR DESCRIPTION
This will allow the python tests to be run when `docker-compose up` is executed. https://github.com/RackHD/RackHD/pull/265/files#diff-072e81fe88d9b23fe00fc189279936a6R39

Progress towards running our tests against a RackHD docker environment.