### PR TITLE
RAC-800: Make the Ansible can run without Packer (Option #2)

### DIFF
--- a/packer/ansible/roles/isc-dhcp-server/files/config_isc-dhcp-server.sh
+++ b/packer/ansible/roles/isc-dhcp-server/files/config_isc-dhcp-server.sh
@@ -2,7 +2,10 @@
 set -e
 
 
-#Load library func, was copied by packer to /tmp/
+#Load library func
+GIT_RAW_FILE_URL=https://raw.githubusercontent.com/RackHD/RackHD/master/
+FILE_PATH=packer/scripts/common/get_nic_name_by_index.sh
+wget ${GIT_RAW_FILE_URL}${FILE_PATH} -O /tmp/get_nic_name_by_index.sh
 source /tmp/get_nic_name_by_index.sh
 
 ########################################


### PR DESCRIPTION
It's option 2, option 1 is https://github.com/RackHD/RackHD/pull/521

**Background**
there's a common script(get_nic_name_by_index.sh) to be invoked by both ```packer/scripts/``` and ```packer/ansible/````
 simply putting the common-script in either place , will make the other can't access this common-scripts.
Example, packer will only copy content under "packer/ansbile" to VM's staging dir(/tmp/packer-provisioner-ansible-local), so the common script will never be found by ansible.

https://rackhd.atlassian.net/browse/RAC-800

**Previous Fix Attempts**
- I used packer provision scripts(running before ansible) to copy the common-script to VM's filesystem. but it makes ansible has to be depend on the packer , and can't run alone
- I tried to leverage some packer parameter to workaround and upload the common script to VM's filesystem , like ```playbook_dir```. but still not working .

**This PR**
I have to give up the ···source··· command to load local file  ,instead,  using wget to download the code from github when running ansible.

@cgx027  @yyscamper @anhou @changev 