### PR TITLE
fix the bug: when a node with enclosure has no manufacturer, t case fails.

### DIFF
--- a/test/tests/api/v2_0/tags_tests.py
+++ b/test/tests/api/v2_0/tags_tests.py
@@ -83,11 +83,12 @@ class TagsTests(object):
             Api().get_nodes_by_tag(tag_name=n.get('id'))
             nodesWithTags = self.__get_data()
             for n in nodesWithTags:
-                rsp = self.__client.last_response
-                nodesList = self.__get_data()
-                tagsList = nodesList[0]['tags']
-                checkTag = n.get('id') in tagsList
-                assert_equal(True, checkTag, message=rsp.reason)
+                if n.get('type') == 'compute':
+                    rsp = self.__client.last_response
+                    nodesList = self.__get_data()
+                    tagsList = nodesList[0]['tags']
+                    checkTag = n.get('id') in tagsList
+                    assert_equal(True, checkTag, message=rsp.reason)
 
     @test(groups=['test_tags_delete'], depends_on_groups=['test-nodes-tagname-api2'])
     def test_tags_del(self):


### PR DESCRIPTION
when a none enclosure node has no manufacturer info the tag based on its id will be tagged to not only the none manufacturer nodes but also the enclosure node, in this case the enclosure node didn't be used to tag but to test tags.
@RackHD/corecommitters