### PR TITLE
Always map the repo dir.

### DIFF
--- a/example/Vagrantfile
+++ b/example/Vagrantfile
@@ -37,9 +37,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             target.vm.synced_folder "#{ENV['WORKSPACE']}/#{ENV['REPO']}", "/home/vagrant/src/on-http/node_modules/on-core/"
             target.vm.synced_folder "#{ENV['WORKSPACE']}/#{ENV['REPO']}", "/home/vagrant/src/on-tftp/node_modules/on-core/"
             target.vm.synced_folder "#{ENV['WORKSPACE']}/#{ENV['REPO']}", "/home/vagrant/src/on-dhcp-proxy/node_modules/on-core/"
-          else
-            target.vm.synced_folder "#{ENV['WORKSPACE']}/#{ENV['REPO']}", "/home/vagrant/src/#{ENV['REPO']}"
           end
+          target.vm.synced_folder "#{ENV['WORKSPACE']}/#{ENV['REPO']}", "/home/vagrant/src/#{ENV['REPO']}"
           if ENV['CONFIG_DIR']
             target.vm.synced_folder "#{ENV['WORKSPACE']}/#{ENV['CONFIG_DIR']}", "/opt/onrack/etc/"
             target.vm.synced_folder "#{ENV['WORKSPACE']}/#{ENV['CONFIG_DIR']}", "/home/vagrant/opt/monorail/"


### PR DESCRIPTION
Currently if the repo dir you specify via the environment is on-core on on-tasks it doesn't get mapped due to the mapping being in the else clause of the special-casing that maps them into the node_modules directories of the other projects.

This fixes that, allowing easier development of on-core and on-tasks.

Fixes #499