### PR TITLE
adjust the order of packer provisioning: config eth1 before ansible

### DIFF
--- a/packer/template-ubuntu-14.04.json
+++ b/packer/template-ubuntu-14.04.json
@@ -38,16 +38,16 @@
             "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'"
         },
         {
+              "type": "file",
+              "source": "scripts/common/get_nic_name_by_index.sh",
+              "destination": "/tmp/get_nic_name_by_index.sh"
+        },
+        {
             "type": "shell",
             "scripts": [
                 "scripts/addnetif.sh"
             ],
             "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'"
-        },
-        {
-              "type": "file",
-              "source": "scripts/common/get_nic_name_by_index.sh",
-              "destination": "/tmp/get_nic_name_by_index.sh"
         },
         {
             "type": "ansible-local",

--- a/packer/template-ubuntu-16.04.json
+++ b/packer/template-ubuntu-16.04.json
@@ -43,18 +43,18 @@
               "destination": "/tmp/get_nic_name_by_index.sh"
         },
         {
-            "type": "ansible-local",
-            "inventory_groups": "local",
-            "playbook_file": "ansible/{{user `playbook`}}.yml",
-            "playbook_dir": "ansible",
-            "extra_arguments": [ "--extra-vars \"rackhd_version={{user `version`}}\"" ]
-        },
-        {
             "type": "shell",
             "scripts": [
                 "scripts/addnetif.sh"
             ],
             "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'"
+        },
+        {
+            "type": "ansible-local",
+            "inventory_groups": "local",
+            "playbook_file": "ansible/{{user `playbook`}}.yml",
+            "playbook_dir": "ansible",
+            "extra_arguments": [ "--extra-vars \"rackhd_version={{user `version`}}\"" ]
         },
         {
             "type": "shell",


### PR DESCRIPTION
What's up:

1. it's a bug  fix for 14.04 packer script. the ```get_nic_name_by_index.sh``` file copy should happen before ```addnetif.sh```
2. change the admin (eth1) configuration before ansible playbooks( install rackhd..etc)

Test Done:
successful build a 14.04 OVA , and verify RackHD service running well for that OVA

@changev  @yyscamper  @anhou 