### PR TITLE
RAC-3711 Common FIT code still contains many references to 'ora', which is the…

### DIFF
--- a/test/fit_tests/README.md
+++ b/test/fit_tests/README.md
@@ -47,7 +47,7 @@ More details in config/README.md.
 All FIT tests can be run from the wrapper 'run_tests.py':
 
     usage: run_tests.py [-h] [-test TEST] [-config CONFIG] [-group GROUP]
-                        [-stack STACK] [-ora ORA] [-version VERSION] [-xunit]
+                        [-stack STACK] [-server SERVER] [-version VERSION] [-xunit]
                         [-list] [-sku SKU] [-obmmac OBMMAC | -nodeid NODEID]
                         [-http | -https] [-v V]
 
@@ -59,8 +59,8 @@ All FIT tests can be run from the wrapper 'run_tests.py':
       -config CONFIG      config file location, default: fit_tests/config
       -group GROUP        test group to execute: 'smoke', 'regression',
                           'extended', default: 'all'
-      -stack STACK        stack label (test bed), overrides -ora
-      -ora ORA            OnRack/RackHD appliance IP address or hostname, default:
+      -stack STACK        stack label (test bed), overrides -server
+      -server SERVER 	  RackHD appliance IP address or hostname, default:
                           localhost
       -version VERSION    OnRack package install version, example:onrack-
                           release-0.3.0, default: onrack-devel
@@ -86,18 +86,18 @@ This example will run the RackHD installer onto stack 1 via the wrapper script:
     python run_tests.py -stack 1 -test deploy/run_rackhd_installer.py
 
 
-The -stack or -ora argument can be omitted when running on the server or appliance. The test defaults to localhost:8080 for API calls.
+The -stack or -server argument can be omitted when running on the server or appliance. The test defaults to localhost:8080 for API calls.
 
 This example will run the smoke test from the appliance node or the default Vagrant test bed:
 
     python run_tests.py -test tests -group smoke
 
 
-Alternatively tests can be run directly from nose. Runtime parameters such as ORA address must be set in the environment.
+Alternatively tests can be run directly from nose. Runtime parameters such as SERVER address must be set in the environment.
 
-The following example will run all the entire test harness from a third party machine to ORA at 192.168.1.1:
+The following example will run all the entire test harness from a third party machine to SERVER at 192.168.1.1:
 
-    export ORA=192.168.1.1
+    export SERVER=192.168.1.1
     nosetests -s tests
 
 

--- a/test/fit_tests/config/global_config.json
+++ b/test/fit_tests/config/global_config.json
@@ -11,7 +11,7 @@
         "password": "password"
       }
     ],
