### PR TITLE
support release, do ci-builds and release based on template-package.json

### DIFF
--- a/packer/ansible/rackhd_ci_builds.yml
+++ b/packer/ansible/rackhd_ci_builds.yml
@@ -1,0 +1,19 @@
+---
+- name: RackHD Demonstration Server
+  hosts: local
+  sudo: no
+  roles:
+    - apt
+    - build
+    - git
+    - rabbitmq
+    - mongodb
+    - node
+    - isc-dhcp-server
+    - monorail
+    - snmptool
+    - ipmitool
+    - integrationtest
+    - postgresql
+    - setuptools
+    - rackhd-ci-builds

--- a/packer/ansible/rackhd_release.yml
+++ b/packer/ansible/rackhd_release.yml
@@ -1,0 +1,19 @@
+---
+- name: RackHD Demonstration Server
+  hosts: local
+  sudo: no
+  roles:
+    - apt
+    - build
+    - git
+    - rabbitmq
+    - mongodb
+    - node
+    - isc-dhcp-server
+    - monorail
+    - snmptool
+    - ipmitool
+    - integrationtest
+    - postgresql
+    - setuptools
+    - rackhd-release

--- a/packer/ansible/roles/rackhd-ci-builds/tasks/main.yml
+++ b/packer/ansible/roles/rackhd-ci-builds/tasks/main.yml
@@ -11,8 +11,16 @@
                   state=present
   sudo: yes
 
-- name: Install RackHD Packages
+- name: Install RackHD Packages latest
   apt: pkg="{{ item }}" state=latest force=yes
   with_items:
     - rackhd
   sudo: yes
+  when: (rackhd_version is undefined) or (not rackhd_version)
+
+- name: Install RackHD Packages specific version
+  apt: pkg="{{ item }}" force=yes
+  with_items:
+    - rackhd={{ rackhd_version }}
+  sudo: yes
+  when: (rackhd_version is not undefined) and rackhd_version

--- a/packer/ansible/roles/rackhd-ci-builds/tasks/main.yml
+++ b/packer/ansible/roles/rackhd-ci-builds/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+# vagrant ansible uses 1.5, which doesn't have the keyserver option enabled
+- shell: "apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 379CE192D401AB61"
+  sudo: yes
+
+# apt_repository apparently requires this to run in Ansible 1.5
+- apt: pkg=python-pycurl state=present
+  sudo: yes
+
+- apt_repository: repo="deb https://dl.bintray.com/rackhd-mirror/debian trusty main"
+                  state=present
+  sudo: yes
+
+- name: Install RackHD Packages
+  apt: pkg="{{ item }}" state=latest force=yes
+  with_items:
+    - rackhd
+  sudo: yes

--- a/packer/ansible/roles/rackhd-release/tasks/main.yml
+++ b/packer/ansible/roles/rackhd-release/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+# vagrant ansible uses 1.5, which doesn't have the keyserver option enabled
+- shell: "apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 379CE192D401AB61"
+  sudo: yes
+
+# apt_repository apparently requires this to run in Ansible 1.5
+- apt: pkg=python-pycurl state=present
+  sudo: yes
+
+- apt_repository: repo="deb https://dl.bintray.com/rackhd-mirror/debian trusty release"
+                  state=present
+  sudo: yes
+
+- name: Install RackHD Packages
+  apt: pkg="{{ item }}" state=latest force=yes
+  with_items:
+    - rackhd
+  sudo: yes

--- a/packer/ansible/roles/rackhd-release/tasks/main.yml
+++ b/packer/ansible/roles/rackhd-release/tasks/main.yml
@@ -11,8 +11,16 @@
                   state=present
   sudo: yes
 
-- name: Install RackHD Packages
+- name: Install RackHD Packages latest
   apt: pkg="{{ item }}" state=latest force=yes
   with_items:
     - rackhd
   sudo: yes
+  when: (rackhd_version is undefined) or (not rackhd_version)
+
+- name: Install RackHD Packages specific version
+  apt: pkg="{{ item }}" force=yes
+  with_items:
+    - rackhd={{ rackhd_version }}
+  sudo: yes
+  when: (rackhd_version is not undefined) and rackhd_version

--- a/packer/ansible/roles/setuptools/tasks/main.yml
+++ b/packer/ansible/roles/setuptools/tasks/main.yml
@@ -1,0 +1,6 @@
+# apt_repository apparently requires this to run in Ansible 1.5
+- apt: pkg=python-pip state=present
+  sudo: yes
+
+- pip: name=setuptools extra_args='--upgrade'
+  sudo: yes

