### PR TITLE
Add Ubuntu install examples for using local mounted iso

### DIFF
--- a/example/samples/install_ubuntu_payload_iso_full.json
+++ b/example/samples/install_ubuntu_payload_iso_full.json
@@ -1,0 +1,80 @@
+{
+    "options": {
+        "defaults": {
+            "version": "trusty",
+            "repo": "{{ api.server }}/ubuntu",
+            "rootPassword": "RackHDRocks!",
+            "hostname": "rackhd-node",
+            "domain": "example.com",
+            "baseUrl": "install/netboot/ubuntu-installer/amd64",
+            "kargs": {
+                "live-installer/net-image": "{{ api.server }}/ubuntu/install/filesystem.squashfs"
+            },
+            "users": [
+                {
+                    "name": "rackhd1",
+                    "password": "123456",
+                    "uid": 1010,
+                    "sshKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDJQ631/sw3D40h/6JfA+PFVy5Ofz6eu7caxbv0zdw4fTJsrFcOliHZTEtAvqx7Oa8gqSC6d7v61M0croQxtt1DGUcH2G4yhfdZOlK4pr5McwtX0T/APACdAr1HtP7Bt7u43mgHpUG4bHGc+NoY7cWCISkxl4apkYWbvcoJy/5bQn0uRgLuHUNXxK/XuLT5vG76xxY+1xRa5+OIoJ6l78nglNGrj2V+jH3+9yZxI43S9I3NOCl4BvX5Cp3CFMHyt80gk2yM1BJpQZZ4GHewkI/XOIFPU3rR5+toEYXHz7kzykZsqt1PtbaTwG3TX9GJI4C7aWyH9H+9Bt76vH/pLBIn rackhd@rackhd-demo"
+                },
+                {
+                    "name": "rackhd2",
+                    "password": "123456",
+                    "uid": 1011,
+                    "sshKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDJQ631/sw3D40h/6JfA+PFVy5Ofz6eu7caxbv0zdw4fTJsrFcOliHZTEtAvqx7Oa8gqSC6d7v61M0croQxtt1DGUcH2G4yhfdZOlK4pr5McwtX0T/APACdAr1HtP7Bt7u43mgHpUG4bHGc+NoY7cWCISkxl4apkYWbvcoJy/5bQn0uRgLuHUNXxK/XuLT5vG76xxY+1xRa5+OIoJ6l78nglNGrj2V+jH3+9yZxI43S9I3NOCl4BvX5Cp3CFMHyt80gk2yM1BJpQZZ4GHewkI/XOIFPU3rR5+toEYXHz7kzykZsqt1PtbaTwG3TX9GJI4C7aWyH9H+9Bt76vH/pLBIn rackhd@rackhd-demo"
+                }
+            ],
+            "rootSshKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDJQ631/sw3D40h/6JfA+PFVy5Ofz6eu7caxbv0zdw4fTJsrFcOliHZTEtAvqx7Oa8gqSC6d7v61M0croQxtt1DGUcH2G4yhfdZOlK4pr5McwtX0T/APACdAr1HtP7Bt7u43mgHpUG4bHGc+NoY7cWCISkxl4apkYWbvcoJy/5bQn0uRgLuHUNXxK/XuLT5vG76xxY+1xRa5+OIoJ6l78nglNGrj2V+jH3+9yZxI43S9I3NOCl4BvX5Cp3CFMHyt80gk2yM1BJpQZZ4GHewkI/XOIFPU3rR5+toEYXHz7kzykZsqt1PtbaTwG3TX9GJI4C7aWyH9H+9Bt76vH/pLBIn rackhd@rackhd-demo",
+            "dnsServers": [
+                "172.12.88.91",
+                "192.168.20.77"
+            ],
+            "networkDevices": [
+                {
+                    "device": "p50p1",
+                    "ipv4": {
+                        "ipAddr": "192.168.1.29",
+                        "gateway": "192.168.1.1",
+                        "netmask": "255.255.255.0",
+                        "vlanIds": [
+                            104,
+                            105
+                        ]
+                    },
+                    "ipv6": {
+                        "ipAddr": "fec0::6ab4:0:5efe:157.60.14.21",
+                        "gateway": "fe80::5efe:131.107.25.1",
+                        "netmask": "ffff.ffff.ffff.ffff.0.0.0.0",
+                        "vlanIds": [
+                            101,
+                            106
+                        ]
+                    }
+                },
+                {
+                    "device": "p802p2",
+                    "ipv4": {
+                        "ipAddr": "192.168.11.89",
+                        "gateway": "192.168.11.1",
+                        "netmask": "255.255.255.0",
+                        "vlanIds": [
+                            105,
+                            109
+                        ]
+                    },
+                    "ipv6": {
+                        "ipAddr": "fec0::6ab4:0:5efe:159.45.14.11",
+                        "gateway": "fe80::5efe:131.107.25.100",
+                        "netmask": "ffff.ffff.ffff.ffff.0.0.0.0",
+                        "vlanIds": [
+                            106,
+                            108
+                        ]
+                    }
+                }
+            ],
+            "kvm": true,
+            "installDisk": "/dev/sda"
+        }
+    }
+}

--- a/example/samples/install_ubuntu_payload_iso_minimal.json
+++ b/example/samples/install_ubuntu_payload_iso_minimal.json
@@ -1,0 +1,12 @@
+{
+    "options": {
+        "defaults": {
+            "repo": "{{ api.server }}/ubuntu",
+            "version": "trusty",
+            "baseUrl": "install/netboot/ubuntu-installer/amd64",
+            "kargs": {
+                "live-installer/net-image": "{{ api.server }}/ubuntu/install/filesystem.squashfs"
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Simply by downloading the ISO and mounting it to on-http static repo
 as follows:
 - mount -o loop /var/mirrors/ubuntu-14.04.4-server-amd64.iso on-http/static/http/ubuntu