### PR TITLE
add the missing version for install-os sample payload

### DIFF
--- a/example/samples/centos_iso_boot.json
+++ b/example/samples/centos_iso_boot.json
@@ -5,6 +5,7 @@
             "obmServiceName": "noop-obm-service"
         },
         "install-os": {
+            "version": "7.0",
             "repo": "{{api.server}}/Centos/7.0",
             "rootPassword": "root"
         }

--- a/example/samples/centos_iso_kvm_boot.json
+++ b/example/samples/centos_iso_kvm_boot.json
@@ -5,6 +5,7 @@
             "obmServiceName": "noop-obm-service"
         },
         "install-os": {
+            "version": "7.0",
             "repo": "{{api.server}}/Centos/7.0",
             "rootPassword": "root",
             "kvm": true

--- a/example/samples/full_centos_mirror_boot.json
+++ b/example/samples/full_centos_mirror_boot.json
@@ -5,6 +5,7 @@
             "obmServiceName": "noop-obm-service"
         },
         "install-os": {
+            "version": "7.0",
             "repo": "{{api.server}}/Centos/7.0",
             "rootPassword": "root",
             "hostname": "demoCentOS",

--- a/example/samples/install_suse_payload_minimal.json
+++ b/example/samples/install_suse_payload_minimal.json
@@ -1,8 +1,8 @@
 {
     "options": {
         "defaults": {
-        "version": "7",
+            "version": "42.1",
             "repo": "http://172.31.128.1:9080/opensuse/distribution/leap/42.1/repo/oss/"
-            }
+        }
     }
 }

--- a/example/samples/vQuanta_default_install_workflow.json
+++ b/example/samples/vQuanta_default_install_workflow.json
@@ -2,22 +2,24 @@
     "friendlyName": "vQuanta D51 Default Workflow",
     "injectableName": "Graph.vQuanta.Default",
     "options": {
-      "defaults": {
-        "version": "7",
-        "dnsServers": ["8.8.8.8", "8.8.4.4"],
-        "repo": "{{api.server}}/Centos/7.0",
-        "rootPassword": "rootpassword",
-        "users": [{
-          "name": "rackhd",
-          "password": "rackhd123",
-          "uid": 1010
-        }]
+        "defaults": {
+            "version": "7",
+            "dnsServers": ["8.8.8.8", "8.8.4.4"],
+            "repo": "{{api.server}}/Centos/7.0",
+            "rootPassword": "rootpassword",
+            "users": [
+                {
+                    "name": "rackhd",
+                    "password": "rackhd123",
+                    "uid": 1010
+                }
+            ]
         },
-      "install-centos": {
-        "schedulerOverrides": {
-          "timeout": 3600000
+        "install-centos": {
+            "schedulerOverrides": {
+                "timeout": 3600000
+            }
         }
-      }
     },
     "tasks": [
         {

--- a/example/samples/vQuanta_default_workflow.json
+++ b/example/samples/vQuanta_default_workflow.json
@@ -2,22 +2,24 @@
     "friendlyName": "vQuanta D51 Default Workflow",
     "injectableName": "Graph.vQuanta.Default",
     "options": {
-      "defaults": {
-        "version": "7",
-        "dnsServers": ["8.8.8.8", "8.8.4.4"],
-        "repo": "{{api.server}}/Centos/7.0",
-        "rootPassword": "rootpassword",
-        "users": [{
-          "name": "rackhd",
-          "password": "rackhd123",
-          "uid": 1010
-        }]
+        "defaults": {
+            "version": "7",
+            "dnsServers": ["8.8.8.8", "8.8.4.4"],
+            "repo": "{{api.server}}/Centos/7.0",
+            "rootPassword": "rootpassword",
+            "users": [
+                {
+                    "name": "rackhd",
+                    "password": "rackhd123",
+                    "uid": 1010
+                }
+            ]
         },
-      "install-centos": {
-        "schedulerOverrides": {
-          "timeout": 3600000
+        "install-centos": {
+            "schedulerOverrides": {
+                "timeout": 3600000
+            }
         }
-      }
     },
     "tasks": [
         {


### PR DESCRIPTION
The `version` is a required option for install-os which is defined in task-schema.

@RackHD/corecommitters @heckj @cgx027 @iceiilin @pengz1 @WangWinson 