### PR TITLE
ansible install node package dependencies for task documentation

### DIFF
--- a/packer/ansible/roles/remoterepos/tasks/main.yml
+++ b/packer/ansible/roles/remoterepos/tasks/main.yml
@@ -70,16 +70,9 @@
     chdir: "{{ ansible_env.HOME }}/src/on-http"
 
 - name: Npm install dependencies for task documentation
-  shell: "npm install {{ item }}"
+  shell: "npm install"
   args:
     chdir: "{{ ansible_env.HOME }}/src/on-http"
-  with_items:
-    - supertest
-    - sinon
-    - sinon-as-promised
-    - chai
-    - chai-as-promised
-    - sinon-chai
 
 - name: Generate hosted task documentation
   shell: "npm run taskdoc"

--- a/packer/ansible/roles/remoterepos/tasks/main.yml
+++ b/packer/ansible/roles/remoterepos/tasks/main.yml
@@ -77,6 +77,7 @@
     - supertest
     - sinon
     - sinon-as-promised
+    - chai
 
 - name: Generate hosted task documentation
   shell: "npm run taskdoc"

--- a/packer/ansible/roles/remoterepos/tasks/main.yml
+++ b/packer/ansible/roles/remoterepos/tasks/main.yml
@@ -73,7 +73,7 @@
   shell: "npm install supertest"
   args:
     chdir: "{{ ansible_env.HOME }}/src/on-http"
-	
+
 - name: Generate hosted task documentation
   shell: "npm run taskdoc"
   args:

--- a/packer/ansible/roles/remoterepos/tasks/main.yml
+++ b/packer/ansible/roles/remoterepos/tasks/main.yml
@@ -74,6 +74,11 @@
   args:
     chdir: "{{ ansible_env.HOME }}/src/on-http"
 
+- name: Npm install sinon
+  shell: "npm install sinon"
+  args:
+    chdir: "{{ ansible_env.HOME }}/src/on-http"
+
 - name: Generate hosted task documentation
   shell: "npm run taskdoc"
   args:

--- a/packer/ansible/roles/remoterepos/tasks/main.yml
+++ b/packer/ansible/roles/remoterepos/tasks/main.yml
@@ -69,6 +69,9 @@
   args:
     chdir: "{{ ansible_env.HOME }}/src/on-http"
 
+- name: Npm install supertest
+  shell: "npm install supertest"
+	
 - name: Generate hosted task documentation
   shell: "npm run taskdoc"
   args:

--- a/packer/ansible/roles/remoterepos/tasks/main.yml
+++ b/packer/ansible/roles/remoterepos/tasks/main.yml
@@ -71,6 +71,8 @@
 
 - name: Npm install supertest
   shell: "npm install supertest"
+  args:
+    chdir: "{{ ansible_env.HOME }}/src/on-http"
 	
 - name: Generate hosted task documentation
   shell: "npm run taskdoc"

--- a/packer/ansible/roles/remoterepos/tasks/main.yml
+++ b/packer/ansible/roles/remoterepos/tasks/main.yml
@@ -78,6 +78,7 @@
     - sinon
     - sinon-as-promised
     - chai
+    - chai-as-promised
 
 - name: Generate hosted task documentation
   shell: "npm run taskdoc"

--- a/packer/ansible/roles/remoterepos/tasks/main.yml
+++ b/packer/ansible/roles/remoterepos/tasks/main.yml
@@ -79,6 +79,7 @@
     - sinon-as-promised
     - chai
     - chai-as-promised
+    - sinon-chai
 
 - name: Generate hosted task documentation
   shell: "npm run taskdoc"

--- a/packer/ansible/roles/remoterepos/tasks/main.yml
+++ b/packer/ansible/roles/remoterepos/tasks/main.yml
@@ -69,15 +69,14 @@
   args:
     chdir: "{{ ansible_env.HOME }}/src/on-http"
 
-- name: Npm install supertest
-  shell: "npm install supertest"
+- name: Npm install dependencies for task documentation
+  shell: "npm install {{ item }}"
   args:
     chdir: "{{ ansible_env.HOME }}/src/on-http"
-
-- name: Npm install sinon
-  shell: "npm install sinon"
-  args:
-    chdir: "{{ ansible_env.HOME }}/src/on-http"
+  with_items:
+    - supertest
+    - sinon
+    - sinon-as-promised
 
 - name: Generate hosted task documentation
   shell: "npm run taskdoc"


### PR DESCRIPTION
When deploying a new rackhd build using the ansible rackhd_local playbook, the playbook fails when generating the task documentation due to missing node packages.  This started a few days ago after a check-in by joseph heck  This pull request adds the missing packages and allows my build to succeed.