### PR TITLE
Remove 'current' from docker coreos proxy config

### DIFF
--- a/docker/monorail/config.json
+++ b/docker/monorail/config.json
@@ -39,7 +39,7 @@
       {
         "localPath": "/coreos",
         "server": "http://stable.release.core-os.net",
-        "remotePath": "/amd64-usr/current/"
+        "remotePath": "/amd64-usr/"
       },
       {
         "localPath": "/centos",


### PR DESCRIPTION
Previously done in https://github.com/RackHD/RackHD/pull/147, not
migrated to docker config.