### PR TITLE
Updated rackHD installer scripts

### DIFF
--- a/test/fit_tests/config/global_config.json
+++ b/test/fit_tests/config/global_config.json
@@ -59,9 +59,6 @@
   },
   "repos": {
     "_comment":   "This is the list of repositories for each category",
-    "proxy":      "http://web.hwimo.lab.emc.com:3128",
-    "proxyhost":  "web.hwimo.lab.emc.com",
-    "proxyport":  "3128",
     "mirror":     "http://mirrors.hwimo.lab.emc.com/mirrors",
     "os": {
       "esxi55":   "http://172.31.128.1:9080/mirror/esxi/5.5/esxi",

--- a/test/fit_tests/config/global_config.json
+++ b/test/fit_tests/config/global_config.json
@@ -58,20 +58,31 @@
     "community": "onrack"
   },
   "repos": {
-    "_comment": "This is the list of repositories for each category",
-    "proxy": "http://web.hwimo.lab.emc.com:3128",
-    "mirror": "http://mirrors.hwimo.lab.emc.com/mirrors",
+    "_comment":   "This is the list of repositories for each category",
+    "proxy":      "http://web.hwimo.lab.emc.com:3128",
+    "proxyhost":  "web.hwimo.lab.emc.com",
+    "proxyport":  "3128",
+    "mirror":     "http://mirrors.hwimo.lab.emc.com/mirrors",
     "os": {
-      "esxi55": "http://172.31.128.1:9080/mirror/esxi/5.5/esxi",
-      "esxi60": "http://172.31.128.1:9080/mirror/esxi/6.0/esxi6",
+      "esxi55":   "http://172.31.128.1:9080/mirror/esxi/5.5/esxi",
+      "esxi60":   "http://172.31.128.1:9080/mirror/esxi/6.0/esxi6",
       "centos65": "http://172.31.128.1:9080/mirror/centos/6.5/os/x86_64",
       "centos70": "http://172.31.128.1:9080/mirror/centos/7/os/x86_64",
-      "rhel70": "http://172.31.128.1:9080/mirror/rhel/7.0/os/x86_64"
+      "rhel70":   "http://172.31.128.1:9080/mirror/rhel/7.0/os/x86_64"
     },
     "install": {
-      "template": "http://mirrors.hwimo.lab.emc.com/mirrors/ova/ora-ubuntu-1604.ova",
-      "onrack": "http://onrack.hwimo.lab.emc.com/get/",
-      "rackhd": "https://github.com/rackhd/"
+      "template":     "http://mirrors.hwimo.lab.emc.com/mirrors/ova/ora-ubuntu-1604.ova",
+      "rackhd":       {"repo":"https://github.com/rackhd/rackhd","branch":"master"},
+      "on-core":      {"repo":"https://github.com/rackhd/on-core","branch":"master"},
+      "on-dhcp-proxy":{"repo":"https://github.com/rackhd/on-dhcp-proxy","branch":"master"},
+      "on-http":      {"repo":"https://github.com/rackhd/on-http","branch":"master"},
+      "on-statsd":    {"repo":"https://github.com/rackhd/on-statsd","branch":"master"},
+      "on-syslog":    {"repo":"https://github.com/rackhd/on-syslog","branch":"master"},
+      "on-tasks":     {"repo":"https://github.com/rackhd/on-tasks","branch":"master"},
+      "on-taskgraph": {"repo":"https://github.com/rackhd/on-taskgraph","branch":"master"},
+      "on-tftp":      {"repo":"https://github.com/rackhd/on-tftp","branch":"master"},
+      "on-tools":     {"repo":"https://github.com/rackhd/on-tools","branch":"master"},
+      "on-wss":       {"repo":"https://github.com/rackhd/on-wss","branch":"master"}
       },
     "skupack": [
       "https://github.com/RackHD/on-skupack"

--- a/test/fit_tests/config/global_config.json
+++ b/test/fit_tests/config/global_config.json
@@ -13,8 +13,8 @@
     ],
     "ora": [
       {
-        "username": "onrack",
-        "password": "onrack"
+        "username": "vagrant",
+        "password": "vagrant"
       }
     ],
     "bmc": [

--- a/test/fit_tests/deploy/rackhd_package_install.py
+++ b/test/fit_tests/deploy/rackhd_package_install.py
@@ -4,7 +4,20 @@ Copyright 2016, EMC, Inc.
 Author(s):
 George Paulos
 
-This script installs RackHD from BinTray packages onto blank OS.
+This script installs RackHD from BIntray packages onto blank Ubuntu 14 or 16 OS via Ansible installer.
+If test bed is behind proxy wall, make sure to enter proxy URL in config/global_config.json.
+This script performs the following functions:
+    - loads prerequisite packages git, ansible, etc.
+    - downloads RackHD source to management server
+    - installs using rackhd_package.yml playbook
+    - set up networking
+    - load configuration files
+    - startup and verify operations
+
+usage:
+    python run_tests.py -ova <ip or host> -test deploy/rackhd_package_install.py
+    or
+    python run_tests.py -stack <stack ID> -test deploy/rackhd_package_install.py
 '''
 
 import os
@@ -14,72 +27,111 @@ import subprocess
 sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/fit_tests/common")
 import fit_common
 
-# local methods
+# set proxy if required
 ENVVARS = ''
 if 'proxy' in fit_common.GLOBAL_CONFIG['repos'] and fit_common.GLOBAL_CONFIG['repos']['proxy'] != '':
     ENVVARS = "export http_proxy=" + fit_common.GLOBAL_CONFIG['repos']['proxy'] + ";" + \
               "export https_proxy=" + fit_common.GLOBAL_CONFIG['repos']['proxy'] + ";"
-# collect nic names
-IFLIST = fit_common.remote_shell("ifconfig -s -a | tail -n +2 | awk \\\'{print \\\$1}\\\' |grep -v lo")['stdout'].split()
 
 class rackhd_package_install(fit_common.unittest.TestCase):
     def test01_install_rackhd_dependencies(self):
         print "**** Installing RackHD dependencies."
-        # install dependencies
-        self.assertEqual(fit_common.remote_shell(ENVVARS + "apt-get -y install rabbitmq-server")['exitcode'], 0, "rabbitmq-server Install failure.")
-        self.assertEqual(fit_common.remote_shell(ENVVARS + "apt-get -y install mongodb")['exitcode'], 0, "mongodb Install failure.")
-        self.assertEqual(fit_common.remote_shell(ENVVARS + "apt-get -y install snmp")['exitcode'], 0, "snmp Install failure.")
-        self.assertEqual(fit_common.remote_shell(ENVVARS + "apt-get -y install ipmitool")['exitcode'], 0, "ipmitool Install failure.")
-        # install Node
-        fit_common.remote_shell(ENVVARS + 'apt-get -y remove nodejs nodejs-legacy')
-        fit_common.remote_shell(ENVVARS +
-                                'wget --quiet -O - https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -;'
-                                'echo "deb https://deb.nodesource.com/node_4.x trusty main" | tee /etc/apt/sources.list.d/nodesource.list;'
-                                'echo "deb-src https://deb.nodesource.com/node_4.x trusty main" | tee -a /etc/apt/sources.list.d/nodesource.list;')
-        fit_common.remote_shell(ENVVARS + 'apt-get -y update;'
-                                'apt-get -y install nodejs;'
-                                )
-        fit_common.remote_shell('apt-get -y install npm;npm config set https-proxy '
-                                + fit_common.GLOBAL_CONFIG['repos']['proxy'])
-        # Install Ansible
-        self.assertEqual(fit_common.remote_shell(ENVVARS + "apt-get -y install ansible")['exitcode'], 0, "ansible Install failure.")
-        self.assertEqual(fit_common.remote_shell(ENVVARS + "apt-get -y install apt-mirror")['exitcode'], 0, "apt-mirror Install failure.")
-        self.assertEqual(fit_common.remote_shell(ENVVARS + "apt-get -y install amtterm")['exitcode'], 0, "amtterm Install failure.")
-        self.assertEqual(fit_common.remote_shell(ENVVARS + "apt-get -y install isc-dhcp-server")['exitcode'], 0, "isc-dhcp-server Install failure.")
+        # update sudoers to preserve proxy environment
+        sudoersproxy = open("sudoersproxy", 'w')
+        sudoersproxy.write('Defaults env_keep="HOME no_proxy http_proxy https_proxy"\n')
+        sudoersproxy.close()
+        fit_common.remote_shell('pwd')
+        fit_common.scp_file_to_ora("sudoersproxy")
+        self.assertEqual(fit_common.remote_shell('cp sudoersproxy /etc/sudoers.d/'
+                                                  )['exitcode'], 0, "sudoersproxy config failure.")
+        os.remove('sudoersproxy')
+        # install git
+        self.assertEqual(fit_common.remote_shell(ENVVARS + "apt-get -y install git")['exitcode'], 0, "Git install failure.")
+        self.assertEqual(fit_common.remote_shell(ENVVARS + "apt-get -y update")['exitcode'], 0, "update failure.")
+        self.assertEqual(fit_common.remote_shell(ENVVARS + "apt-get -y dist-upgrade")['exitcode'], 0, "upgrade failure.")
+        self.assertEqual(fit_common.remote_shell("git config --global http.sslverify false")['exitcode'], 0, "Git config failure.")
+        if 'proxy' in fit_common.GLOBAL_CONFIG['repos'] and fit_common.GLOBAL_CONFIG['repos']['proxy'] != '':
+            self.assertEqual(fit_common.remote_shell("git config --global http.proxy " + fit_common.GLOBAL_CONFIG['repos']['proxy']
+                                                  )['exitcode'], 0, "Git proxy config failure.")
+        # install Ansible
+        self.assertEqual(fit_common.remote_shell(ENVVARS + "cd ~;apt-get -y install ansible")['exitcode'], 0, "Ansible Install failure.")
+        self.assertEqual(fit_common.remote_shell(ENVVARS + "apt-get -y update")['exitcode'], 0, "Ansible Update failure.")
+        # create startup files
+        self.assertEqual(fit_common.remote_shell(
+            "touch /etc/default/on-dhcp-proxy /etc/default/on-http /etc/default/on-tftp /etc/default/on-syslog /etc/default/on-taskgraph"
+            )['exitcode'], 0, "Startup files failure.")
+
+    def test02_clone_rackhd_source(self):
+        print "**** Cloning RackHD repo."
+        # clone base repo
+        fit_common.remote_shell('rm -rf ~/rackhd')
+        self.assertEqual(fit_common.remote_shell(ENVVARS + "git clone "
+                                                + fit_common.GLOBAL_CONFIG['repos']['install']['rackhd']['repo']
+                                                + " ~/rackhd"
+                                                )['exitcode'], 0, "RackHD git clone failure.")
+
+    def test03_run_ansible_installer(self):
+        print "**** Run RackHD Ansible installer."
+        self.assertEqual(fit_common.remote_shell(ENVVARS +
+                                                 "cd ~/rackhd/packer/ansible/;"
+                                                 "ansible-playbook -i 'local,' -c local rackhd_package.yml",
+                                                 timeout=800,
+                                                 )['exitcode'], 0, "RackHD Install failure.")
+
+    def test04_install_network_config(self):
+        print "**** Installing RackHD network config."
+        # collect nic names
+        getifs = fit_common.remote_shell("ifconfig -s -a |tail -n +2 |grep -v -e Iface -e lo")
+        # clean out login stuff
+        splitifs = getifs['stdout'].split('\n')
+        ifslist = [] # array of valid eth ports
+        for item in splitifs:
+            if "assword" not in item and item.split(" ")[0]:
+                ifslist.append(item.split(" ")[0])
+
         # install control network config
-        self.assertEqual(fit_common.remote_shell("echo 'auto " + IFLIST[7] + "' > /etc/network/interfaces.d/control.cfg;"
-                                                  "echo 'iface " + IFLIST[7] + " inet static' >> /etc/network/interfaces.d/control.cfg;"
-                                                  "echo 'address 172.31.128.1' >> /etc/network/interfaces.d/control.cfg;"
-                                                  "echo 'netmask 255.255.252.0' >> /etc/network/interfaces.d/control.cfg"
-                                                  )['exitcode'], 0, "Network config failure.")
-        # If PDU network is present, configure
+        control_cfg = open('control.cfg', 'w')
+        control_cfg.write(
+                            'auto ' + ifslist[1] + '\n'
+                            'iface ' + ifslist[1] + ' inet static\n'
+                            'address 172.31.128.1\n'
+                            'netmask 255.255.252.0\n'
+                        )
+        control_cfg.close()
+        # copy file to ORA
+        fit_common.scp_file_to_ora('control.cfg')
+        self.assertEqual(fit_common.remote_shell('cp control.cfg /etc/network/interfaces.d/')['exitcode'], 0, "Control network config failure.")
+        os.remove('control.cfg')
+        # startup NIC
+        fit_common.remote_shell('ip addr add 172.31.128.1/22 dev ' + ifslist[1])
+        fit_common.remote_shell('ip link set ' + ifslist[1] + ' up')
+        self.assertEqual(fit_common.remote_shell('ping -c 1 -w 5 172.31.128.1')['exitcode'], 0, 'Control NIC failure.')
+
+        # If PDU network adapter is present, configure
         try:
-            IFLIST[8]
+            ifslist[2]
         except IndexError:
             print "**** No PDU network will be configured"
         else:
-            self.assertEqual(fit_common.remote_shell("echo 'auto " + IFLIST[8] + "' > /etc/network/interfaces.d/pdudirect.cfg;"
-                                                      "echo 'iface " + IFLIST[8] + " inet static' >> /etc/network/interfaces.d/pdudirect.cfg;"
-                                                      "echo 'address 192.168.1.1' >> /etc/network/interfaces.d/pdudirect.cfg;"
-                                                      "echo 'netmask 255.255.255.0' >> /etc/network/interfaces.d/pdudirect.cfg"
-                                                      )['exitcode'], 0, "Network config failure.")
+            pdudirect_cfg = open('pdudirect.cfg', 'w')
+            pdudirect_cfg.write(
+                                'auto ' + ifslist[2] + '\n'
+                                'iface ' + ifslist[2] + ' inet static\n'
+                                'address 192.168.1.1\n'
+                                'netmask 255.255.255.0\n'
+                                )
+            pdudirect_cfg.close()
+            # copy file to ORA
+            fit_common.scp_file_to_ora('pdudirect.cfg')
+            self.assertEqual(fit_common.remote_shell('cp pdudirect.cfg /etc/network/interfaces.d/')['exitcode'], 0, "DHCP Config failure.")
+            os.remove('pdudirect.cfg')
+            # startup NIC
+            fit_common.remote_shell('ip addr add 192.168.1.1/24 dev ' + ifslist[2])
+            fit_common.remote_shell('ip link set ' + ifslist[2] + ' up')
+            self.assertEqual(fit_common.remote_shell('ping -c 1 -w 5 192.168.1.1')['exitcode'], 0, 'PDU NIC failure.')
 
-    def test02_install_rackhd_packages(self):
-        print "**** Installing RackHD packages."
-        self.assertEqual(fit_common.remote_shell("echo 'deb https://dl.bintray.com/rackhd/debian trusty main' | tee -a /etc/apt/sources.list")['exitcode'], 0, "Package Install failure.")
-        self.assertEqual(fit_common.remote_shell(ENVVARS
-                                                  + "apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 379CE192D401AB61")['exitcode'], 0, "Package Install failure.")
-        self.assertEqual(fit_common.remote_shell(ENVVARS
-                                                  + "apt-get -y update")['exitcode'], 0, "Install failure.")
-        self.assertEqual(fit_common.remote_shell(ENVVARS
-                                                  + "apt-get -y install on-dhcp-proxy on-http on-taskgraph")['exitcode'], 0, "Package Install failure.")
-        self.assertEqual(fit_common.remote_shell(ENVVARS
-                                                  + "apt-get -y install on-tftp on-syslog")['exitcode'], 0, "Package Install failure.")
-
-    def test03_install_rackhd_config_files(self):
-        print "**** Installing RackHD config files."
         #create DHCP config
-        fit_common.remote_shell('echo INTERFACES=' + IFLIST[7] + ' > /etc/default/isc-dhcp-server')
+        fit_common.remote_shell('echo INTERFACES=' + ifslist[1] + ' > /etc/default/isc-dhcp-server')
         dhcp_conf = open('dhcpd.conf', 'w')
         dhcp_conf.write(
                         'ddns-update-style none;\n'
@@ -96,12 +148,20 @@ class rackhd_package_install(fit_common.unittest.TestCase):
                         '}\n'
                          )
         dhcp_conf.close()
+        # copy file to ORA
+        fit_common.scp_file_to_ora('dhcpd.conf')
+        self.assertEqual(fit_common.remote_shell('cp dhcpd.conf /etc/dhcp/')['exitcode'], 0, "DHCP Config failure.")
+        os.remove('dhcpd.conf')
+
+    def test05_install_rackhd_config_files(self):
+        print "**** Installing RackHD config files."
         # create RackHD config
         hdconfig = {
                     "CIDRNet": "172.31.128.0/22",
                     "amqp": "amqp://localhost",
                     "apiServerAddress": "172.31.128.1",
                     "apiServerPort": 9080,
+                    "arpCacheEnabled": True,
                     "broadcastaddr": "172.31.131.255",
                     "dhcpGateway": "172.31.128.1",
                     "dhcpProxyBindAddress": "172.31.128.1",
@@ -168,57 +228,30 @@ class rackhd_package_install(fit_common.unittest.TestCase):
         rabbitmq_config.close()
         # copy files to ORA
         fit_common.scp_file_to_ora('config.json')
-        fit_common.scp_file_to_ora('dhcpd.conf')
         fit_common.scp_file_to_ora('rabbitmq.config')
-        self.assertEqual(fit_common.remote_shell('cp dhcpd.conf /etc/dhcp/')['exitcode'], 0, "DHCP Config failure.")
         self.assertEqual(fit_common.remote_shell('cp config.json /opt/monorail/')['exitcode'], 0, "RackHD Config file failure.")
         self.assertEqual(fit_common.remote_shell('cp rabbitmq.config /etc/rabbitmq/')['exitcode'], 0, "AMQP Config file failure.")
-        os.remove('dhcpd.conf')
         os.remove('config.json')
         os.remove('rabbitmq.config')
 
-    def test04_install_rackhd_binary_support_packages(self):
-        print "**** Installing RackHD binaries."
-        self.assertEqual(fit_common.remote_shell(
-            ENVVARS +
-            "mkdir -p /var/renasar/on-tftp/static/tftp;"
-            "cd /var/renasar/on-tftp/static/tftp;"
-            "wget 'https://dl.bintray.com/rackhd/binary/ipxe/monorail-undionly.kpxe';"
-            "wget 'https://dl.bintray.com/rackhd/binary/ipxe/monorail-efi64-snponly.efi';"
-            "wget 'https://dl.bintray.com/rackhd/binary/ipxe/monorail-efi32-snponly.efi';"
-            "wget 'https://dl.bintray.com/rackhd/binary/ipxe/monorail.intel.ipxe';"
-            "wget 'https://dl.bintray.com/rackhd/binary/ipxe/monorail.ipxe';"
-        )['exitcode'], 0, "Binary Support Install failure.")
-        self.assertEqual(fit_common.remote_shell(
-            ENVVARS +
-            "mkdir -p /var/renasar/on-http/static/http/common;"
-            "cd /var/renasar/on-http/static/http/common;"
-            "wget 'https://dl.bintray.com/rackhd/binary/builds/base.trusty.3.16.0-25-generic.squashfs.img';"
-            "wget 'https://dl.bintray.com/rackhd/binary/builds/discovery.overlay.cpio.gz';"
-            "wget 'https://dl.bintray.com/rackhd/binary/builds/initrd.img-3.16.0-25-generic';"
-            "wget 'https://dl.bintray.com/rackhd/binary/builds/vmlinuz-3.16.0-25-generic';"
-        )['exitcode'], 0, "Binary Support Install failure.")
-
-    def test05_reboot_and_check(self):
-        print "**** Reboot and check installation."
-        self.assertEqual(fit_common.remote_shell(
-            "touch /etc/default/on-dhcp-proxy /etc/default/on-http /etc/default/on-tftp /etc/default/on-syslog /etc/default/on-taskgraph"
-        )['exitcode'], 0, "Install failure.")
-        # reboot
-        print "**** Rebooting appliance..."
-        fit_common.remote_shell("shutdown -r now")
-        print "**** Waiting for login..."
-        fit_common.countdown(30)
-        shell_data = 0
-        for dummy in range(0, 30):
-            shell_data = fit_common.remote_shell("pwd")
-            if shell_data['exitcode'] == 0:
-                break
+    def test06_startup(self):
+        print "Restart services."
+        self.assertEqual(fit_common.remote_shell("service isc-dhcp-server restart")['exitcode'], 0, "on-http failure.")
+        self.assertEqual(fit_common.remote_shell("service on-http restart")['exitcode'], 0, "on-http failure.")
+        self.assertEqual(fit_common.remote_shell("service on-dhcp-proxy restart")['exitcode'], 0, "on-http failure.")
+        self.assertEqual(fit_common.remote_shell("service on-syslog restart")['exitcode'], 0, "on-http failure.")
+        self.assertEqual(fit_common.remote_shell("service on-taskgraph restart")['exitcode'], 0, "on-http failure.")
+        self.assertEqual(fit_common.remote_shell("service on-tftp restart")['exitcode'], 0, "on-http failure.")
+        print "**** Check installation."
+        for dummy in range(0, 10):
+            try:
+                fit_common.rackhdapi("/api/2.0/config")
+            except:
+                fit_common.time.sleep(10)
             else:
-                fit_common.time.sleep(5)
-        self.assertEqual(shell_data['exitcode'], 0, "Shell test failed after appliance reboot")
-        fit_common.time.sleep(10)
+                break
         self.assertEqual(fit_common.rackhdapi("/api/2.0/config")['status'], 200, "Unable to contact RackHD.")
 
 if __name__ == '__main__':
     fit_common.unittest.main()
+    

--- a/test/fit_tests/deploy/rackhd_package_install.py
+++ b/test/fit_tests/deploy/rackhd_package_install.py
@@ -28,9 +28,9 @@ sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=T
 import fit_common
 
 # set proxy if required
-ENVVARS = ''
+PROXYVARS = ''
 if 'proxy' in fit_common.GLOBAL_CONFIG['repos'] and fit_common.GLOBAL_CONFIG['repos']['proxy'] != '':
-    ENVVARS = "export http_proxy=" + fit_common.GLOBAL_CONFIG['repos']['proxy'] + ";" + \
+    PROXYVARS = "export http_proxy=" + fit_common.GLOBAL_CONFIG['repos']['proxy'] + ";" + \
               "export https_proxy=" + fit_common.GLOBAL_CONFIG['repos']['proxy'] + ";"
 
 class rackhd_package_install(fit_common.unittest.TestCase):
@@ -46,16 +46,16 @@ class rackhd_package_install(fit_common.unittest.TestCase):
                                                   )['exitcode'], 0, "sudoersproxy config failure.")
         os.remove('sudoersproxy')
         # install git
-        self.assertEqual(fit_common.remote_shell(ENVVARS + "apt-get -y install git")['exitcode'], 0, "Git install failure.")
-        self.assertEqual(fit_common.remote_shell(ENVVARS + "apt-get -y update")['exitcode'], 0, "update failure.")
-        self.assertEqual(fit_common.remote_shell(ENVVARS + "apt-get -y dist-upgrade")['exitcode'], 0, "upgrade failure.")
+        self.assertEqual(fit_common.remote_shell(PROXYVARS + "apt-get -y install git")['exitcode'], 0, "Git install failure.")
+        #self.assertEqual(fit_common.remote_shell(PROXYVARS + "apt-get -y update")['exitcode'], 0, "update failure.")
+        #self.assertEqual(fit_common.remote_shell(PROXYVARS + "apt-get -y dist-upgrade")['exitcode'], 0, "upgrade failure.")
         self.assertEqual(fit_common.remote_shell("git config --global http.sslverify false")['exitcode'], 0, "Git config failure.")
         if 'proxy' in fit_common.GLOBAL_CONFIG['repos'] and fit_common.GLOBAL_CONFIG['repos']['proxy'] != '':
             self.assertEqual(fit_common.remote_shell("git config --global http.proxy " + fit_common.GLOBAL_CONFIG['repos']['proxy']
                                                   )['exitcode'], 0, "Git proxy config failure.")
         # install Ansible
-        self.assertEqual(fit_common.remote_shell(ENVVARS + "cd ~;apt-get -y install ansible")['exitcode'], 0, "Ansible Install failure.")
-        self.assertEqual(fit_common.remote_shell(ENVVARS + "apt-get -y update")['exitcode'], 0, "Ansible Update failure.")
+        self.assertEqual(fit_common.remote_shell(PROXYVARS + "cd ~;apt-get -y install ansible")['exitcode'], 0, "Ansible Install failure.")
+        #self.assertEqual(fit_common.remote_shell(PROXYVARS + "apt-get -y update")['exitcode'], 0, "Ansible Update failure.")
         # create startup files
         self.assertEqual(fit_common.remote_shell(
             "touch /etc/default/on-dhcp-proxy /etc/default/on-http /etc/default/on-tftp /etc/default/on-syslog /etc/default/on-taskgraph"
@@ -65,14 +65,14 @@ class rackhd_package_install(fit_common.unittest.TestCase):
         print "**** Cloning RackHD repo."
         # clone base repo
         fit_common.remote_shell('rm -rf ~/rackhd')
-        self.assertEqual(fit_common.remote_shell(ENVVARS + "git clone "
+        self.assertEqual(fit_common.remote_shell(PROXYVARS + "git clone "
                                                 + fit_common.GLOBAL_CONFIG['repos']['install']['rackhd']['repo']
                                                 + " ~/rackhd"
                                                 )['exitcode'], 0, "RackHD git clone failure.")
 
     def test03_run_ansible_installer(self):
         print "**** Run RackHD Ansible installer."
-        self.assertEqual(fit_common.remote_shell(ENVVARS +
+        self.assertEqual(fit_common.remote_shell(PROXYVARS +
                                                  "cd ~/rackhd/packer/ansible/;"
                                                  "ansible-playbook -i 'local,' -c local rackhd_package.yml",
                                                  timeout=800,
@@ -236,12 +236,12 @@ class rackhd_package_install(fit_common.unittest.TestCase):
 
     def test06_startup(self):
         print "Restart services."
-        self.assertEqual(fit_common.remote_shell("service isc-dhcp-server restart")['exitcode'], 0, "on-http failure.")
+        self.assertEqual(fit_common.remote_shell("service isc-dhcp-server restart")['exitcode'], 0, "isc-dhcp-server failure.")
         self.assertEqual(fit_common.remote_shell("service on-http restart")['exitcode'], 0, "on-http failure.")
-        self.assertEqual(fit_common.remote_shell("service on-dhcp-proxy restart")['exitcode'], 0, "on-http failure.")
-        self.assertEqual(fit_common.remote_shell("service on-syslog restart")['exitcode'], 0, "on-http failure.")
-        self.assertEqual(fit_common.remote_shell("service on-taskgraph restart")['exitcode'], 0, "on-http failure.")
-        self.assertEqual(fit_common.remote_shell("service on-tftp restart")['exitcode'], 0, "on-http failure.")
+        self.assertEqual(fit_common.remote_shell("service on-dhcp-proxy restart")['exitcode'], 0, "on-dhcp-proxy failure.")
+        self.assertEqual(fit_common.remote_shell("service on-syslog restart")['exitcode'], 0, "on-syslog failure.")
+        self.assertEqual(fit_common.remote_shell("service on-taskgraph restart")['exitcode'], 0, "on-taskgraph failure.")
+        self.assertEqual(fit_common.remote_shell("service on-tftp restart")['exitcode'], 0, "on-tftp failure.")
         print "**** Check installation."
         for dummy in range(0, 10):
             try:

--- a/test/fit_tests/deploy/rackhd_package_install.py
+++ b/test/fit_tests/deploy/rackhd_package_install.py
@@ -52,6 +52,7 @@ class rackhd_package_install(fit_common.unittest.TestCase):
             self.assertEqual(fit_common.remote_shell("git config --global http.proxy " + fit_common.GLOBAL_CONFIG['repos']['proxy']
                                                   )['exitcode'], 0, "Git proxy config failure.")
         # install Ansible
+        self.assertEqual(fit_common.remote_shell(PROXYVARS + "apt-get -y update")['exitcode'], 0, "Update failure.")
         self.assertEqual(fit_common.remote_shell(PROXYVARS + "cd ~;apt-get -y install ansible")['exitcode'], 0, "Ansible Install failure.")
         # create startup files
         self.assertEqual(fit_common.remote_shell(

--- a/test/fit_tests/deploy/rackhd_package_install.py
+++ b/test/fit_tests/deploy/rackhd_package_install.py
@@ -47,15 +47,12 @@ class rackhd_package_install(fit_common.unittest.TestCase):
         os.remove('sudoersproxy')
         # install git
         self.assertEqual(fit_common.remote_shell(PROXYVARS + "apt-get -y install git")['exitcode'], 0, "Git install failure.")
-        #self.assertEqual(fit_common.remote_shell(PROXYVARS + "apt-get -y update")['exitcode'], 0, "update failure.")
-        #self.assertEqual(fit_common.remote_shell(PROXYVARS + "apt-get -y dist-upgrade")['exitcode'], 0, "upgrade failure.")
         self.assertEqual(fit_common.remote_shell("git config --global http.sslverify false")['exitcode'], 0, "Git config failure.")
         if 'proxy' in fit_common.GLOBAL_CONFIG['repos'] and fit_common.GLOBAL_CONFIG['repos']['proxy'] != '':
             self.assertEqual(fit_common.remote_shell("git config --global http.proxy " + fit_common.GLOBAL_CONFIG['repos']['proxy']
                                                   )['exitcode'], 0, "Git proxy config failure.")
         # install Ansible
         self.assertEqual(fit_common.remote_shell(PROXYVARS + "cd ~;apt-get -y install ansible")['exitcode'], 0, "Ansible Install failure.")
-        #self.assertEqual(fit_common.remote_shell(PROXYVARS + "apt-get -y update")['exitcode'], 0, "Ansible Update failure.")
         # create startup files
         self.assertEqual(fit_common.remote_shell(
             "touch /etc/default/on-dhcp-proxy /etc/default/on-http /etc/default/on-tftp /etc/default/on-syslog /etc/default/on-taskgraph"

--- a/test/fit_tests/deploy/rackhd_source_install.py
+++ b/test/fit_tests/deploy/rackhd_source_install.py
@@ -13,8 +13,7 @@ This script performs the following functions:
     - load configuration files
     - startup and verify operations
 
-NOTES: This installer does not currently work behind a proxy. If test bed is behind a proxy wall,
-       use the package installer deploy/rackhd_package_install.py.
+NOTES:
        If the host is rebooted, the RackHD must be restarted by typing 'sudo nf start' at console.
 
 usage:

--- a/test/fit_tests/deploy/rackhd_source_install.py
+++ b/test/fit_tests/deploy/rackhd_source_install.py
@@ -77,6 +77,7 @@ class rackhd_source_install(fit_common.unittest.TestCase):
             self.assertEqual(fit_common.remote_shell("git config --global http.proxy " + fit_common.GLOBAL_CONFIG['repos']['proxy']
                                                   )['exitcode'], 0, "Git proxy config failure.")
         # install Ansible
+        self.assertEqual(fit_common.remote_shell(PROXYVARS + "apt-get -y update")['exitcode'], 0, "Update failure.")
         self.assertEqual(fit_common.remote_shell(PROXYVARS + "cd ~;apt-get -y install ansible")['exitcode'], 0, "Ansible Install failure.")
         # create startup files
         self.assertEqual(fit_common.remote_shell(

--- a/test/fit_tests/deploy/rackhd_source_install.py
+++ b/test/fit_tests/deploy/rackhd_source_install.py
@@ -30,9 +30,9 @@ sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=T
 import fit_common
 
 # set proxy if required
-ENVVARS = ''
+PROXYVARS = ''
 if 'proxy' in fit_common.GLOBAL_CONFIG['repos'] and fit_common.GLOBAL_CONFIG['repos']['proxy'] != '':
-    ENVVARS = "export http_proxy=" + fit_common.GLOBAL_CONFIG['repos']['proxy'] + ";" + \
+    PROXYVARS = "export http_proxy=" + fit_common.GLOBAL_CONFIG['repos']['proxy'] + ";" + \
               "export https_proxy=" + fit_common.GLOBAL_CONFIG['repos']['proxy'] + ";"
     # maven proxy settings
     maven_proxy = open('settings.xml', 'w')
@@ -71,16 +71,16 @@ class rackhd_source_install(fit_common.unittest.TestCase):
                                                   )['exitcode'], 0, "sudoersproxy config failure.")
         os.remove('sudoersproxy')
         # install git
-        self.assertEqual(fit_common.remote_shell(ENVVARS + "apt-get -y install git")['exitcode'], 0, "Git install failure.")
-        self.assertEqual(fit_common.remote_shell(ENVVARS + "apt-get -y update")['exitcode'], 0, "update failure.")
-        self.assertEqual(fit_common.remote_shell(ENVVARS + "apt-get -y dist-upgrade")['exitcode'], 0, "upgrade failure.")
+        self.assertEqual(fit_common.remote_shell(PROXYVARS + "apt-get -y install git")['exitcode'], 0, "Git install failure.")
+        #self.assertEqual(fit_common.remote_shell(PROXYVARS + "apt-get -y update")['exitcode'], 0, "update failure.")
+        #self.assertEqual(fit_common.remote_shell(PROXYVARS + "apt-get -y dist-upgrade")['exitcode'], 0, "upgrade failure.")
         self.assertEqual(fit_common.remote_shell("git config --global http.sslverify false")['exitcode'], 0, "Git config failure.")
         if 'proxy' in fit_common.GLOBAL_CONFIG['repos'] and fit_common.GLOBAL_CONFIG['repos']['proxy'] != '':
             self.assertEqual(fit_common.remote_shell("git config --global http.proxy " + fit_common.GLOBAL_CONFIG['repos']['proxy']
                                                   )['exitcode'], 0, "Git proxy config failure.")
         # install Ansible
-        self.assertEqual(fit_common.remote_shell(ENVVARS + "cd ~;apt-get -y install ansible")['exitcode'], 0, "Ansible Install failure.")
-        self.assertEqual(fit_common.remote_shell(ENVVARS + "apt-get -y update")['exitcode'], 0, "Ansible Update failure.")
+        self.assertEqual(fit_common.remote_shell(PROXYVARS + "cd ~;apt-get -y install ansible")['exitcode'], 0, "Ansible Install failure.")
+        #self.assertEqual(fit_common.remote_shell(PROXYVARS + "apt-get -y update")['exitcode'], 0, "Ansible Update failure.")
         # create startup files
         self.assertEqual(fit_common.remote_shell(
             "touch /etc/default/on-dhcp-proxy /etc/default/on-http /etc/default/on-tftp /etc/default/on-syslog /etc/default/on-taskgraph"
@@ -102,7 +102,7 @@ class rackhd_source_install(fit_common.unittest.TestCase):
         ]
         # clone base repo
         fit_common.remote_shell('rm -rf ~/rackhd')
-        self.assertEqual(fit_common.remote_shell(ENVVARS + "git clone "
+        self.assertEqual(fit_common.remote_shell(PROXYVARS + "git clone "
                                                 + fit_common.GLOBAL_CONFIG['repos']['install']['rackhd']['repo']
                                                 + " ~/rackhd"
                                                 )['exitcode'], 0, "RackHD git clone failure.")
@@ -111,7 +111,7 @@ class rackhd_source_install(fit_common.unittest.TestCase):
                                                  )['exitcode'], 0, "Branch not found on RackHD repo.")
         # clone modules
         for repo in modules:
-            self.assertEqual(fit_common.remote_shell(ENVVARS
+            self.assertEqual(fit_common.remote_shell(PROXYVARS
                                                     + "rm -rf ~/rackhd/" + repo + ";"
                                                     + "git clone "
                                                     + fit_common.GLOBAL_CONFIG['repos']['install'][repo]['repo']
@@ -123,7 +123,7 @@ class rackhd_source_install(fit_common.unittest.TestCase):
 
     def test03_run_ansible_installer(self):
         print "**** Run RackHD Ansible installer."
-        self.assertEqual(fit_common.remote_shell(ENVVARS +
+        self.assertEqual(fit_common.remote_shell(PROXYVARS +
                                                  "cd ~/rackhd/packer/ansible/;"
                                                  "ansible-playbook -i 'local,' -c local rackhd_local.yml",
                                                  timeout=1200,

--- a/test/fit_tests/deploy/rackhd_source_install.py
+++ b/test/fit_tests/deploy/rackhd_source_install.py
@@ -123,7 +123,7 @@ class rackhd_source_install(fit_common.unittest.TestCase):
         self.assertEqual(fit_common.remote_shell(PROXYVARS +
                                                  "cd ~/rackhd/packer/ansible/;"
                                                  "ansible-playbook -i 'local,' -c local rackhd_local.yml",
-                                                 timeout=1200,
+                                                 timeout=2000,
                                                  )['exitcode'], 0, "RackHD Install failure.")
 
     def test04_install_network_config(self):

--- a/test/fit_tests/deploy/rackhd_source_install.py
+++ b/test/fit_tests/deploy/rackhd_source_install.py
@@ -72,15 +72,12 @@ class rackhd_source_install(fit_common.unittest.TestCase):
         os.remove('sudoersproxy')
         # install git
         self.assertEqual(fit_common.remote_shell(PROXYVARS + "apt-get -y install git")['exitcode'], 0, "Git install failure.")
-        #self.assertEqual(fit_common.remote_shell(PROXYVARS + "apt-get -y update")['exitcode'], 0, "update failure.")
-        #self.assertEqual(fit_common.remote_shell(PROXYVARS + "apt-get -y dist-upgrade")['exitcode'], 0, "upgrade failure.")
         self.assertEqual(fit_common.remote_shell("git config --global http.sslverify false")['exitcode'], 0, "Git config failure.")
         if 'proxy' in fit_common.GLOBAL_CONFIG['repos'] and fit_common.GLOBAL_CONFIG['repos']['proxy'] != '':
             self.assertEqual(fit_common.remote_shell("git config --global http.proxy " + fit_common.GLOBAL_CONFIG['repos']['proxy']
                                                   )['exitcode'], 0, "Git proxy config failure.")
         # install Ansible
         self.assertEqual(fit_common.remote_shell(PROXYVARS + "cd ~;apt-get -y install ansible")['exitcode'], 0, "Ansible Install failure.")
-        #self.assertEqual(fit_common.remote_shell(PROXYVARS + "apt-get -y update")['exitcode'], 0, "Ansible Update failure.")
         # create startup files
         self.assertEqual(fit_common.remote_shell(
             "touch /etc/default/on-dhcp-proxy /etc/default/on-http /etc/default/on-tftp /etc/default/on-syslog /etc/default/on-taskgraph"


### PR DESCRIPTION
This PR is to update the RackHD installer scripts as part of Phase 1 of RackHD Test Framework:
https://groups.google.com/forum/?hl=en#!topic/rackhd/cscQ2T20Uxs

Files updated are:
test/fit_tests/deploy/rackhd_source_install.py  - installs RackHD from source using rackhd_local.yml 
test/fit_tests/deploy/rackhd_package_install.py  - installs RackHD from packages using rackhd_package.yml 
test/fit_tests/config/global_config.json - contains repo and branch selections for source installer

The new installers are intended meet the following objectives:
- run either remote or local on management server (default)
- run from ESXi-based or Virtualbox-based management server VMs
- ability to run behind proxy
- run from Ubuntu 16 or Ubuntu 14 (see exception below)
- source installed from selectable repos and branches, default to RackHD/master
- install all RackHD package requirements, config files, network config
- start RackHD services without reboot
- check API to verify operational

The installers perform the following functions:
 - loads prerequisite packages git, ansible, etc.
 - downloads RackHD source or packages to management server 
 - installs using Ansible playbook
 - set up networking
 - load configuration files
 - startup and verify operations

Notes: 

Source installer fails on Ubuntu 14 due to a recent change in rackhd_local.yml than cause it to hang. If Ubuntu 14 is still supported then I will file this as a bug. Package installer works with both 14 and 16.

Source repos/branches installed via rackhd_source_install.py can be selected by changing the global_config.json file under the 'repos':'install' section. The configuration file format is likely to be changed when the Test Configuration Management story is completed. 

Updated source installer is currently running this Jenkins smoke test job in MN lab:
https://roebling.hwimo.lab.emc.com/jenkins/job/Running-Tests/job/RackHD-FIT-Smoke-Test/

 

