### PR TITLE
Add intel iPXE file to "files" docker container

### DIFF
--- a/docker/files/Dockerfile
+++ b/docker/files/Dockerfile
@@ -10,6 +10,8 @@ ADD https://bintray.com/artifact/download/rackhd/binary/ipxe/monorail.ipxe \
     /RackHD/downloads/monorail.ipxe
 ADD https://bintray.com/artifact/download/rackhd/binary/ipxe/monorail-undionly.kpxe \
     /RackHD/downloads/monorail-undionly.kpxe
+ADD https://bintray.com/artifact/download/rackhd/binary/ipxe/monorail.intel.ipxe \
+    /RackHD/downloads/monorail.intel.ipxe
 
 ADD https://bintray.com/artifact/download/rackhd/binary/syslinux/undionly.kkpxe \
     /RackHD/downloads/undionly.kkpxe


### PR DESCRIPTION
Since the `monorail.intel.ipxe` file is now built and uploaded to bintray by default, it should be added to the "files" container.

Reference #345 