### PR TITLE
Fix a case-dependency-error of api2.0

### DIFF
--- a/test/tests/api/v2_0/nodes_tests.py
+++ b/test/tests/api/v2_0/nodes_tests.py
@@ -244,7 +244,7 @@ class NodesTests(object):
             assert_equal(204, c.status, message=c.reason)
         assert_raises(rest.ApiException, Api().nodes_del_by_id, 'fooey')
 
-    @test(groups=['catalog_nodes-api2'], depends_on_groups=['delete-whitelist-node-api2'])
+    @test(groups=['catalog_nodes-api2'], depends_on_groups=['delete-node-api2'])
     def test_node_catalogs(self):
         """ Testing GET:/api/2.0/nodes/:id/catalogs """
         resps = []


### PR DESCRIPTION
**Introduction**
in ```nodes_tests.py```, there're three cases in order 
```
def test_node_patch(self)
def test_node_delete(self):
def test_node_catalogs(self):
``` 
1. patch fooey node, 2, delete fooey node, 3, test node catalogs.

Before test node catalogs, fooey must be deleted or error occurs.
so test_node_catalogs should depends test_node_delete, but it used to depends on **delete-whitelist-node-api2**, a group never exist. So I believe this's a mistake.

Because the cases are in order so normally **delete fooey will be done before test catalogs**.
But sometimes error still occurs, most of the time a success "test this please" would cover this issue.

**Error log**
see http://10.240.19.21/job/Templates/job/smoke-test/3377/consoleFull 
```
09:31:47 ======================================================================
09:31:47 FAIL: Testing GET:/api/2.0/nodes/:id/catalogs
09:31:47 ----------------------------------------------------------------------
09:31:47 Traceback (most recent call last):
09:31:47   File "/tmp/.venv/local/lib/python2.7/site-packages/proboscis/case.py", line 296, in testng_method_mistake_capture_func
09:31:47     compatability.capture_type_error(s_func)
09:31:47   File "/tmp/.venv/local/lib/python2.7/site-packages/proboscis/compatability/exceptions_2_6.py", line 27, in capture_type_error
09:31:47     func()
09:31:47   File "/tmp/.venv/local/lib/python2.7/site-packages/proboscis/case.py", line 350, in func
09:31:47     func(test_case.state.get_state())
09:31:47   File "/home/jenkins/workspace/on-http/RackHD/test/tests/api/v2_0/nodes_tests.py", line 258, in test_node_catalogs
09:31:47     assert_not_equal(0, len(resp), message='Node catalog is empty!')
09:31:47 AssertionError: Node catalog is empty!
```
and in vagrant.log we can find 
```
1:27:37 PM http.1 |  error: 
1:27:37 PM http.1 |    message: Could not find node with identifier fooey
1:27:37 PM http.1 |    name:    NotFoundError
1:27:37 PM http.1 |    context: 
1:27:37 PM http.1 |      identifier: fooey
1:27:37 PM http.1 |      collection: nodes
1:27:37 PM http.1 |    status:  404
1:27:37 PM http.1 |  path:  /nodes/fooey/catalogs
```

@iceiilin @panpan0000 @RackHD/corecommitters 