-    "ora": [
+    "server": [
       {
         "username": "vagrant",
         "password": "vagrant"

--- a/test/fit_tests/config/stack_config.json
+++ b/test/fit_tests/config/stack_config.json
@@ -4,13 +4,13 @@
     "control": "control switch admin address",
     "data": "data switch admin address",
     "hyper": "hypervisor admin address",
-    "ora": "appliance OVA admin address",
+    "server": "appliance OVA admin address",
     "ovamac": "appliance OVA MAC address",
     "pdu": "PDU admin address",
     "type": "deployment type: esxi, docker, linux, or vagrant"
   },
   "vagrant":{
-    "ora": "localhost",
+    "server": "localhost",
     "type": "vagrant"
   },
   "1": {
@@ -18,7 +18,7 @@
     "control": "stack1-control.admin", 
     "data": "stack1-data.admin", 
     "hyper": "stack1-esxi.admin", 
-    "ora": "stack1-ora.admin",
+    "server": "stack1-ora.admin",
     "ovamac": "00:50:56:00:01:00",
     "pdu": "192.168.1.254",
     "type": "esxi"
@@ -28,7 +28,7 @@
     "control": "stack2-control.admin", 
     "data": "stack2-data.admin", 
     "hyper": "stack2-esxi.admin", 
-    "ora": "stack2-ora.admin",
+    "server": "stack2-ora.admin",
     "ovamac": "00:50:56:00:02:00",
     "pdu": "192.168.1.254",
     "type": "esxi"
@@ -38,7 +38,7 @@
     "control": "stack3-control.admin", 
     "data": "stack3-data.admin", 
     "hyper": "stack3-esxi.admin", 
-    "ora": "stack3-ora.admin",
+    "server": "stack3-ora.admin",
     "ovamac": "00:50:56:00:03:00",
     "pdu": "192.168.1.254",
     "type": "esxi"
@@ -48,7 +48,7 @@
     "control": "stack4-control.admin", 
     "data": "stack4-data.admin", 
     "hyper": "stack4-esxi.admin", 
-    "ora": "stack4-ora.admin",
+    "server": "stack4-ora.admin",
     "ovamac": "00:50:56:00:04:00",
     "pdu": "192.168.1.254",
     "type": "esxi"
@@ -58,7 +58,7 @@
     "control": "stack5-control.admin", 
     "data": "stack5-data.admin", 
     "hyper": "stack5-esxi.admin", 
-    "ora": "stack5-ora.admin",
+    "server": "stack5-ora.admin",
     "ovamac": "00:50:56:00:05:00",
     "pdu": "192.168.1.254",
     "type": "esxi"
@@ -68,7 +68,7 @@
     "control": "stack6-control.admin", 
     "data": "stack6-data.admin", 
     "hyper": "stack6-esxi.admin", 
-    "ora": "stack6-ora.admin",
+    "server": "stack6-ora.admin",
     "ovamac": "00:50:56:00:06:00",
     "pdu": "192.168.1.254",
     "type": "esxi"
@@ -78,7 +78,7 @@
     "control": "stack7-control.admin", 
     "data": "stack7-data.admin", 
     "hyper": "stack7-esxi.admin", 
-    "ora": "stack7-ora.admin",
+    "server": "stack7-ora.admin",
     "ovamac": "00:50:56:00:07:00",
     "pdu": "192.168.1.254",
     "type": "esxi"
@@ -88,7 +88,7 @@
     "control": "stack8-control.admin", 
     "data": "stack8-data.admin", 
     "hyper": "stack8-esxi.admin", 
-    "ora": "stack8-ora.admin",
+    "server": "stack8-ora.admin",
     "ovamac": "00:50:56:00:08:00",
     "pdu": "192.168.1.254",
     "type": "esxi"
@@ -98,7 +98,7 @@
     "control": "stack9-control.admin", 
     "data": "stack9-data.admin", 
     "hyper": "stack9-esxi.admin", 
-    "ora": "stack9-ora.admin",
+    "server": "stack9-ora.admin",
     "ovamac": "00:50:56:00:09:00",
     "pdu": "192.168.1.254",
     "type": "esxi"
@@ -108,7 +108,7 @@
     "control": "stack10-control.admin", 
     "data": "stack10-data.admin", 
     "hyper": "stack10-esxi.admin", 
-    "ora": "stack10-ora.admin",
+    "server": "stack10-ora.admin",
     "ovamac": "00:50:56:00:10:00",
     "pdu": "192.168.1.254",
     "type": "esxi"
@@ -118,7 +118,7 @@
     "control": "stack11-control.admin", 
     "data": "stack11-data.admin", 
     "hyper": "stack11-esxi.admin", 
-    "ora": "stack11-ora.admin",
+    "server": "stack11-ora.admin",
     "ovamac": "00:50:56:00:11:00",
     "pdu": "192.168.1.254",
     "type": "esxi"
@@ -128,7 +128,7 @@
     "control": "stack12-control.admin", 
     "data": "stack12-data.admin", 
     "hyper": "stack12-esxi.admin", 
-    "ora": "stack12-ora.admin",
+    "server": "stack12-ora.admin",
     "ovamac": "00:50:56:00:12:00",
     "pdu": "192.168.1.254",
     "type": "esxi"
@@ -138,7 +138,7 @@
     "control": "stack13-control.admin", 
     "data": "stack13-data.admin", 
     "hyper": "stack13-esxi.admin", 
-    "ora": "stack13-ora.admin",
+    "server": "stack13-ora.admin",
     "ovamac": "00:50:56:00:13:00",
     "pdu": "192.168.1.254",
     "type": "esxi"
@@ -148,7 +148,7 @@
     "control": "stack14-control.admin", 
     "data": "stack14-data.admin", 
     "hyper": "stack14-esxi.admin", 
-    "ora": "stack14-ora.admin",
+    "server": "stack14-ora.admin",
     "ovamac": "00:50:56:00:14:00",
     "pdu": "192.168.1.254",
     "type": "esxi"
@@ -158,7 +158,7 @@
     "control": "stack15-control.admin", 
     "data": "stack15-data.admin", 
     "hyper": "stack15-esxi.admin", 
-    "ora": "stack15-ora.admin",
+    "server": "stack15-ora.admin",
     "ovamac": "00:50:56:00:15:00",
     "pdu": "192.168.1.254",
     "type": "esxi"
@@ -168,7 +168,7 @@
     "control": "stack16-control.admin", 
     "data": "stack16-data.admin", 
     "hyper": "stack16-esxi.admin", 
-    "ora": "stack16-ora.admin",
+    "server": "stack16-ora.admin",
     "ovamac": "00:50:56:00:16:00",
     "pdu": "",
     "type": "esxi"
@@ -178,7 +178,7 @@
     "control": "stack17-control.admin", 
     "data": "stack17-data.admin", 
     "hyper": "stack17-esxi.admin", 
-    "ora": "stack17-ora.admin",
+    "server": "stack17-ora.admin",
     "ovamac": "00:50:56:00:17:00",
     "pdu": "192.168.1.254",
     "type": "esxi"
@@ -188,7 +188,7 @@
     "control": "stack18-control.admin", 
     "data": "stack18-data.admin", 
     "hyper": "stack18-esxi.admin", 
-    "ora": "stack18-ora.admin",
+    "server": "stack18-ora.admin",
     "ovamac": "00:50:56:00:18:00",
     "pdu": "192.168.1.254",
     "type": "esxi"
@@ -198,7 +198,7 @@
     "control": "stack19-control.admin", 
     "data": "stack19-data.admin", 
     "hyper": "stack19-esxi.admin", 
-    "ora": "stack19-ora.admin",
+    "server": "stack19-ora.admin",
     "ovamac": "00:50:56:00:19:00",
     "pdu": "192.168.1.254",
     "type": "esxi"
@@ -208,7 +208,7 @@
     "control": "stack20-control.admin", 
     "data": "stack20-data.admin", 
     "hyper": "stack20-esxi.admin", 
-    "ora": "stack20-ora.admin",
+    "server": "stack20-ora.admin",
     "ovamac": "00:50:56:00:20:00",
     "pdu": "",
     "type": "esxi"
@@ -218,7 +218,7 @@
     "control": "stack21-control.admin", 
     "data": "stack21-data.admin", 
     "hyper": "stack21-esxi.admin", 
-    "ora": "stack21-ora.admin",
+    "server": "stack21-ora.admin",
     "ovamac": "00:50:56:00:21:00",
     "pdu": "",
     "type": "esxi"
@@ -228,7 +228,7 @@
     "control": "stack22-control.admin", 
     "data": "stack22-data.admin", 
     "hyper": "stack22-esxi.admin", 
-    "ora": "stack22-ora.admin",
+    "server": "stack22-ora.admin",
     "ovamac": "00:50:56:00:22:00",
     "pdu": "",
     "type": "esxi"
@@ -238,7 +238,7 @@
     "control": "stack23-control.admin", 
     "data": "stack23-data.admin", 
     "hyper": "stack23-esxi.admin", 
-    "ora": "stack23-ora.admin",
+    "server": "stack23-ora.admin",
     "ovamac": "00:50:56:00:23:00",
     "pdu": "",
     "type": "esxi"
@@ -248,7 +248,7 @@
     "control": "stack24-control.admin", 
     "data": "stack24-data.admin", 
     "hyper": "stack24-esxi.admin", 
-    "ora": "stack24-ora.admin",
+    "server": "stack24-ora.admin",
     "ovamac": "00:50:56:00:24:00",
     "pdu": "",
     "type": "esxi"
@@ -258,7 +258,7 @@
     "control": "stack25-control.admin", 
     "data": "stack25-data.admin", 
     "hyper": "stack25-esxi.admin", 
-    "ora": "stack25-ora.admin",
+    "server": "stack25-ora.admin",
     "ovamac": "00:50:56:00:25:00",
     "pdu": "",
     "type": "esxi"
@@ -268,7 +268,7 @@
     "control": "stack26-control.admin", 
     "data": "stack26-data.admin", 
     "hyper": "stack26-esxi.admin", 
-    "ora": "stack26-ora.admin",
+    "server": "stack26-ora.admin",
     "ovamac": "00:50:56:00:26:00",
     "pdu": "",
     "type": "esxi"
@@ -278,7 +278,7 @@
     "control": "stack27-control.admin", 
     "data": "stack27-data.admin", 
     "hyper": "stack27-esxi.admin", 
-    "ora": "stack27-ora.admin",
+    "server": "stack27-ora.admin",
     "ovamac": "00:50:56:00:27:00",
     "pdu": "",
     "type": "esxi"
@@ -288,7 +288,7 @@
     "control": "stack28-control.admin", 
     "data": "stack28-data.admin", 
     "hyper": "stack28-esxi.admin", 
-    "ora": "stack28-ora.admin",
+    "server": "stack28-ora.admin",
     "ovamac": "00:50:56:00:28:00",
     "pdu": "",
     "type": "esxi"
@@ -298,7 +298,7 @@
     "control": "stack29-control.admin", 
     "data": "stack29-data.admin", 
     "hyper": "stack29-esxi.admin", 
-    "ora": "stack29-ora.admin",
+    "server": "stack29-ora.admin",
     "ovamac": "00:50:56:00:29:00",
     "pdu": "",
     "type": "esxi"
@@ -308,7 +308,7 @@
     "control": "stack30-control.admin", 
     "data": "stack30-data.admin", 
     "hyper": "stack30-esxi.admin", 
-    "ora": "stack30-ora.admin",
+    "server": "stack30-ora.admin",
     "ovamac": "00:50:56:00:30:00",
     "pdu": "",
     "type": "esxi"

--- a/test/fit_tests/run_tests.py
+++ b/test/fit_tests/run_tests.py
@@ -8,7 +8,7 @@ George Paulos
 
 This Script runs nose tests with command-line arguments.
 
-usage: run_tests.py [-h] [-test TEST] [-group GROUP] [-stack STACK] [-ora ORA]
+usage: run_tests.py [-h] [-test TEST] [-group GROUP] [-stack STACK] [-server SERVER]
                     [-version VERSION] [-xunit] [-list] [-sku SKU]
                     [-obmmac OBMMAC | -nodeid NODEID] [-v V]
 
@@ -19,11 +19,9 @@ optional arguments:
   -test TEST        test to execute, default: tests/
   -group GROUP      test group to execute: 'smoke', 'regression', 'extended',
                     default: 'all'
-  -stack STACK      stack label (test bed), overrides -ora
-  -ora ORA          OnRack/RackHD appliance IP address or hostname, default:
+  -stack STACK      stack label (test bed), overrides -server
+  -server SERVER    RackHD appliance IP address or hostname, default:
                     localhost
-  -version VERSION  OnRack version, example:onrack-release-0.3.0, default:
-                    onrack-devel
   -xunit            generates xUnit XML report files
   -list             generates test list only
   -sku SKU          node SKU, example:Phoenix, default=all
@@ -54,13 +52,11 @@ ARG_PARSER.add_argument("-config", default="config",
 ARG_PARSER.add_argument("-group", default="all",
                         help="test group to execute: 'smoke', 'regression', 'extended', default: 'all'")
 ARG_PARSER.add_argument("-stack", default="None",
-                        help="stack label (test bed), overrides -ora")
-ARG_PARSER.add_argument("-ora", default="localhost",
-                        help="OnRack/RackHD appliance IP address or hostname, default: localhost")
-ARG_PARSER.add_argument("-version", default="onrack-devel",
-                        help="OnRack package install version, example:onrack-release-0.3.0, default: onrack-devel")
+                        help="stack label (test bed), overrides -server")
+ARG_PARSER.add_argument("-server", default="localhost",
+                        help="RackHD appliance IP address or hostname, default: localhost")
 ARG_PARSER.add_argument("-template", default=fit_common.GLOBAL_CONFIG['repos']['install']['template'],
-                        help="path or URL link to OVA template or OnRack OVA, default from global_config.json")
+                        help="path or URL link to OVA template, default from global_config.json")
 ARG_PARSER.add_argument("-xunit", default="False", action="store_true",
                         help="generates xUnit XML report files")
 ARG_PARSER.add_argument("-list", default="False", action="store_true",


### PR DESCRIPTION
… address of the Onrack or RackHD server, mostly via the ARGS_LIST dict that contains most of the runtime parameters.

This story will change 'ora' references to 'server' in the following files but still retain ARGS_LIST'ora' as a duplicate of ARGS_LIST'server' for backward compatibility.

Files affected:

common/fit_common.py - defines ARGS_LIST and related stuff.
config/stack_config.json - change keys 'ora' to 'server'
run_tests.py - change 'ora' argument to 'server'
README.md