### PR TITLE
Update POST /api/2.0/nodes related tests to provide now required 'type' field.

### DIFF
--- a/test/fit_tests/tests/rackhd20/test_rackhd20_api_nodes.py
+++ b/test/fit_tests/tests/rackhd20/test_rackhd20_api_nodes.py
@@ -58,7 +58,7 @@ class rackhd20_api_nodes(fit_common.unittest.TestCase):
                 self.assertGreater(len(api_data['json'][item]), 0, item + ' field error')
 
     def test_api_20_create_delete_node(self):
-        data_payload = {"name": "testnode"}
+        data_payload = {"name": "testnode", "type": "compute"}
         api_data = fit_common.rackhdapi("/api/2.0/nodes", action='post', payload=data_payload)
         self.assertEqual(api_data['status'], 201, 'Incorrect HTTP return code, expected 201, got:' + str(api_data['status']))
         nodeid = api_data['json']['id']
@@ -111,7 +111,7 @@ class rackhd20_api_nodes(fit_common.unittest.TestCase):
 
     def test_api_20_nodes_ID_obmsettings(self):
         # create fake node
-        data_payload = {"name": "fakenode"}
+        data_payload = {"name": "fakenode", "type": "compute"}
         api_data = fit_common.rackhdapi("/api/2.0/nodes", action="post",
                                            payload=data_payload)
         self.assertEqual(api_data['status'], 201, 'Incorrect HTTP return code, expected 201, got:' + str(api_data['status']))

--- a/test/fit_tests/tests/rackhd20/test_rackhd20_api_tags.py
+++ b/test/fit_tests/tests/rackhd20/test_rackhd20_api_tags.py
@@ -32,7 +32,7 @@ class rackhd20_api_tags(fit_common.unittest.TestCase):
             self.assertIn("test_tag_" + nodeid, fit_common.json.dumps(api_data['json']), "Tag not set:" + fit_common.json.dumps(api_data['json']))
     def test_api_20_tags_post_delete(self):
         # create dummy node
-        data_payload = {"name": "test"}
+        data_payload = {"name": "test", "type": "compute"}
         nodeid = fit_common.rackhdapi("/api/2.0/nodes", action='post', payload=data_payload)['json']['id']
         # add tags
         api_data = fit_common.rackhdapi("/api/2.0/nodes/" + nodeid + "/tags", action="patch", payload={"tags":["test_node","dummy_node"]})


### PR DESCRIPTION
This fixes three test failures related to /api/2.0/nodes requiring a type field in its POST block.

@RackHD/corecommitters
@gpaulos @stuart-stanley 