### PR TITLE
 SUSE OS installation was failing when the node has too many Ethernet …

### DIFF
--- a/test/tests/api/v1_1/os_install_tests.py
+++ b/test/tests/api/v1_1/os_install_tests.py
@@ -147,7 +147,8 @@ class OSInstallTests(object):
                         'installDisk': '/dev/sda',
                         'version': version,
                         'repo': os_repo,
-                        'users': [{ 'name': 'onrack', 'password': 'Onr@ck1!', 'uid': 1010 }]
+                        'users': [{ 'name': 'onrack', 'password': 'Onr@ck1!', 'uid': 1010 }],
+                        'kargs' : {'NetWait': '180'}
                     },
                     'set-boot-pxe': self.__obm_options,
                     'reboot': self.__obm_options,


### PR DESCRIPTION
…ports.

We added a wait statement to give a chance for the ports to initialize