### PR TITLE
Bug fix: move library script to VM's /tmp/

### DIFF
--- a/packer/ansible/roles/isc-dhcp-server/files/config_isc-dhcp-server.sh
+++ b/packer/ansible/roles/isc-dhcp-server/files/config_isc-dhcp-server.sh
@@ -2,8 +2,8 @@
 set -e
 
 
-#Load library func
-source get_nic_name_by_index.sh
+#Load library func, was copied by packer to /tmp/
+source /tmp/get_nic_name_by_index.sh
 
 ########################################
 # Main

--- a/packer/ansible/roles/isc-dhcp-server/tasks/main.yml
+++ b/packer/ansible/roles/isc-dhcp-server/tasks/main.yml
@@ -9,10 +9,6 @@
   copy: src=isc-dhcp-server.in dest=/etc/default/isc-dhcp-server
   sudo: yes
 
-- name: Copy nic name utility script to guest( was in packer/scripts/common/ and was copied here by dep.sh)
-  copy: src=get_nic_name_by_index.sh  dest=~/get_nic_name_by_index.sh  mode=0755
-  sudo: yes
-
 - name: Copy isc-dhcp-server config script to guest
   copy: src=config_isc-dhcp-server.sh  dest=~/config_isc-dhcp-server.sh mode=0755
   sudo: yes

--- a/packer/scripts/addnetif.sh
+++ b/packer/scripts/addnetif.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-#Load library func
-source common/get_nic_name_by_index.sh
+#Load library func, it was loaded by packer to /tmp/ in previous steps
+source /tmp/get_nic_name_by_index.sh
 
 #######################################
 # Force set Secondary NIC static IP

--- a/packer/scripts/dep.sh
+++ b/packer/scripts/dep.sh
@@ -10,5 +10,3 @@ apt-get -y install ansible
 rm -f /etc/hostname
 echo "rackhd" > /etc/hostname
 
-# Move the library script in scripts/common to ansible folder, so that it can be copied to remote node and be invoked in ansible scripts
-cp  scripts/common/get_nic_name_by_index.sh  ansible/roles/isc-dhcp-server/files/

--- a/packer/scripts/firstuser.sh
+++ b/packer/scripts/firstuser.sh
@@ -16,8 +16,8 @@ login() {
 }
 
 
-# Load Library function
-source common/get_nic_name_by_index.sh
+#Load library func, it was loaded by packer to /tmp/ in previous steps
+source /tmp/get_nic_name_by_index.sh
 
 
 # Include the on-* services in case we're installing from .deb packages

--- a/packer/template-ubuntu-14.04.json
+++ b/packer/template-ubuntu-14.04.json
@@ -45,6 +45,11 @@
             "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'"
         },
         {
+              "type": "file",
+              "source": "scripts/common/get_nic_name_by_index.sh",
+              "destination": "/tmp/get_nic_name_by_index.sh"
+        },
+        {
             "type": "ansible-local",
             "inventory_groups": "local",
             "playbook_file": "ansible/{{user `playbook`}}.yml",

--- a/packer/template-ubuntu-16.04.json
+++ b/packer/template-ubuntu-16.04.json
@@ -38,6 +38,11 @@
             "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'"
         },
         {
+              "type": "file",
+              "source": "scripts/common/get_nic_name_by_index.sh",
+              "destination": "/tmp/get_nic_name_by_index.sh"
+        },
+        {
             "type": "ansible-local",
             "inventory_groups": "local",
             "playbook_file": "ansible/{{user `playbook`}}.yml",


### PR DESCRIPTION
this is a hot fix https://github.com/RackHD/RackHD/pull/508/

because any script in packer ( either in packer provision or ansible) runs inside the created VM,
so the shell library file should be copied to VM first, before invoking it.


@changev @cgx027 @anhou @yyscamper 