### PR TITLE
adding in monorail.intel.ipxe for NUC support

### DIFF
--- a/packer/ansible/roles/images/tasks/main.yml
+++ b/packer/ansible/roles/images/tasks/main.yml
@@ -28,6 +28,7 @@
    - monorail-undionly.kpxe
    - monorail-efi32-snponly.efi
    - monorail-efi64-snponly.efi
+   - monorail.intel.ipxe
 
 - name: retrieve the latest syslinux bootloader from bintray
   get_url: url="https://bintray.com/artifact/download/rackhd/binary/syslinux/{{ item }}"


### PR DESCRIPTION
requires https://github.com/RackHD/on-imagebuilder/pull/51 to be merged prior to this being fully operational (need the merge to generate binaries in bintray for this to work)

