### PR TITLE
 Auto Config primary IP address, when OVA is deployed 

### DIFF
--- a/packer/HWIMO-BUILD
+++ b/packer/HWIMO-BUILD
@@ -107,7 +107,6 @@ BASENAME=${VM_NAME}
 OVA="${BASENAME}.ova"
 ovftool $SIGN_ARGS -o ${VMDIR}/${VM_NAME}.vmx $OVA
 
-
 if [ $? != 0 ]; then
     echo "ovftool exec failed.. exit"
     exit 4
@@ -122,6 +121,50 @@ then
 else
     echo "skip clamscan..."
 fi
+
+
+########## Modify the OVF file and update checksum ##############
+echo "covert to OVF"
+OVF=$"${BASENAME}.ovf"
+ovftool $OVA  $OVF
+echo "modify the OVF"
+
+
+# Note : this is ESXi format. (other ESX version may varies )
+# Add ProductSection/Property xml nodes under VirtualSystem xml node( kind of declare OVF Enviromental Properties)
+sed -i 's/<\/VirtualSystem>/ \
+  <ProductSection>    \
+     <Info>Information about the installed software<\/Info> \
+     <Product>Rackhd<\/Product> \
+     <Category>adminnetwork<\/Category>  \
+     <Property ovf:key="adminIP" ovf:type="string" ovf:userConfigurable="true"> \
+        <Label>adminIP<\/Label> \
+     <\/Property> \
+     <Property ovf:key="adminGateway" ovf:type="string" ovf:userConfigurable="true"> \
+        <Label>adminGateway<\/Label> \
+     <\/Property> \
+     <Property ovf:key="adminNetmask" ovf:type="string" ovf:userConfigurable="true"> \
+        <Label>adminNetmask<\/Label> \
+     <\/Property> \
+     <Property ovf:key="adminDNS" ovf:type="string" ovf:userConfigurable="true"> \
+        <Label>adminDNS<\/Label> \
+     <\/Property>  \
+  <\/ProductSection> \
+<\/VirtualSystem>   \
+/'  $OVF
+
+# specific the "OVF enviroment transport" method to VMWare Tools
+sed -i 's/<VirtualHardwareSection>/<VirtualHardwareSection ovf:transport="com.vmware.guestInfo" > /' $OVF
+
+echo "recovert back to OVA"
+# update checksum
+NewChk=$(sha1sum $OVF | awk '{print $1}')
+sed  -i -E  "s/SHA1\(.*ovf\)=.*$/SHA1\($OVF\)= $NewChk/g"  $"${BASENAME}.mf"
+# re-package into OVA
+rm $OVA
+ovftool $OVF $OVA
+
+
 
 
 # Create MD5 & Sha256 checksum file
@@ -157,4 +200,5 @@ then
 fi
 
 chmod a=r "$OVA"*
+
 

--- a/packer/HWIMO-BUILD
+++ b/packer/HWIMO-BUILD
@@ -87,7 +87,7 @@ if [ $? != 0 ]; then
 fi
 
 if [ "$BUILD_TYPE"  != "vmware" ];  then
-    echo "Skip the signing for virtualbox for the time being ..."
+    echo "Skip the post-processing(signing/clamscan/ovf-template injection) for virtualbox for the time being ..."
     exit 0
 fi
 

--- a/packer/HWIMO-BUILD
+++ b/packer/HWIMO-BUILD
@@ -123,15 +123,41 @@ else
 fi
 
 
-########## Modify the OVF file and update checksum ##############
+#### BEGIN ###### Modify the OVF file and update checksum ##############
+#
+#Background:
+#   for the purpose of RackHD deployment enviroment without DHCP on admin port (e.x.: eth0),
+#   "OVF Environment" is leveraged to configure VM's IP during OVA/OVF deployment
+#
+#Implementation:
+#   1. define customized fields in OVF template file(XML format)
+#   2. when deploy RackHD OVA , you can specific the eth0 IP (thru OVF Env Parameter) like ```ovftool --prop:adminIP=1.2.3.4 .....```
+#   3. in VM OS's bootup scripts: use VMWare Tool to retrieve IP and set the primary NIC(eth0 for example)
+#
+#  Reference: http://www.v-front.de/2014/01/building-self-configuring-nested-esxi.html
+#
+###################################################################
 echo "covert to OVF"
 OVF=$"${BASENAME}.ovf"
 ovftool $OVA  $OVF
 echo "modify the OVF"
 
-
+#######################################################
 # Note : this is ESXi format. (other ESX version may varies )
 # Add ProductSection/Property xml nodes under VirtualSystem xml node( kind of declare OVF Enviromental Properties)
