### PR TITLE
Updates to FIT test common library

### DIFF
--- a/test/fit_tests/common/fit_common.py
+++ b/test/fit_tests/common/fit_common.py
@@ -615,7 +615,7 @@ def cancel_active_workflows(nodeid):
        exitstatus = False
     return exitstatus
 
-def apply_obm_settings():
+def apply_obm_settings(retry=30):
     # New routine to install OBM credentials via workflows in parallel
     count = 0
     for creds in GLOBAL_CONFIG['credentials']['bmc']:
@@ -672,7 +672,7 @@ def apply_obm_settings():
 
     # run each OBM credential workflow on each node in parallel until success
     nodestatus = {} # dictionary with node IDs and status of each node
-    for dummy in range(0, 30):
+    for dummy in range(0, retry):
         nodelist = node_select()
         for node in nodelist:
             if node not in nodestatus:

--- a/test/fit_tests/common/fit_common.py
+++ b/test/fit_tests/common/fit_common.py
@@ -214,7 +214,7 @@ def scp_file_to_ora(src_file_name):
         remote_shell('cp ' + src_file_name + ' ~/' + src_file_name)
         return src_file_name
 
-    scp_target = 'onrack@{0}:'.format(ARGS_LIST["ora"])
+    scp_target = ARGS_LIST['usr'] + '@{0}:'.format(ARGS_LIST["ora"])
     cmd = 'scp -o StrictHostKeyChecking=no {0} {1}'.format(src_file_name, scp_target)
     if VERBOSITY >= 4:
         print "scp_file_to_ora: '{0}'".format(cmd)
@@ -363,7 +363,7 @@ def restful(url_command, rest_action='get', rest_payload=[], rest_timeout=None, 
                                        verify=sslverify,
                                        )
         if rest_action == "binary-put":
