### PR TITLE
Rac 249 Vagrant installer

### DIFF
--- a/test/fit_tests/README.md
+++ b/test/fit_tests/README.md
@@ -141,7 +141,7 @@ Use the following commands to initialize the server and run a Smoke Test:
     source .venv/bin/activate
     cd fit_tests/test/fit_tests
     python run_tests.py -stack vagrant -test deploy/rackhd_stack_init.py -v 4
-    python run_tests.py -test tests/
+    python run_tests.py -test tests -group smoke
 
 (On Windows, use Putty to log into the server using IP 127.0.0.1, port 2222, and credentials vagrant/vagrant)
 

--- a/test/fit_tests/README.md
+++ b/test/fit_tests/README.md
@@ -118,8 +118,9 @@ For example, to run the test 'test_rackhd11_api_catalogs' in script 'tests/rackh
 The RackHD 'Vagrant' configuration is a convenient simulated hardware environment with one management server and one node.
 It can be run on a Windows or Ubuntu Linux workstation for testing and development.
 
-Install Git, Oracle VirtualBox. and HashiCorp Vagrant onto a Windows or Linux host machine or workstation
+Install Git, Oracle VirtualBox. and HashiCorp Vagrant from the following links onto a Windows or Linux host machine or workstation
 
+https://git-scm.com/downloads
 https://www.virtualbox.org/wiki/Downloads
 https://www.vagrantup.com/downloads.html
 
@@ -142,6 +143,10 @@ Use the following commands to initialize the server and run a Smoke Test:
     python run_tests.py -stack vagrant -test deploy/rackhd_stack_init.py -v 4
     python run_tests.py -test tests/
 
+(On Windows, use Putty to log into the server using IP 127.0.0.1, port 2222, and credentials vagrant/vagrant)
+
+Note that any previously installed RackHD Vagrant boxes will prevent a new instance from running.
+Please remove any old RackHD VMs prior to executing this routine.
 
 ## Test conventions
 
@@ -154,5 +159,4 @@ The setUp and tearDown methods are useful ways to setup and clean out test-speci
 - If scripts need to run in a sequence, use a wrapper script and number the method names.
 - Tests that need specific conditions should be run in a single script and utilize 'setUp' and 'tearDown' methods.
 - Tests should not have any direct references to IP addresses or hostnames. Use GLOBAL_CONFIG or STACK_CONFIG for hardware or resource references.
-
 

--- a/test/fit_tests/README.md
+++ b/test/fit_tests/README.md
@@ -120,9 +120,9 @@ It can be run on a Windows or Ubuntu Linux workstation for testing and developme
 
 Install Git, Oracle VirtualBox. and HashiCorp Vagrant from the following links onto a Windows or Linux host machine or workstation
 
-https://git-scm.com/downloads
-https://www.virtualbox.org/wiki/Downloads
-https://www.vagrantup.com/downloads.html
+    https://git-scm.com/downloads
+    https://www.virtualbox.org/wiki/Downloads
+    https://www.vagrantup.com/downloads.html
 
 Open a shell or command prompt on host.
 

--- a/test/fit_tests/README.md
+++ b/test/fit_tests/README.md
@@ -115,14 +115,14 @@ For example, to run the test 'test_rackhd11_api_catalogs' in script 'tests/rackh
 
 ## Running FIT tests on Vagrant RackHD
 
-The RackHD 'Vagrant' configuration is a convenient simulated hardware environment with one management server and one node.
+The RackHD 'Vagrant' configuration is a convenient simulated hardware environment with one management server and one node running as VMs.
 It can be run on a Windows or Ubuntu Linux workstation for testing and development.
 
 Install Git, Oracle VirtualBox. and HashiCorp Vagrant from the following links onto a Windows or Linux host machine or workstation
 
     https://git-scm.com/downloads
-    https://www.virtualbox.org/wiki/Downloads
-    https://www.vagrantup.com/downloads.html
+    https://www.virtualbox.org/wiki/Downloads (version 5.1 or greater)
+    https://www.vagrantup.com/downloads.html (version 1.8.5 or greater)
 
 Open a shell or command prompt on host.
 