+#######################################################
+
+################
+#[ OVF Template Injection Step #1 ]
+# Below 'sed' will "insert" below XML tree at the end of <VirtualSystem> tag of the OVF template file.
+#     |-ProductSection
+#     |----Info
+#     |----Product
+#     |----Category
+#     |----Property #1
+#     |----Property #..
+#     |----Property #n
+#################
 sed -i 's/<\/VirtualSystem>/ \
   <ProductSection>    \
      <Info>Information about the installed software<\/Info> \
@@ -152,18 +178,28 @@ sed -i 's/<\/VirtualSystem>/ \
   <\/ProductSection> \
 <\/VirtualSystem>   \
 /'  $OVF
-
+################
+#[ OVF Template Injection Step #2 ]
 # specific the "OVF enviroment transport" method to VMWare Tools
+###############
 sed -i 's/<VirtualHardwareSection>/<VirtualHardwareSection ovf:transport="com.vmware.guestInfo" > /' $OVF
 
+
+
 echo "recovert back to OVA"
+###############
+#[ OVF Template Injection Step #3 ]
 # update checksum
+###############
 NewChk=$(sha1sum $OVF | awk '{print $1}')
 sed  -i -E  "s/SHA1\(.*ovf\)=.*$/SHA1\($OVF\)= $NewChk/g"  $"${BASENAME}.mf"
+##############
+#[ OVF Template Injection Step #4 ]
 # re-package into OVA
+##############
 rm $OVA
 ovftool $OVF $OVA
-
+### END ####### Modify the OVF file and update checksum ##############
 
 
 

--- a/packer/ansible/rackhd_package.yml
+++ b/packer/ansible/rackhd_package.yml
@@ -11,6 +11,7 @@
     - node
     - isc-dhcp-server
     - monorail
+    - config_admin_ip
     - snmptool
     - ipmitool
     - rackhd-packages