-            rest_headers.update({"Content-Type": "application/octet-stream"})
+            rest_headers.update({"Content-Type": "application/x-www-form-urlencoded"})
             result_data = requests.put(url_command,
                                        data=rest_payload,
                                        headers=rest_headers,
@@ -386,7 +386,7 @@ def restful(url_command, rest_action='get', rest_payload=[], rest_timeout=None, 
                                         verify=sslverify
                                         )
         if rest_action == "binary-post":
-            rest_headers.update({"Content-Type": "application/octet-stream"})
+            rest_headers.update({"Content-Type": "application/x-www-form-urlencoded"})
             result_data = requests.post(url_command,
                                         data=rest_payload,
                                         headers=rest_headers,
@@ -587,18 +587,23 @@ def get_node_sku(nodeid):
                 if VERBOSITY >= 2:
                     errmsg = "Error: SKU API failed {}, return code {} ".format(sku, skudata['status'])
                     print errmsg
+                    return "unknown"
         else:
-            if VERBOSITY >= 2:
-                errmsg = "Error: nodeid {} did not return a valid sku in get_rackhd_nodetype{}".format(nodeid,sku)
-                print errmsg
+            return "unknown"
     return nodetype
 
 def check_active_workflows(nodeid):
     # Return True if active workflows are found on node
     workflows = rackhdapi('/api/2.0/nodes/' + nodeid + '/workflows')['json']
     for item in workflows:
-        if 'running' in item['_status'] or 'pending' in item['_status']:
-            return True
+        if '_status' in item:
+            if item['_status'] in ['running', 'pending']:
+                return True
+        if 'status' in item:
+            if item['status'] in ['running', 'pending']:
+                return True
+        else:
+            return False
     return False
 
 def cancel_active_workflows(nodeid):
@@ -610,8 +615,8 @@ def cancel_active_workflows(nodeid):
        exitstatus = False
     return exitstatus
 
-def apply_obm_settings_new():
-    # Experimental routine to install OBM credentials via workflows
+def apply_obm_settings():
+    # New routine to install OBM credentials via workflows in parallel
     count = 0
     for creds in GLOBAL_CONFIG['credentials']['bmc']:
         # greate graph for setting OBM credentials
@@ -666,29 +671,28 @@ def apply_obm_settings_new():
         count += 1
 
     # run each OBM credential workflow on each node in parallel until success
-    nodelist = node_select()
     nodestatus = {} # dictionary with node IDs and status of each node
-    for node in nodelist:
-        nodestatus[node]= {"status": "pending", "instanceId": "", "sku": get_node_sku(node), "retry": 0}
-    for dummy in range(0, 60):
+    for dummy in range(0, 30):
+        nodelist = node_select()
+        for node in nodelist:
+            if node not in nodestatus:
+                nodestatus[node] = {"status": "pending", "instanceId": "", "sku": get_node_sku(node), "retry": 0}
         for num in range(0, count):
             for node in nodelist:
-                skuid = rackhdapi('/api/2.0/nodes/' + node)['json'].get("sku")
-                skudata = rackhdapi(skuid)['text']
-                if "rmm.data.MAC" in skudata:
-                    workflow = {"name": 'Graph.Obm.Ipmi.CreateSettings.RMM' + str(num)}
-                else:
-                    workflow = {"name": 'Graph.Obm.Ipmi.CreateSettings' + str(num)}
                 # try workflow
                 if nodestatus[node]['status'] == "pending":
-                    for dummy in range(0, 60):
-                        # retry if other workflows active
+                    skuid = rackhdapi('/api/2.0/nodes/' + node)['json'].get("sku")
+                    if skuid:
+                        if nodestatus[node]['sku'] == "unknown":
+                            nodestatus[node].update({"sku": get_node_sku(node)})
+                        skudata = rackhdapi(skuid)['text']
+                        if "rmm.data.MAC" in skudata:
+                            workflow = {"name": 'Graph.Obm.Ipmi.CreateSettings.RMM' + str(num)}
+                        else:
+                            workflow = {"name": 'Graph.Obm.Ipmi.CreateSettings' + str(num)}
                         result = rackhdapi("/api/2.0/nodes/"  + node + "/workflows", action="post", payload=workflow)
                         if result['status'] == 201:
-                            nodestatus[node].update({"status": "running", "instanceId": result['json']["instanceId"], "retry": 0})
-                            break
-                        else:
-                           time.sleep(5)
+                            nodestatus[node].update({"status": "running", "instanceId": result['json']["instanceId"]})
             for node in nodelist:
                 # check OBM workflow status
                 if nodestatus[node]['status'] == "running":
@@ -703,18 +707,27 @@ def apply_obm_settings_new():
                             nodestatus[node]['status'] = "succeeded"
                         if state in ["failed", "cancelled", "timeout"]:
                             nodestatus[node]['status'] = "pending"
-        if VERBOSITY > 4:
+                            # if the workflow left an invalid OBM, delete it
+                            result = rackhdapi("/api/2.0/nodes/" + node)
+                            if result['status'] == 200:
+                                if result['json']['obms']:
+                                    for ref in result['json']['obms']:
+                                        obmref = ref.get('ref')
+                                        if obmref:
+                                            rackhdapi(obmref, action="delete")
+
+        if VERBOSITY >= 4:
             print "**** Node(s) OBM status:\n", json.dumps(nodestatus, sort_keys=True, indent=4,)
         if "pending" not in str(nodestatus) and "running" not in str(nodestatus):
             # All OBM settings successful
             return True
-        time.sleep(10)
+        time.sleep(30)
     # Failures occurred
     print "**** Node(s) OBM settings failed."
     return False
 
-def apply_obm_settings():
-    # legacy routine to install OBM credentials via workflows
+def apply_obm_settings_seq():
+    # legacy routine to install OBM credentials via workflows sequentially one-at-a-time
     count = 0
     for creds in GLOBAL_CONFIG['credentials']['bmc']:
         # greate graph for setting OBM credentials
@@ -774,35 +787,71 @@ def apply_obm_settings():
     for node in nodelist:
         for num in range(0, count):
             nodestatus = ""
+            wfstatus = ""
             skuid = rackhdapi('/api/2.0/nodes/' + node)['json'].get("sku")
-            skudata = rackhdapi(skuid)['text']
-            if "rmm.data.MAC" in skudata:
-                workflow = {"name": 'Graph.Obm.Ipmi.CreateSettings.RMM' + str(num)}
+            # Check is sku is empty
+            sku = skuid.rstrip("/api/2.0/skus/")
+            if sku:
+                skudata = rackhdapi(skuid)['text']
+                if "rmm.data.MAC" in skudata:
+                    workflow = {"name": 'Graph.Obm.Ipmi.CreateSettings.RMM' + str(num)}
+                else:
+                    workflow = {"name": 'Graph.Obm.Ipmi.CreateSettings' + str(num)}
             else:
-                workflow = {"name": 'Graph.Obm.Ipmi.CreateSettings' + str(num)}
+                print "*** SKU not set for node ", node
+                nodestatus = "failed"
+                break
+
             # wait for existing workflow to complete
             for dummy in range(0, 60):
+                print "*** Using workflow: ", workflow
                 result = rackhdapi("/api/2.0/nodes/"  + node + "/workflows", action="post", payload=workflow)
                 if result['status'] != 201:
                     time.sleep(5)
+                elif dummy == 60:
+                    print "*** Workflow failed to start"
+                    wfstatus = "failed"
                 else:
                     break
-            # wait for OBM workflow to complete
-            counter = 0
-            for counter in range(0, 60):
-                time.sleep(10)
-                state_data = rackhdapi("/api/2.0/workflows/" + result['json']["instanceId"])
-                if state_data['status'] == 200:
-                    if "_status" in state_data['json']:
-                        nodestatus = state_data['json']['_status']
-                    else:
-                        nodestatus = state_data['json']['status']
-                    if nodestatus != "running" and nodestatus != "pending":
-                        break
-            if nodestatus == "succeeded":
-                break
-            if counter == 60:
-                failedlist.append(node)
+
+            if wfstatus != "failed":
+                # wait for OBM workflow to complete
+                counter = 0
+                for counter in range(0, 60):
+                    time.sleep(10)
+                    state_data = rackhdapi("/api/2.0/workflows/" + result['json']["instanceId"])
+                    if state_data['status'] == 200:
+                        if "_status" in state_data['json']:
+                            nodestatus = state_data['json']['_status']
+                        else:
+                            nodestatus = state_data['json']['status']
+                        if nodestatus != "running" and nodestatus != "pending":
+                            break
+                if nodestatus == "succeeded":
+                    print "*** Succeeded on workflow ", workflow
+                    break
+                if counter == 60:
+                    #print "Timed out status", nodestatus
+                    nodestatus = "failed"
+                    print "*** Node failed OBM settings - timeout:", node
+                    print "*** Failed on workflow ", workflow
+
+        # check final loop status for node workflow
+        if wfstatus == "failed" or nodestatus == "failed":
+            failedlist.append(node)
+
+    # cleanup failed nodes OBM settings on nodes, need to remove failed settings
+    for node in failedlist:
+        result = rackhdapi("/api/2.0/nodes/"  + node)
+        if result['status'] == 200:
+            if result['json']['obms']:
+                obms = result['json']['obms'][0]
+                obmref = obms.get('ref')
+                if obmref:
+                    result = rackhdapi(obmref, action="delete")
+                    if result['status'] != 204:
+                        print "*** Warning: failed to delete invalid OBM setting ", obmref
+
     if len(failedlist) > 0:
         print "**** Nodes failed OBM settings:", failedlist
         return False


### PR DESCRIPTION
This is an update to the FIT common library that includes several required fixes:
- The primary change is to the appy_obm_settings(). This is a new routine to apply OBM settings in parallel rather than the old sequential routing. The legacy routine has been renamed to apply_obm_settings_seq(). This has code been tested for about two weeks in the MN lab.
- check_active_workflows() needed revision to be compatible with the new 'status' field in the workflows API JSON. OnRack 2.1 was branched before that change so the old '_status' field needs to be supported as well.
- restful() 'binary-put' and 'binary-post' content type was changed to "application/x-www-form-urlencoded" for compatibility with API 2.0. Now the /api/2.0/skus/pack upload will work.
- Line 217 still had a reference to the appliance 'onrack' username which was changed to the global parameter ARGS_LIST['usr'] 
