### PR TITLE
Update functional test's HTTP codes

### DIFF
--- a/test/tests/api/v2_0/lookups_tests.py
+++ b/test/tests/api/v2_0/lookups_tests.py
@@ -127,7 +127,7 @@ class LookupsTests(object):
         LOG.info("The lookup ID to be deleted is "+ self.id)
         Api().lookups_del_by_id(self.id)
         rsp = self.__client.last_response
-        assert_equal(200, rsp.status, message=rsp.reason)
+        assert_equal(204, rsp.status)
 
         #Validate that the lookup has been deleted and the returned value is an empty list
         try:

--- a/test/tests/api/v2_0/lookups_tests.py
+++ b/test/tests/api/v2_0/lookups_tests.py
@@ -127,7 +127,7 @@ class LookupsTests(object):
         LOG.info("The lookup ID to be deleted is "+ self.id)
         Api().lookups_del_by_id(self.id)
         rsp = self.__client.last_response
-        assert_equal(204, rsp.status)
+        assert_equal(204, rsp.status, message=rsp.reason)
 
         #Validate that the lookup has been deleted and the returned value is an empty list
         try:

--- a/test/tests/api/v2_0/nodes_tests.py
+++ b/test/tests/api/v2_0/nodes_tests.py
@@ -380,9 +380,9 @@ class NodesTests(object):
             for t in self.__test_tags.get('tags'):
                 assert_true(t not in updated_node.get('tags'), message= "Tag " + t + " was not deleted" )
         for c in get_codes:
-            assert_equal(200, c.status)
+            assert_equal(200, c.status, message=c.reason)
         for c in del_codes:
-            assert_equal(204, c.status)
+            assert_equal(204, c.status, message=c.reason)
           
         assert_raises(rest.ApiException, Api().nodes_del_tag_by_id, 'fooey',tag_name=['tag'])
 

--- a/test/tests/api/v2_0/nodes_tests.py
+++ b/test/tests/api/v2_0/nodes_tests.py
@@ -231,7 +231,7 @@ class NodesTests(object):
 
         assert_not_equal(0, len(codes), message='Delete node list empty!')
         for c in codes:
-            assert_equal(200, c.status, message=c.reason)
+            assert_equal(204, c.status, message=c.reason)
         assert_raises(rest.ApiException, Api().nodes_del_by_id, 'fooey')
 
     @test(groups=['catalog_nodes-api2'], depends_on_groups=['delete-whitelist-node-api2'])
@@ -362,24 +362,28 @@ class NodesTests(object):
     @test(groups=['node_tags_delete'], depends_on_groups=['node_tags_get'])
     def test_node_tags_del(self):
         """ Testing DELETE:api/2.0/nodes/:id/tags/:tagName """
-        codes = []
+        get_codes = []
+        del_codes = []
         Api().nodes_get_all()
         rsp = self.__client.last_response
         nodes = loads(rsp.data)
-        codes.append(rsp)
+        get_codes.append(rsp)
         for n in nodes:
             for t in self.__test_tags.get('tags'):
                 Api().nodes_del_tag_by_id(identifier=n.get('id'), tag_name=t)
                 rsp = self.__client.last_response
-                codes.append(rsp)
+                del_codes.append(rsp)
             Api().nodes_get_by_id(identifier=n.get('id'))
             rsp = self.__client.last_response
-            codes.append(rsp)
+            get_codes.append(rsp)
             updated_node = loads(rsp.data)
             for t in self.__test_tags.get('tags'):
                 assert_true(t not in updated_node.get('tags'), message= "Tag " + t + " was not deleted" )
-        for c in codes:
-            assert_equal(200, c.status, message=c.reason)
+        for c in get_codes:
+            assert_equal(200, c.status)
+        for c in del_codes:
+            assert_equal(204, c.status)
+          
         assert_raises(rest.ApiException, Api().nodes_del_tag_by_id, 'fooey',tag_name=['tag'])
 
 
@@ -393,16 +397,11 @@ class NodesTests(object):
         Api().nodes_master_del_tag_by_id(tag_name=t)
         rsp = self.__client.last_response
         codes.append(rsp)
-        updated_node = loads(rsp.data)
-        assert_equal([], updated_node, message= "masterDel API deleted an invalid node ")
         LOG.info("Test to check valid tags are deleted")
         for t in self.__test_tags.get('tags'):
             Api().nodes_master_del_tag_by_id(tag_name=t)
             rsp = self.__client.last_response
             codes.append(rsp)
-            updated_node = loads(rsp.data)
-            LOG.info("Printing nodes list")
-            LOG.info(updated_node)
         for c in codes:
-            assert_equal(200, c.status, message=c.reason)
+            assert_equal(204, c.status, message=c.reason)
 

--- a/test/tests/api/v2_0/skupack_tests.py
+++ b/test/tests/api/v2_0/skupack_tests.py
@@ -113,7 +113,7 @@ class SkusTests(object):
 
         Api().skus_id_delete(identifier = self.__sku_id)
         result = self.__client.last_response
-        assert_equal(200, result.status, message=result.reason)
+        assert_equal(204, result.status, message=result.reason)
 
         try:
             Api().skus_id_get(identifier = self.__sku_id)
@@ -187,7 +187,7 @@ class SkusTests(object):
                     LOG.info("Deleting the added sku")
                     Api().skus_id_delete(identifier=sku_id)
                     result = self.__client.last_response
-                    assert_equal(200, result.status, message=result.reason)
+                    assert_equal(204, result.status, message=result.reason)
             i = i +1
 
     @test(groups=['api2_post_skupack'], depends_on_groups=['api2_get_sku_nodes'])
@@ -257,9 +257,7 @@ class SkusTests(object):
                         assert_equal(None, n.get('httpProfileRoot'))
                     Api().skus_id_delete(self.__packFolderId)
                     result = self.__client.last_response
-                    assert_equal(200, result.status, message=result.reason)
-                    data = loads(result.data)
-                    LOG.info("ID of the deleted sku pack is:   "+ data.get('id'))
+                    assert_equal(204, result.status, message=result.reason)
                     # check to see if sku contents are cleaned up
                     Api().skus_get()
                     skus = loads(self.__client.last_response.data)

--- a/test/tests/api/v2_0/workflows_tests.py
+++ b/test/tests/api/v2_0/workflows_tests.py
@@ -164,7 +164,7 @@ class WorkflowsTests(object):
         rawj = json.loads(self.__client.last_response.data)
         assert_equal(self.workflowDict2.get('friendlyName'), str(rawj[0].get('friendlyName')))
         Api().workflows_delete_graphs_by_name(self.workflowDict.get('injectableName'))
-        assert_equal(200,self.__client.last_response.status)
+        assert_equal(204,self.__client.last_response.status)
         Api().workflows_get_graphs_by_name(self.workflowDict.get('injectableName'))
         assert_equal(0, len(json.loads(self.__client.last_response.data)))
 


### PR DESCRIPTION
Update functional tests codes, based on the on-http PR.  

**Depends on** PR https://github.com/RackHD/on-http/pull/389

All functional tests with the on-http changes PASS locally.

@benbp @keedya @BillyAbildgaard @brianparry @dalebremner @RackHD/corecommitters @zyoung51 @jlongever 