### PR TITLE
RAC-800 Changed path references from ~/ to {{ ansible_env.HOME }}

### DIFF
--- a/packer/ansible/roles/isc-dhcp-server/tasks/main.yml
+++ b/packer/ansible/roles/isc-dhcp-server/tasks/main.yml
@@ -10,12 +10,12 @@
   sudo: yes
 
 - name: Copy isc-dhcp-server config script to guest
-  copy: src=config_isc-dhcp-server.sh  dest=~/config_isc-dhcp-server.sh mode=0755
+  copy: src=config_isc-dhcp-server.sh  dest="{{ ansible_env.HOME }}/config_isc-dhcp-server.sh" mode=0755
   sudo: yes
 
 
 - name: Retrieve the control nic name, and update the /etc/default/isc-dhcp-server
-  shell: ~/config_isc-dhcp-server.sh
+  shell: "{{ ansible_env.HOME }}/config_isc-dhcp-server.sh"
   sudo: yes
 
 


### PR DESCRIPTION
Bugfix for RAC-800

Ansible RackHD installers were failing on the isc-dhcp-server task when logged in as anything other than root.

Problem is using "~/" in path which is interpreted differently under different circumstances. Should always use "{{ ansible_env.HOME }}" to reference home dir.

One file changed:
packer/ansible/roles/isc-dhcp-server/tasks/main.yml