### PR TITLE
[WIP]add  in docker-compose.yml to support release/ci-builds

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,0 +1,1 @@
+TAG=latest

--- a/docker/README.md
+++ b/docker/README.md
@@ -25,9 +25,9 @@ $ docker-compose up           # Run RackHD and ELK.
   * docker-compose v1.6 or higher [Install Docker Compose](https://docs.docker.com/compose/install/)
 
 ```
-$ cd RackHD/docker
-$ sudo docker-compose pull         # Download prebuilt docker images.
-$ sudo docker-compose up           # Create containers and Run RackHD and ELK.
+$ cd RackHD/docker                            # TAG can be a release version, if not set default: latest
+$ sudo TAG=${TAG} docker-compose pull         # Download prebuilt docker images.
+$ sudo TAG=${TAG} docker-compose up           # Create containers and Run RackHD and ELK.
 ```
 
 ## Once RackHD and ELK are running.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -46,12 +46,12 @@ services:
 
   core:
     build: "../on-core"
-    image: rackhd/on-core:latest
+    image: rackhd/on-core:${TAG}
     command: "/bin/echo \"exit\""
 
   tasks:
     build: "../on-tasks"
-    image: rackhd/on-tasks:latest
+    image: rackhd/on-tasks:${TAG}
     command: "/bin/echo \"exit\""
 
   dhcp-proxy: # 68/udp, 4011
@@ -62,7 +62,7 @@ services:
       - mongo
       - rabbitmq
       - statsd
-    image: rackhd/on-dhcp-proxy:latest
+    image: rackhd/on-dhcp-proxy:${TAG}
     network_mode: "host"
     privileged: true
     volumes:
@@ -78,7 +78,7 @@ services:
       - rabbitmq
       - statsd
       - tasks
-    image: rackhd/on-http:latest
+    image: rackhd/on-http:${TAG}
     network_mode: "host"
     privileged: true
     volumes:
@@ -92,7 +92,7 @@ services:
       - logstash
       - mongo
       - rabbitmq
-    image: rackhd/on-statsd:latest
+    image: rackhd/on-statsd:${TAG}
     network_mode: "host"
     privileged: true
     volumes:
@@ -105,7 +105,7 @@ services:
       - logstash
       - rabbitmq
       - statsd
-    image: rackhd/on-syslog:latest
+    image: rackhd/on-syslog:${TAG}
     network_mode: "host"
     privileged: true
     volumes:
@@ -121,7 +121,7 @@ services:
       - syslog
       - statsd
       - tasks
-    image: rackhd/on-taskgraph:latest
+    image: rackhd/on-taskgraph:${TAG}
     network_mode: "host"
     privileged: true
     volumes:
@@ -136,7 +136,7 @@ services:
       - rabbitmq
       - statsd
       - syslog
-    image: rackhd/on-tftp:latest
+    image: rackhd/on-tftp:${TAG}
     network_mode: "host"
     privileged: true
     volumes:
@@ -153,7 +153,7 @@ services:
       - rabbitmq
       - statsd
       - syslog
-    image: rackhd/on-wss:latest
+    image: rackhd/on-wss:${TAG}
     network_mode: "host"
     privileged: true
     volumes:


### PR DESCRIPTION
Background: https://github.com/RackHD/on-tools/pull/35
Add ${TAG} in docker-compose, support:
```
$ cd RackHD/docker                            # TAG can be a release version, if not set default: latest
$ sudo TAG=${TAG} docker-compose pull         # Download prebuilt docker images.
$ sudo TAG=${TAG} docker-compose up           # Create containers and Run RackHD and ELK.
```

if just
``` 
sudo docker-compose pull  
```
docker-compose will get default value of ${TAG} in .env .

### Issue left

No Dockerfile in https://github.com/RackHD/on-statsd

@panpan0000 