--- a/test/fit_tests/README.md
+++ b/test/fit_tests/README.md
@@ -1,7 +1,7 @@
 # FIT Test Overview
 
 The FIT test suite is an open-source testing harness for RackHD and OnRack software.
-RackHD/OnRack (https://github.com/RackHD) is the open-sourced Hardware Management and Orchestration
+RackHD (https://github.com/RackHD) is the open-sourced Hardware Management and Orchestration
 software developed by EMC for datacenter administration.
 
 FIT stands for Functional Integration Tests and is intended for Continuous Integration testing
@@ -26,6 +26,8 @@ Tests require the following virtual environment commands be executed:
 
 
 ## Directory Organization
+
+The FIT test framework is under RackHD/test/fit_tests.
 
 - 'tests' is the test 'harness'
 - 'common' contains any common library functions
@@ -113,37 +115,32 @@ For example, to run the test 'test_rackhd11_api_catalogs' in script 'tests/rackh
 
 ## Running FIT tests on Vagrant RackHD
 
-Install the Vagrant box using the instructions here:
-https://github.com/RackHD/RackHD/tree/master/example
+The RackHD 'Vagrant' configuration is a convenient simulated hardware environment with one management server and one node.
+It can be run on a Windows or Ubuntu Linux workstation for testing and development.
 
-Install the Quanta simulator:
+Install Git, Oracle VirtualBox. and HashiCorp Vagrant onto a Windows or Linux host machine or workstation
 
-    vagrant up quanta_d51
+https://www.virtualbox.org/wiki/Downloads
+https://www.vagrantup.com/downloads.html
 
-Log into the Vagrant box:
+Open a shell or command prompt on host.
+
+Run the following commands at the command prompt:
+
+    git clone https://github.com/RackHD/RackHD
+    cd RackHD/test/fit_tests
+    vagrant up
+
+This will load a virtual RackHD server and one virtual Quanta D51 node into VirtualBox.
+
+Use the following commands to initialize the server and run a Smoke Test:
 
     vagrant ssh dev
-
-Clone FIT tests:
-
-    git clone https://github.com/onrack2/fit_tests
-
-Load virtual environment:
-
-    cd fit_tests/tests/fit_tests
-    virtualenv .venv
+    sudo bash
     source .venv/bin/activate
-    pip install -r requirements.txt
-
-Run stack init script to discover nodes and populate database:
-
-    python run_tests.py -stack vagrant -v 9 -test deploy/rackhd_stack_init.py
-
-Run Smoke test suite:
-
-    python run_tests.py -test tests/ -group smoke
-
-Use run_tests.py options if needed such as '-port' '-ora' '-https' to select IP address, port and protocol.
+    cd fit_tests/test/fit_tests
+    python run_tests.py -stack vagrant -test deploy/rackhd_stack_init.py -v 4
+    python run_tests.py -test tests/
 
 
 ## Test conventions

--- a/test/fit_tests/Vagrantfile
+++ b/test/fit_tests/Vagrantfile
@@ -30,6 +30,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             pip install -r fit_tests/requirements.txt
             cd fit_tests/test/fit_tests
             python run_tests.py -test deploy/rackhd_source_install.py -v 9
+            python run_tests.py -test deploy/rackhd_stack_init.py:rackhd_stack_init.test01_preload_sku_packs -stack vagrant -v 9
         SHELL
     end
 

--- a/test/fit_tests/Vagrantfile
+++ b/test/fit_tests/Vagrantfile
@@ -23,6 +23,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         target.ssh.forward_agent = true
         target.vm.provision "shell", inline: <<-SHELL
             git clone https://github.com/RackHD/RackHD fit_tests
+            sudo apt-get -y update
             sudo apt-get -y install python-pip
             sudo apt-get -y install virtualenv
             virtualenv .venv

--- a/test/fit_tests/Vagrantfile
+++ b/test/fit_tests/Vagrantfile
@@ -1,0 +1,70 @@
+######################
+# Vagrant File Start #
+######################
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+    config.vm.provider 'virtualbox' do |vb|
+      vb.customize ['modifyvm', :id, '--cableconnected1', 'on']
+    end
+
+    # RackHD SERVER (Install and start RackHD server)
+    config.vm.define "dev" do |target|
+        target.vm.box = "bento/ubuntu-16.04"
+        target.vm.provider "virtualbox" do |v|
+            v.memory = 4096
+            v.cpus = 4
+            v.customize ["modifyvm", :id, "--nicpromisc2", "allow-all", "--ioapic", "on"]
+        end
+        target.ssh.username = "vagrant"
+        target.ssh.password = "vagrant"
+        target.vm.network "private_network", ip: "172.31.128.1", virtualbox__intnet: "closednet"
+        target.ssh.forward_agent = true
+        target.vm.provision "shell", inline: <<-SHELL
+            git clone https://github.com/RackHD/RackHD fit_tests
+            sudo apt-get -y install python-pip
+            sudo apt-get -y install virtualenv
+            virtualenv .venv
+            source .venv/bin/activate
+            pip install -r fit_tests/requirements.txt
+            cd fit_tests/test/fit_tests
+            python run_tests.py -test deploy/rackhd_source_install.py -v 9
+        SHELL
+    end
+
+    # Virtual HW SERVER (Virtual Quanta D51 node)
+    config.vm.define "quanta_d51" do |d51|
+        d51.vm.box = "InfraSIM/quanta_d51"
+        d51.vm.provider "virtualbox" do |v|
+            v.memory = 4096
+            v.cpus = 4
+            v.customize ["modifyvm", :id, "--nicpromisc2", "allow-all", "--ioapic", "on"]
+        end
+        d51.vm.network "private_network", virtualbox__intnet: "closednet", auto_config: false, nic_type: "82540EM"
+        d51.vm.provision "shell", inline: <<-SHELL
+            sudo ifconfig eth1 up
+            sleep 10
+            sudo udhcpc -i br1
+        SHELL
+    end
+
+    # RackHD SERVER TEMPLATE (RackHD installer downloaded but not installed)
+    config.vm.define "template", autostart: false do |target|
+        target.vm.box = "bento/ubuntu-16.04"
+        target.vm.provider "virtualbox" do |v|
+            v.memory = 4096
+            v.cpus = 4
+            v.customize ["modifyvm", :id, "--nicpromisc2", "allow-all", "--ioapic", "on"]
+        end
+        target.ssh.username = "vagrant"
+        target.ssh.password = "vagrant"
+        target.vm.network "private_network", ip: "172.31.128.1", virtualbox__intnet: "closednet"
+        target.ssh.forward_agent = true
+        target.vm.provision "shell", inline: <<-SHELL
+            git clone https://github.com/RackHD/RackHD fit_tests
+        SHELL
+    end
+
+
+end

--- a/test/fit_tests/Vagrantfile
+++ b/test/fit_tests/Vagrantfile
@@ -21,6 +21,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         target.ssh.password = "vagrant"
         target.vm.network "private_network", ip: "172.31.128.1", virtualbox__intnet: "closednet"
         target.ssh.forward_agent = true
+        target.vm.network "forwarded_port", guest: 8080, host: 8080
+        target.vm.network "forwarded_port", guest: 9080, host: 9080
+        target.vm.network "forwarded_port", guest: 9090, host: 9090
+        target.vm.network "forwarded_port", guest: 443, host: 443
         target.vm.provision "shell", inline: <<-SHELL
             git clone https://github.com/RackHD/RackHD fit_tests
             sudo apt-get -y update

--- a/test/fit_tests/config/global_config.json
+++ b/test/fit_tests/config/global_config.json
@@ -58,20 +58,28 @@
     "community": "onrack"
   },
   "repos": {
-    "_comment": "This is the list of repositories for each category",
-    "proxy": "http://web.hwimo.lab.emc.com:3128",
-    "mirror": "http://mirrors.hwimo.lab.emc.com/mirrors",
+    "_comment":   "This is the list of repositories for each category",
+    "mirror":     "http://mirrors.hwimo.lab.emc.com/mirrors",
     "os": {
-      "esxi55": "http://172.31.128.1:9080/mirror/esxi/5.5/esxi",
-      "esxi60": "http://172.31.128.1:9080/mirror/esxi/6.0/esxi6",
+      "esxi55":   "http://172.31.128.1:9080/mirror/esxi/5.5/esxi",
+      "esxi60":   "http://172.31.128.1:9080/mirror/esxi/6.0/esxi6",
       "centos65": "http://172.31.128.1:9080/mirror/centos/6.5/os/x86_64",
       "centos70": "http://172.31.128.1:9080/mirror/centos/7/os/x86_64",
-      "rhel70": "http://172.31.128.1:9080/mirror/rhel/7.0/os/x86_64"
+      "rhel70":   "http://172.31.128.1:9080/mirror/rhel/7.0/os/x86_64"
     },
     "install": {
-      "template": "http://mirrors.hwimo.lab.emc.com/mirrors/ova/ora-ubuntu-1604.ova",
-      "onrack": "http://onrack.hwimo.lab.emc.com/get/",
-      "rackhd": "https://github.com/rackhd/"
+      "template":     "http://mirrors.hwimo.lab.emc.com/mirrors/ova/ora-ubuntu-1604.ova",
+      "rackhd":       {"repo":"https://github.com/rackhd/rackhd","branch":"master"},
+      "on-core":      {"repo":"https://github.com/rackhd/on-core","branch":"master"},
+      "on-dhcp-proxy":{"repo":"https://github.com/rackhd/on-dhcp-proxy","branch":"master"},
+      "on-http":      {"repo":"https://github.com/rackhd/on-http","branch":"master"},
+      "on-statsd":    {"repo":"https://github.com/rackhd/on-statsd","branch":"master"},
+      "on-syslog":    {"repo":"https://github.com/rackhd/on-syslog","branch":"master"},
+      "on-tasks":     {"repo":"https://github.com/rackhd/on-tasks","branch":"master"},
+      "on-taskgraph": {"repo":"https://github.com/rackhd/on-taskgraph","branch":"master"},
+      "on-tftp":      {"repo":"https://github.com/rackhd/on-tftp","branch":"master"},
+      "on-tools":     {"repo":"https://github.com/rackhd/on-tools","branch":"master"},
+      "on-wss":       {"repo":"https://github.com/rackhd/on-wss","branch":"master"}
       },
     "skupack": [
       "https://github.com/RackHD/on-skupack"

--- a/test/fit_tests/config/global_config.json
+++ b/test/fit_tests/config/global_config.json
@@ -13,8 +13,8 @@
     ],
     "ora": [
       {
-        "username": "onrack",
-        "password": "onrack"
+        "username": "vagrant",
+        "password": "vagrant"
       }
     ],
     "bmc": [


### PR DESCRIPTION
This PR contains a new 'Vagrant' RackHD installer for workstation-based development and test environments.

This update consists of two files:
test/fit_tests/Vagrantfile
test/fit_tests/README.md

Vagrantfile is a script that executes the following procedures:
- downloads and starts a Ubuntu 16 template from Vagrant Atlas as server
- runs the FIT source installer to load the latest RackHD on Ubuntu server
- configures RackHD to run on the Vagrant host
- starts up RackHD
- loads SKU packs
- downloads and starts InfraSim Quanta D51 simulator

The README.md file has detailed instructions on how to configure and run the script.

This PR is dependent upon the following PRs to run properly:
https://github.com/RackHD/RackHD/pull/491
https://github.com/RackHD/RackHD/pull/487

This has been tested using Windows 7 and Ubuntu 16 desktop environments.

The 'template' section of the Vagrantfile is for future use in Jenkins automation.
