### PR TITLE
Fixing the centOS install test

### DIFF
--- a/test/tests/api/v1_1/os_install_tests.py
+++ b/test/tests/api/v1_1/os_install_tests.py
@@ -35,7 +35,7 @@ class OSInstallTests(object):
         self.__obm_options = { 
             'obmServiceName': defaults.get('RACKHD_GLOBAL_OBM_SERVICE_NAME', \
                 'ipmi-obm-service')
-        }
+	}
             
     @before_class()
     def setup(self):
@@ -84,9 +84,9 @@ class OSInstallTests(object):
                 'options': {
                     'defaults': {
                         'installDisk': '/dev/sda',
-                        'kvm': 'undefined', 
                         'version': version,
-                        'repo': os_repo
+                        'repo': os_repo,
+			'users': [{ 'name': 'onrack', 'password': 'Onr@ck1!', 'uid': 1010 }]
                     },
                     'set-boot-pxe': self.__obm_options,
                     'reboot': self.__obm_options,
@@ -188,7 +188,7 @@ class OSInstallTests(object):
     def test_install_ubuntu(self, nodes=[], options=None):
         """ Testing Ubuntu 14.04 Installer Workflow """
         self.install_ubuntu('trusty')
-        
+       
     @test(enabled=True, groups=['suse-install.v1.1.test'])
     def test_install_suse(self, nodes=[], options=None):
         """ Testing OpenSuse Leap 42.1 Installer Workflow """
@@ -203,3 +203,4 @@ class OSInstallTests(object):
     def test_install_esxi_6(self, nodes=[], options=None):
         """ Testing ESXi 6 Installer Workflow """
         self.install_esxi('6.0')
+


### PR DESCRIPTION
The undefined KVM option was causing a problem:
"
ApiException: (400)
Reason: Bad Request
HTTP response headers: HTTPHeaderDict({'Content-Length': '96', 'X-Powered-By': 'Express', 'Connection': 'keep-alive', 'ETag': 'W/"60-XK65W/Oe2Sdf6stTjyKPWQ"', 'Date': 'Tue, 12 Jul 2016 15:23:55 GMT', 'Access-Control-Allow-Origin': '*', 'Content-Type': 'application/json; charset=utf-8'})
HTTP response body: {"message":"Task.Os.Install.CentOS: JSON schema validation failed - data.kvm should
"