### PR TITLE
Create rsyslog configure file example

### DIFF
--- a/example/config/rsyslog_rackhd.conf.example
+++ b/example/config/rsyslog_rackhd.conf.example
@@ -1,0 +1,24 @@
+# rsyslog configure file for RackHD server to receive OS installation logs
+# Enable RackHD server to receive syslog from nodes
+# Logs from different nodes will be restored in /var/log/rackhd/<node_ip>_<time>.log
+# Copy this file to /etc/rsyslog.d/ and restart rsyslog to make configurations effective
+
+# Provides UDP syslog reception
+# RackHD on-syslog service occupies UDP 514 port
+# rsyslog UDP port is set to 10514 instead
+$ModLoad imudp
+$UDPServerRun 10514
+# Allowed sender IP aligns with RackHD dhcp configure
+$AllowedSender UDP, 172.31.128.0/22
+
+# Provides TCP syslog reception
+$ModLoad imtcp
+$InputTCPServerRun 514
+# Allowed sender IP aligns with RackHD dhcp configure
+$AllowedSender TCP, 172.31.128.0/22
+
+# This one is the template to generate the log filename dynamically, depending on the client's IP address and log creation time slot.
+$template Remote,"/var/log/rackhd/%fromhost-ip%_%$YEAR%-%$MONTH%-%$DAY%.log"
+# Log all messages to the dynamically formed file.
+:fromhost-ip, !isequal, "127.0.0.1" ?Remote
+& ~


### PR DESCRIPTION
Create rsyslog configure file example.
A new feature is added to OS installation to enable node to send OS installation syslog to RackHD server. This PR created a rsyslog configure that enables RackHD server rsyslog to received syslog from nodes and store logs in /var/log/rackhd/ with <node_ip>_<date> format.