### PR TITLE
Functional test fixes

### DIFF
--- a/test/tests/api/v1_1/nodes_tests.py
+++ b/test/tests/api/v1_1/nodes_tests.py
@@ -284,17 +284,21 @@ class NodesTests(object):
         """ Verify Delete:/nodes/:mac/dhcp/whitelist """
         Nodes().nodes_get()
         nodes = self.__get_data()
+        macList = []
         for n in nodes:
-            for i in n:
-                if i == 'identifiers':
-                    if len(n[i]) > 0:
-                        macaddress = n[i]
+            type = n.get('type')
+            assert_is_not_none(type)
+            if type == 'compute':
+                idList = n.get('identifiers')
+                assert_is_not_none(idList)
+                if len(idList) > 0:
+                    macList.append(idList[0]) # grab the first mac
 
-        macaddress_to_delete = macaddress[len(macaddress)-1]
-        LOG.info('Deleting macaddress {0}' .format(macaddress_to_delete))
-        Nodes().nodes_macaddress_dhcp_whitelist_delete(macaddress_to_delete)
-        rsp = self.__client.last_response
-        assert_equal(204, rsp.status, message=rsp.reason)
+        for addr in macList:
+            LOG.info('Deleting macaddress {0}' .format(addr))
+            Nodes().nodes_macaddress_dhcp_whitelist_delete(addr)
+            rsp = self.__client.last_response
+            assert_equal(204, rsp.status, message=rsp.reason)
 
     @test(groups=['catalog_nodes', 'check-nodes-catalogs.test'], \
         depends_on_groups=['nodes.discovery.test'])

--- a/test/tests/api/v2_0/skupack_tests.py
+++ b/test/tests/api/v2_0/skupack_tests.py
@@ -148,12 +148,12 @@ class SkusTests(object):
 
                 #update the sku rule above (rules[0].name.contains) with a value from the cataloged node
                 node_id = n.get('id')
-                Api().nodes_get_catalog_by_id(identifier=node_id)
+                Api().nodes_get_catalog_source_by_id(identifier=node_id,source='dmi')
                 node_catalog_data =loads(self.__client.last_response.data)
                 #LOG.info('node_manufacturer is  :  {0} '.format((node_catalog_data)))
                 if len(node_catalog_data) > 0:
-                    LOG.info('node_manufacturer is  :  {0} '.format((node_catalog_data)[0].get('data').get("Base Board Information").get("Manufacturer")))
-                    node_manufacturer= (node_catalog_data)[0].get('data').get("Base Board Information").get("Manufacturer").split(" ")[0]
+                    LOG.info('node_manufacturer is  :  {0} '.format(node_catalog_data.get('data').get("Base Board Information").get("Manufacturer")))
+                    node_manufacturer= node_catalog_data.get('data').get("Base Board Information").get("Manufacturer").split(" ")[0]
                     sku['rules'][0]['contains'] = node_manufacturer
 
                     #POST the new sku
@@ -200,10 +200,10 @@ class SkusTests(object):
             if n.get('type') == 'compute':
                 # update the sku rule above (rules[0].name.contains) with a value from the cataloged node
                 node_id = n.get('id')
-                Api().nodes_get_catalog_by_id(identifier=node_id)
-                node_catalog_data = loads(self.__client.last_response.data)
+                Api().nodes_get_catalog_source_by_id(identifier=node_id,source='dmi')
+                node_catalog_data =loads(self.__client.last_response.data)
                 if len(node_catalog_data) > 0:
-                    node_manufacturer = (node_catalog_data)[0].get('data').get("System Information").get("Manufacturer").split(" ")[0]
+                    node_manufacturer = node_catalog_data.get('data').get("System Information").get("Manufacturer").split(" ")[0]
 
 
                     #Post the sku pack
@@ -257,8 +257,8 @@ class SkusTests(object):
         for n in self.__nodes:
             if n.get('type') == 'compute':
                 node_id = n.get('id')
-                Api().nodes_get_catalog_by_id(identifier=node_id)
-                node_catalog_data = loads(self.__client.last_response.data)
+                Api().nodes_get_catalog_source_by_id(identifier=node_id,source='dmi')
+                node_catalog_data =loads(self.__client.last_response.data)
                 if len(node_catalog_data) > 0:
                     # update the sku rule above (rules[0].name.contains) with a value from the cataloged node
                     node_id = n.get('id')

--- a/test/tests/api/v2_0/tags_tests.py
+++ b/test/tests/api/v2_0/tags_tests.py
@@ -22,6 +22,19 @@ class TagsTests(object):
     def __get_data(self):
         return loads(self.__client.last_response.data)
 
+    def __create_tag_rule(self, id):
+        Api().nodes_get_catalog_source_by_id(identifier=id,source='dmi')
+        updated_catalog = self.__get_data()
+        return {
+            "name": id,
+            "rules": [
+                {
+                    "equals": updated_catalog["data"]["System Information"]["Manufacturer"],
+                    "path": "dmi.System Information.Manufacturer" 
+                }
+            ]
+        }
+
     @test(groups=['create-tag-api2'])
     def test_tag_create(self):
         """ Testing POST:/api/2.0/tags/ """
@@ -29,11 +42,8 @@ class TagsTests(object):
         nodes = self.__get_data()
         for n in nodes:
             if n.get('type') == 'compute':
-                Api().nodes_get_catalog_by_id(identifier=n.get('id'))
-                updated_catalog = self.__get_data()
-                tagsWithRules = {"name": n.get('id'),
-                                 "rules":[{"equals": updated_catalog[0]["data"]["System Information"]["Manufacturer"],
-                                           "path": "dmi.System Information.Manufacturer" }]}
+                tagsWithRules = self.__create_tag_rule(n.get('id'))
+                assert_not_equal(len(tagsWithRules), 0, "Failed to create tag rules")
                 LOG.info(tagsWithRules)
                 Api().create_tag(body=tagsWithRules)
                 tag_data = self.__get_data()
@@ -48,11 +58,8 @@ class TagsTests(object):
         tagsArray = []
         for n in nodes:
             if n.get('type') == 'compute':
-                Api().nodes_get_catalog_by_id(identifier=n.get('id'))
-                updated_catalog = self.__get_data()
-                tagsWithRules = {"name": n.get('id'),
-                                 "rules":[{"equals": updated_catalog[0]["data"]["System Information"]["Manufacturer"],
-                                           "path": "dmi.System Information.Manufacturer" }]}
+                tagsWithRules = self.__create_tag_rule(n.get('id'))
+                assert_not_equal(len(tagsWithRules), 0, "Failed to create tag rules")
                 tagsArray.append(tagsWithRules)
         Api().get_all_tags()
         rsp = self.__client.last_response


### PR DESCRIPTION
- Modify tags and skus to request the 'dmi' catalog instead of attempting
  to parse the catalog array.  This resolves an issue where the 'dmi' was
  not the first element in the array, and the tests would fail.
- Modify the 1.1 Delete:/nodes/:mac/dhcp/whitelist to only delete compute
  type identifiers to align with the POST:/nodes/:mac/dhcp/whitelist test.

@RackHD/corecommitters @uppalk1 @keedya @tannoa2 @jlongever 