### PR TITLE
extend build role to include deb packaging tooling

### DIFF
--- a/packer/ansible/roles/build/tasks/main.yml
+++ b/packer/ansible/roles/build/tasks/main.yml
@@ -4,4 +4,7 @@
   with_items:
     - build-essential
     - genisoimage
+    - debhelper
+    - devscripts
+    - fakeroot
   sudo: yes


### PR DESCRIPTION
- enables vagrant instance to be used to generate/test packaging 