### PR TITLE
Get workflow by instanceId, not mongo id

### DIFF
--- a/test/tests/api/v2_0/workflows_tests.py
+++ b/test/tests/api/v2_0/workflows_tests.py
@@ -75,7 +75,7 @@ class WorkflowsTests(object):
         # Getting the identifier of the first workflow in order to validate the get-id function
         Api().workflows_get()
         rawj = json.loads(self.__client.last_response.data)
-        instance_id = rawj[0].get('id')
+        instance_id = rawj[0].get('instanceId')
         assert_is_not_none(instance_id)
         Api().workflows_get_by_id(instance_id)
         assert_equal(200,self.__client.last_response.status)


### PR DESCRIPTION
Supports/requires changes made in https://github.com/RackHD/on-http/pull/323

Replacing the use of the internal mongo `graph.id` field with the `graph.instanceId` attribute instead.

@RackHD/corecommitters @jlongever 