### PR TITLE
RAC-800: Make the Ansible can run without Packer ( option #1)

### DIFF
--- a/packer/ansible/roles/isc-dhcp-server/files/config_isc-dhcp-server.sh
+++ b/packer/ansible/roles/isc-dhcp-server/files/config_isc-dhcp-server.sh
@@ -1,9 +1,84 @@
 #!/bin/bash
 set -e
 
+############################################################
+##     Why Duplication code below ?
+##
+## Below two functions come from packer/scripts/common/get_nic_name_by_index.sh
+## becauce when packer execute ansible ,
+## packer will copy the whole packer/ansible folder to VM's /tmp/packer-provisioner-ansible-local
+## but the files outside packer/ansible do not exist in VM's filesystem.
+## so ansible-playbook can't copy common/get_nic_name_by_index.sh because ansible can't find it anywhere.
+## so we will have to duplicate below scripts here.
+############################################################
 
-#Load library func, was copied by packer to /tmp/
-source /tmp/get_nic_name_by_index.sh
+
+##########################################################
+# retrieve nic name via ```ip addr``` command, by given id
+#
+# param: index of nic(starting from 1)
+#
+# echo:  the nic name
+#
+# exception:  exit non-zero with echo error message
+##########################################################
+get_nic_name_by_index()
+{
+    #######################
+    # this script is to obtain and echo the nic name (lo/eth0/eth1) by index(1/2/3) shown in ```ip addr```
+    #
+    #
+    # ip addr will show:
+    #
+    #1: lo: <loopback,up,lower_up> mtu 65536 qdisc noqueue state unknown group default
+    #.......
+    #2: eth0: <broadcast,multicast,up,lower_up> mtu 1500 ...
+    #.......
+    #3: eth1: <broadcast,multicast,up,lower_up> mtu 1500 qdisc pf....
+    #......
+    #
+    ########################
+    id=$1
+    if ! [[ "$id" =~ ^[0-9]+$ ]] || [[ "$id" -eq 0 ]]; then
+        echo "[error]: invalid parameter passed to get_nic_name_by_index(): nic id=${id} should be number and be larger than 0.";
+        exit 1
+    fi
+
+    tmp=$( ip addr|grep "^${id}:" | awk '{print $2}')
+
+    # the output should be like "lo:", "eth1:", "br-123asdf23:" if this nic index exists
+    if [[ "$tmp" == "" ]] || ! [[ $(echo $tmp|grep ":$") ]]
+    then
+        echo "[error]: invalid parameter passed to get_nic_name_by_index(): nic id=${id} not detected";
+        exit 2
+    fi
+    name=${tmp/:/}  # remove the ":"
+    echo $name
+}
+
+#################################
+# retrieve secondary nic name(example :control port of rackhd), skipping the loopback dev(lo)
+#
+# echo:  the nic name
+################################
+get_secondary_nic_name()
+{
+
+    # by default, the control port index is 3. say: eth1/enp0s8/ens33...
+    sec_nic_index=3;
+
+
+    # if the index 1 is not loopback device, then eth0 may starts from index 1.
+    nic1=$(get_nic_name_by_index 1)
+    if [[ $nic1 != "lo" ]]; then
+        sec_nic_index=$(expr $sec_nic_index - 1 )
+    fi
+
+    sec_nic=$(get_nic_name_by_index $sec_nic_index)
+
+    echo $sec_nic
+}
+
 
 ########################################
 # Main


### PR DESCRIPTION
It's option 1, option 2 is https://github.com/RackHD/RackHD/pull/522

**Background**
there's a common script(get_nic_name_by_index.sh) to be invoked by both ```packer/scripts/``` and ```packer/ansible/````
 simply putting the common-script in either place , will make the other can't access this common-scripts.
Example, packer will only copy content under "packer/ansbile" to VM's staging dir(/tmp/packer-provisioner-ansible-local), so the common script will never be found by ansible.

**Previous Fix Attempts**
- I used packer provision scripts(running before ansible) to copy the common-script to VM's filesystem. but it makes ansible has to be depend on the packer , and can't run alone
- I tried to leverage some packer parameter to workaround and upload the common script to VM's filesystem , like ```playbook_dir```. but still not working .

**This PR**
I have to give up the code reuse , and copy the code again here..


@cgx027  @yyscamper @anhou @changev 