### PR TITLE
Add NFS NIC device last, so that eth1 in /etc/default/isc-dhcp-server…

### DIFF
--- a/example/Vagrantfile
+++ b/example/Vagrantfile
@@ -15,18 +15,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             v.customize ["modifyvm", :id, "--nicpromisc2", "allow-all", "--ioapic", "on"]
         end
 
-        # NOTE: virtualbox shared folder syncing can be quite slow, but shared folders
-        # can be configured as NFS mounts to the host instead. 
-        # To do so, append: `, type: "nfs"` to all of the target.vm.synced_folder commands
-        # below, then on the host system, run `sudo nfsd start`.
-        # Additionally, uncomment the below configuration:
-
-        # For NFS mounts, a host only network is needed. Feel free to change the IP.
-        # target.vm.network "private_network", ip: "192.168.50.4"
-
         # Sync optional local workspace directory to the vagrant instances src/ path.
         # REPO is optional when WORKSPACE is defined, used for synchronizing single RackHD repos
         # otherwise it assumes all service repos have been cloned and built under the WORKSPACE path.
+        # NOTE: See further below for instructions on how to use an NFS mount for faster synced file performance
         if ENV['WORKSPACE']
 	  if ENV['REPO'] == "on-tasks"
             target.vm.synced_folder "#{ENV['WORKSPACE']}/#{ENV['REPO']}", "/home/vagrant/src/on-taskgraph/node_modules/on-tasks/"
@@ -61,6 +53,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         target.vm.network "forwarded_port", guest: 5672, host: 9091
         target.vm.network "forwarded_port", guest: 9080, host: 9092
         target.vm.network "forwarded_port", guest: 8443, host: 9093
+
+        # NOTE: virtualbox shared folder syncing can be quite slow, but shared folders
+        # can be configured as NFS mounts to the host instead. 
+        # To do so, append: `, type: "nfs"` to all of the target.vm.synced_folder commands
+        # below, then on the host system, run `sudo nfsd start`.
+        # Additionally, uncomment the below configuration:
+        #
+        # For NFS mounts, a host only network is needed. Feel free to change the IP.
+        # target.vm.network "private_network", ip: "192.168.50.4"
 
         # If true, then any SSH connections made will enable agent forwarding.
         # Default value: false


### PR DESCRIPTION
… points to the right interface

Hat tip to @DavidjohnBlodgett for finding this issue.

Basically, if you uncomment the private network settings for using NFS mounts, in its current place in the Vagrantfile, it will add a network interface to be enumerated _before_ the closednet interface that the RackHD/DHCP services run on. This conflicts with the entry in `/etc/default/isc-dhcp-server` that points to `eth1`, such that the isc-dhcp-server upstart service will fail on startup. If we move the extra private network interface to be after all other network setup commands in the Vagrantfile, then it gets enumerated as `eth2` and the closednet interface stays on `eth1`

@RackHD/corecommitters @zhangy42 @lacarb 