### PR TITLE
updating ansible playbook for node4

### DIFF
--- a/packer/ansible/rackhd_package.yml
+++ b/packer/ansible/rackhd_package.yml
@@ -8,7 +8,7 @@
     - git
     - rabbitmq
     - mongodb
-    - node-legacy
+    - node
     - rackhd-packages
     - isc-dhcp-server
     - monorail

--- a/packer/ansible/roles/node-legacy/tasks/main.yml
+++ b/packer/ansible/roles/node-legacy/tasks/main.yml
@@ -1,8 +1,0 @@
----
-- name: Install NodeJS Packages
-  apt: pkg={{ item }} state=installed
-  with_items:
-    - nodejs
-    - nodejs-legacy
-    - npm
-  sudo: yes


### PR DESCRIPTION
 - no longer install legacy (node 0.10) packages
 - install nodesource node4 packages
- removing ansible role for node 0.10