### PR TITLE
Changing device name to pass MAC address 

### DIFF
--- a/example/samples/install_windows_payload_full.json
+++ b/example/samples/install_windows_payload_full.json
@@ -8,7 +8,8 @@
       "firewallDisable": true,
       "networkDevices": [
         {
-          "device": "2C-60-0C-AD-D5-B1"
+          "device": "2C-60-0C-AD-D5-B1",
+          "ipv4": {
             "ipAddr": "172.31.128.152",
             "gateway": "172.31.128.5",
             "netmask": "255.255.255.0"

--- a/example/samples/install_windows_payload_full.json
+++ b/example/samples/install_windows_payload_full.json
@@ -8,8 +8,7 @@
       "firewallDisable": true,
       "networkDevices": [
         {
-          "device": "Ethernet 4",
-          "ipv4": {
+          "device": "2C-60-0C-AD-D5-B1"
             "ipAddr": "172.31.128.152",
             "gateway": "172.31.128.5",
             "netmask": "255.255.255.0"


### PR DESCRIPTION
Device name doesn't stay consistent in Windows OS on Jenkins slave 5. So changing the name to MAC address.