### PR TITLE
fix: rackhd services start before load config

### DIFF
--- a/packer/ansible/rackhd_package.yml
+++ b/packer/ansible/rackhd_package.yml
@@ -9,11 +9,11 @@
     - rabbitmq
     - mongodb
     - node
-    - rackhd-packages
     - isc-dhcp-server
     - monorail
     - snmptool
     - ipmitool
+    - rackhd-packages
     - images
     - integrationtest
     - postgresql


### PR DESCRIPTION
The rackhd services will start after installation.
But rackhd is installed before loading config file and the config file takes no effect on rackhd services.

This PR move rackhd installation after loading config file.

@heckj @panpan0000 @iceiilin @anhou @yyscamper 