--- a/packer/ansible/roles/config_admin_ip/files/config_IP_with_OVF_ENV.sh
+++ b/packer/ansible/roles/config_admin_ip/files/config_IP_with_OVF_ENV.sh
@@ -1,0 +1,84 @@
+#!/bin/bash -e
+
+getprops_from_ovfxml() {
+python - <<EOS
+from xml.dom.minidom import parseString
+ovfEnv = open("$1", "r").read()
+dom = parseString(ovfEnv)
+section = dom.getElementsByTagName("PropertySection")[0]
+for property in section.getElementsByTagName("Property"):
+   key = property.getAttribute("oe:key").replace('.','_')
+   value = property.getAttribute("oe:value")
+   print "{0}={1}".format(key,value)
+dom.unlink()
+EOS
+}
+
+
+vmtoolsd --cmd='info-get guestinfo.ovfEnv' >/tmp/ovf.xml
+arr=$(getprops_from_ovfxml /tmp/ovf.xml)
+
+IP_KEY="adminIP="
+DNS_KEY="adminDNS="
+GW_KEY="adminGateway="
+MASK_KEY="adminNetmask="
+
+if [[ ${#arr[@]} -eq 0  ]]
+then
+    return 0
+fi
+
+for line in ${arr[@]}
+do
+        echo $line
+done
+
+ETH0_CFG='# The primary network interface\
+auto eth0\
+iface eth0 inet static'
+
+
+
+for line in ${arr[@]}
+do
+     if [[ $(echo $line | grep ${IP_KEY}) != "" ]]
+     then
+          IP=${line##*${IP_KEY}}
+          echo IP:$IP
+          ETH0_CFG=$ETH0_CFG"\n    address $IP"
+     fi
+     if [[ $(echo $line | grep ${DNS_KEY}) != "" ]]
+     then
+          DNS=${line##*${DNS_KEY}}
+          echo DNS:$DNS
+          ETH0_CFG=$ETH0_CFG"\n    dns-nameserver $DNS"
+     fi
+     if [[ $(echo $line | grep ${GW_KEY}) != "" ]]
+     then
+          GW=${line##*${GW_KEY}}
+          echo Gateway:$GW
+          ETH0_CFG=$ETH0_CFG"\n    gateway $GW"
+     fi
+     if [[ $(echo $line | grep ${MASK_KEY}) != "" ]]
+     then
+          MASK=${line##*${MASK_KEY}}
+          echo NetMask:$MASK
+          ETH0_CFG=$ETH0_CFG"\n    netmask $MASK"
+     fi
+done
+
+
+if [[ $(echo -e $ETH0_CFG | grep address ) != "" ]]
+then
+    # remove old eth0 seting
+    sed -i '/auto eth0/,/auto eth1/c\auto eth1' /etc/network/interfaces
+    # add new eth0 setting
+    sed -i "s/iface lo inet loopback/iface lo inet loopback\n$ETH0_CFG/"  /etc/network/interfaces
+    # Force restart eth0 ###
+    ifdown eth0
+    ifup eth0
+else
+    echo "can't detect IP address from OVF ENV, skip the eth0 configuration.."
+fi
+
+

--- a/packer/ansible/roles/config_admin_ip/files/config_IP_with_OVF_ENV.sh
+++ b/packer/ansible/roles/config_admin_ip/files/config_IP_with_OVF_ENV.sh
@@ -1,4 +1,16 @@
 #!/bin/bash -e
+###################################################
+# Summary:
+#   1. use VMWare Tool(vmtoolsd) to retrieve OVF ENV Parameters
+#   2. parse the XML format( via getprops_from_ovfxml()) and retrieve the network settings
+#   3. modify the /etc/network/interfaces
+#   4. ifdown the primary NIC , then ifup (to let /etc/network/interfaces takes effect)
+#
+# Reference: http://www.v-front.de/2014/01/building-self-configuring-nested-esxi.html
+# Note: for different ESXi version, the OVF XML Propertity format varies.
+# Note: this feature is only supported by vCenter( not supported by vSphere)
+####################################################
+
 
 getprops_from_ovfxml() {
 python - <<EOS
@@ -14,6 +26,7 @@ dom.unlink()
 EOS
 }
 
+#####################################################
 
 vmtoolsd --cmd='info-get guestinfo.ovfEnv' >/tmp/ovf.xml
 arr=$(getprops_from_ovfxml /tmp/ovf.xml)

--- a/packer/ansible/roles/config_admin_ip/tasks/main.yml
+++ b/packer/ansible/roles/config_admin_ip/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Load script, to read IP from OVF Env and set IP to VM
+  copy: src=config_IP_with_OVF_ENV.sh  dest=/etc/init.d/config_IP_with_OVF_ENV.sh mode=0755
+  sudo: yes
+
+- name: register the script with upstart (autorun)
+  shell: update-rc.d config_IP_with_OVF_ENV.sh defaults
+  sudo: yes
+


### PR DESCRIPTION
**Background**
Default RackHD OVA( same as Onrack) eth0(primary admin NIC) are configured as DHCP.
**How about  enviroment **without DHCP** on admin port (eth0) ?**
For many user scenario,   the OVA will be deployed into a network without DHCP against its eth0.
to enable this VM with static IP, before anyone can remote talk to this RackHD instance : then it will require manual operation: going to VMWare Console, and login into VM, modify the /etc/network/interface to re-configure that VM to static IP ....

A more automatic way is definitely needed.

---
**Summary of Implementation**
1. modify the OVF template file(XML) , to inject customized fields 
2. when deploying the OVA, pass IP/DNS/Gateway..etc parameter to ovftool or vCenter GUI
3. when the VM boot up , there's a script will be run during bootup (```config_IP_with_OVF_ENV.sh```), it will read the OVF ENV parameters via VMWare Tools, then config the /etc/network/interface

reference from 
-http://www.virtuallyghetto.com/2014/06/an-alternate-way-to-inject-ovf-properties-when-deploying-virtual-appliances-directly-onto-esxi.html
-http://www.v-front.de/2014/01/building-self-configuring-nested-esxi.html

---
**FAQ & Impacts**
- it supports both Ubuntu 14.04 & Ubuntu 16.04
- it doesn't impact vagrant box (```config_IP_with_OVF_ENV.sh``` will not take effect... ) 
- also it will not impact OVA in a DHCP environment or impact OVA without specific those parameters

---
**Usage** (NOTE : Only works for VCenter) 
   ** a. using ovftool as command line **
   1. using HWIMO-BUILD script, the OVA build is ready for this feature
   2. when deploying , below is an example of ovftool usage:
   ovftool --prop:adminIP=1.2.3.4 --prop:adminGateway=1.2.3.1 --prop:adminNetmask=255.255.255.0  --prop:adminDNS=10.1.1.1    --net:"ADMIN"="ADMIN vSwitch" --datastore="ds" --name="yourVMname"  rackhd_ovf_file_build.ovf  vi://user:pwd@vCenterIP

  ** b. using vCenter GUI **
![image](https://cloud.githubusercontent.com/assets/14049268/20550836/c70c3ef8-b174-11e6-81ff-591cb6ca2f25.png)


---

**What's been Tested**

original  /etc/network/interface ( inside the OVA) before this PR:
![image](https://cloud.githubusercontent.com/assets/14049268/20549206/34551d28-b165-11e6-8f76-b6057b73332a.png)

1. Created OVA for 14.04 & 16.04

2. using ```ovftool``` to deploy the OVA with specified IP setting  , then when boot up , the  /etc/network/interface as below:
![image](https://cloud.githubusercontent.com/assets/14049268/20549189/15c2317a-b165-11e6-8327-fba8f16700a6.png)


3.  using ```ovftool``` to deploy the OVA **without** specified IP setting  , when boot up , the VM's /etc/network/interface remains no change as original content.

---
**Who to Review**
@RackHD/corecommitters   @changev 