### PR TITLE
Edit readme, change foreman nf start to pm2 start rackhd.yml

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -40,7 +40,7 @@ Clone RackHD repo to your local machine.
     # create the RackHD instance.
     vagrant up dev
     # start the RackHD services
-    vagrant ssh dev -c "sudo pm2 start rackhd.yml"
+    vagrant ssh dev -c "sudo pm2 start rackhd-pm2-config.yml"
 
 ### LOCAL SOURCE
 

--- a/example/README.md
+++ b/example/README.md
@@ -40,7 +40,7 @@ Clone RackHD repo to your local machine.
     # create the RackHD instance.
     vagrant up dev
     # start the RackHD services
-    vagrant ssh dev -c "sudo nf start"
+    vagrant ssh dev -c "sudo pm2 start rackhd.yml"
 
 ### LOCAL SOURCE
 

--- a/example/bin/monorail_rack
+++ b/example/bin/monorail_rack
@@ -71,4 +71,4 @@ fi
 
 echo "starting the services"
 echo "The RackHD documentation will be available shortly at http://localhost:9090/docs"
-vagrant ssh dev -c "sudo nf start"
+vagrant ssh dev -c "sudo pm2 start rackhd.yml"

--- a/example/bin/monorail_rack
+++ b/example/bin/monorail_rack
@@ -71,4 +71,4 @@ fi
 
 echo "starting the services"
 echo "The RackHD documentation will be available shortly at http://localhost:9090/docs"
-vagrant ssh dev -c "sudo pm2 start rackhd.yml"
+vagrant ssh dev -c "sudo pm2 start rackhd-pm2-config.yml"

--- a/test/README.md
+++ b/test/README.md
@@ -15,7 +15,7 @@ Run Vagrant environment
 
     cd ../example
     vagrant up
-    vagrant ssh dev -c "sudo nf start"
+    vagrant ssh dev -c "sudo pm2 start rackhd.yml"
     cd ../test
 
 Run the tests

--- a/test/README.md
+++ b/test/README.md
@@ -15,7 +15,7 @@ Run Vagrant environment
 
     cd ../example
     vagrant up
-    vagrant ssh dev -c "sudo pm2 start rackhd.yml"
+    vagrant ssh dev -c "sudo pm2 start rackhd-pm2-config.yml"
     cd ../test
 
 Run the tests


### PR DESCRIPTION
use PM2 instead of foreman to  manage rackhd process.
see GG https://groups.google.com/forum/#!topic/rackhd/UfyZ1v9Gdc4

This PR should be merged at the same time with https://github.com/RackHD/docs/pull/357  after new version vagrant box be updated.

Related PR
* https://github.com/RackHD/RackHD/pull/478  edit packer script, change foreman to pm2.
* https://github.com/RackHD/docs/pull/357 docs change
* https://github.com/RackHD/on-build-config/pull/31 edit Vagrantfile for smoke-test
@panpan0000 
