### PR TITLE
fix node discover test case issue: RackHD/RackHD issue #270

### DIFF
--- a/test/tests/api/v1_1/nodes_tests.py
+++ b/test/tests/api/v1_1/nodes_tests.py
@@ -106,7 +106,8 @@ class NodesTests(object):
     @test(groups=['nodes.discovery.test'])
     def test_nodes_discovery(self):
         """ Testing Graph.Discovery completion """
-        if self.check_compute_count():
+        count = defaults.get('RACKHD_NODE_COUNT', '')
+        if (count.isdigit() and self.check_compute_count() == int(count)) or self.check_compute_count():
             LOG.warning('Nodes already discovered!')
             return
         self.__discovery_duration = datetime.now()

--- a/test/tests/api/v2_0/nodes_tests.py
+++ b/test/tests/api/v2_0/nodes_tests.py
@@ -119,7 +119,8 @@ class NodesTests(object):
     @test(groups=['nodes.api2.discovery.test'])
     def test_nodes_discovery(self):
         """ API 2.0 Testing Graph.Discovery completion """
-        if self.check_compute_count():
+        count = defaults.get('RACKHD_NODE_COUNT', '')
+        if (count.isdigit() and self.check_compute_count() == int(count)) or self.check_compute_count():
             LOG.warning('Nodes already discovered!')
             return
         self.__discovery_duration = datetime.now()


### PR DESCRIPTION
enhance https://github.com/RackHD/RackHD/issues/270

Import a external value **NODES_NUMBER** ,which means how many nodes are used for test.

Enhanced node discovery test case skip condition, only if all nodes are in mongodb this case skip.

@iceiilin @panpan0000 @RackHD/corecommitters    

Jenkins: depends on https://github.com/RackHD/on-build-config/pull/23
