### PR TITLE
OS Install Regression test failures for  ESXI 

### DIFF
--- a/test/tests/api/v1_1/os_install_tests.py
+++ b/test/tests/api/v1_1/os_install_tests.py
@@ -110,7 +110,8 @@ class OSInstallTests(object):
                     'defaults': {
                         'installDisk': 'firstdisk',
                         'version': version, 
-                        'repo': os_repo
+                        'repo': os_repo,
+                        'users': [{ 'name': 'onrack', 'password': 'Onr@ck1!', 'uid': 1010 }]
                     },
                     'set-boot-pxe': self.__obm_options,
                     'reboot': self.__obm_options,


### PR DESCRIPTION
Add user to users[] in options, required for ssh Validation task
depends on :https://github.com/RackHD/on-core/pull/173