### PR TITLE
adding libkrb5-dev library for NPM install

### DIFF
--- a/docker/monorail/config.json
+++ b/docker/monorail/config.json
@@ -14,7 +14,6 @@
     "dhcpProxyBindAddress": "0.0.0.0",
     "dhcpProxyBindPort": 4011,
     "dhcpSubnetMask": "255.255.252.0",
-    "gatewayaddr": "172.31.128.1",
     "httpDocsRoot": "./build/apidoc",
     "httpEndpoints": [
       {

--- a/packer/ansible/roles/monorail/files/config.json
+++ b/packer/ansible/roles/monorail/files/config.json
@@ -8,7 +8,6 @@
     "dhcpProxyBindAddress": "172.31.128.1",
     "dhcpProxyBindPort": 4011,
     "dhcpSubnetMask": "255.255.252.0",
-    "gatewayaddr": "172.31.128.1",
     "httpEndpoints": [
         {
             "address": "0.0.0.0",

--- a/packer/ansible/roles/remoterepos/tasks/main.yml
+++ b/packer/ansible/roles/remoterepos/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: install dev libraries for NPM installs
+  apt: pkg={{ item }} state=installed
+  with_items:
+    - libkrb5-dev
+
 - name: Get RackHD from source
   git: repo=https://github.com/rackhd/rackhd
        dest="{{ ansible_env.HOME }}/src"


### PR DESCRIPTION
 - needed for on-http install during source installation now
 - duplicate in later role (swagger) that we might consider removing in that role, but dupe doesn't hurt ansible doing it's thing, and trying to keep the dependencies relevant to their roles to maintain good form there