--- a/packer/scripts/firstuser.sh
+++ b/packer/scripts/firstuser.sh
@@ -18,6 +18,15 @@ login() {
 # Include the on-* services in case we're installing from .deb packages
 SERVICES="isc-dhcp-server rabbitmq-server mongodb postgresql \
     on-http on-taskgraph on-dhcp-proxy on-syslog on-tftp"
+RACKHD_SERVICES="on-http on-taskgraph on-dhcp-proxy on-syslog on-tftp"
+
+cleanServicesPIDs() {
+    for srv in ${RACKHD_SERVICES}; do
+        sudo rm /var/run/${srv}.pid
+    done
+    echo "PIDs cleaned"
+}
+
 startServices() {
   ifconfig eth1 172.31.128.1 netmask 255.255.255.0
   cd ~
@@ -86,6 +95,8 @@ checkFirstUser() {
    echo "${status}"
 }
 
+stopServices
+cleanServicesPIDs
 startServices
 if [ $? -eq "0" ]; then
   waitForServices

--- a/packer/template-packages.json
+++ b/packer/template-packages.json
@@ -35,7 +35,8 @@
             "type": "ansible-local",
             "inventory_groups": "local",
             "playbook_file": "ansible/{{user `playbook`}}.yml",
-            "playbook_dir": "ansible"
+            "playbook_dir": "ansible",
+            "extra_arguments": [ "--extra-vars \"rackhd_version={{user `version`}}\"" ]
         },
         {
             "type": "shell",
@@ -81,8 +82,8 @@
       "iso_checksum_type": "md5",
       "iso_url": "{{user `iso_url`}}",
       "headless": false,
-      "ssh_username": "vagrant",
-      "ssh_password": "vagrant",
+      "ssh_username": "rackhd",
+      "ssh_password": "rackhd",
       "ssh_port": 22,
       "ssh_wait_timeout": "10000s",
       "shutdown_command": "echo 'shutdown -P now' > /tmp/shutdown.sh; echo 'vagrant'|sudo -S sh '/tmp/shutdown.sh'",

--- a/packer/template-packages.json
+++ b/packer/template-packages.json
@@ -4,8 +4,12 @@
       "vcs": true
     },
     "variables": {
-        "atlas_username": "{{ env `ATLAS_USERNAME` }}",
-        "atlas_name": "{{ env `ATLAS_NAME` }}"
+        "atlas_username": "",
+        "atlas_name": "",
+        "atlas_token": "",
+        "iso_url": "http://releases.ubuntu.com/14.04/ubuntu-14.04.4-server-amd64.iso",
+        "playbook": "rackhd_ci_builds",
+        "version": ""
     },
     "provisioners": [
         {
@@ -30,7 +34,7 @@
         {
             "type": "ansible-local",
             "inventory_groups": "local",
-            "playbook_file": "ansible/rackhd_package.yml",
+            "playbook_file": "ansible/{{user `playbook`}}.yml",
             "playbook_dir": "ansible"
         },
         {
@@ -75,7 +79,8 @@
       "http_directory": "http",
       "iso_checksum": "2ac1f3e0de626e54d05065d6f549fa3a",
       "iso_checksum_type": "md5",
-      "iso_url": "http://releases.ubuntu.com/14.04/ubuntu-14.04.4-server-amd64.iso",
+      "iso_url": "{{user `iso_url`}}",
+      "headless": false,
       "ssh_username": "vagrant",
       "ssh_password": "vagrant",
       "ssh_port": 22,
@@ -92,6 +97,17 @@
     [{
         "type": "vagrant",
         "keep_input_artifact": true
+    },
+    {
+        "type": "atlas",
+        "only": ["virtualbox-iso"],
+        "artifact": "{{user `atlas_username`}}/{{user `atlas_name`}}",
+        "token": "{{user `atlas_token`}}",
+        "artifact_type": "vagrant.box",
+        "metadata": {
+            "provider": "virtualbox",
+            "version": "{{user `version`}}"
+        }
     }]
-]
+  ]
 }


### PR DESCRIPTION
Add 

```
ansible/rackhd_ci_builds.yml
ansible/rackhd_release.yml
ansible/roles/rackhd-ci-builds/
ansible/roles/rackhd-release/
```

support ci-builds and release builds.

Template file `template-packages.json` is changed to accept more vars.
see config and usage in executed shell in http://rackhdci.lss.emc.com/job/vagrant-build-bri/

About change of `firstuser.sh`:
- After installing rackhd, the eth1 hasn't been up. So services can't start normally then stopped abnormally, but left PID files. So though `firstuser.sh` start eth1, services still can't start because of PID files. Delete those files solvedthis issue.

@panpan0000 @PengTian0 
