### PR TITLE
RAC 3712 ansible source installer

### DIFF
--- a/packer/ansible/rackhd_source.yml
+++ b/packer/ansible/rackhd_source.yml
@@ -1,0 +1,25 @@
+---
+- name: Development Server
+  hosts: local
+  sudo: no
+  roles:
+    - apt
+    - build
+    - git
+    - rabbitmq
+    - mongodb
+    - node
+    - isc-dhcp-server
+    - monorail
+    - snmptool
+    - ipmitool
+    - foreman
+    - pm2
+    - localsource
+    - images
+    - swagger
+    - integrationtest
+    - postgresql
+  vars:
+# branch of https://github.com/rackhd/rackhd to be used
+    - branch: "master"

--- a/packer/ansible/roles/localsource/tasks/main.yml
+++ b/packer/ansible/roles/localsource/tasks/main.yml
@@ -7,7 +7,7 @@
   sudo: yes
 
 - name: Install RackHD from local source
-  copy: src="../../{{ item }}" dest="{{ ansible_env.HOME }}/src/{{ item }}"
+  copy: src="../../{{ item }}" dest="{{ ansible_env.HOME }}/src/"
   with_items:
     - on-core
     - on-tasks
@@ -43,6 +43,10 @@
   shell: "npm run apidoc"
   args:
     chdir: "{{ ansible_env.HOME }}/src/on-http"
+
+- file:
+    path: "{{ ansible_env.HOME }}/src/on-http/install-task-doc.sh"
+    mode: 0777
 
 - name: Generate hosted task documentation
   shell: "npm run taskdoc"

--- a/packer/ansible/roles/localsource/tasks/main.yml
+++ b/packer/ansible/roles/localsource/tasks/main.yml
@@ -1,0 +1,45 @@
+---
+- name: install dev libraries for NPM installs
+  apt: pkg={{ item }} state=installed
+  with_items:
+    - libkrb5-dev
+    - unzip
+  sudo: yes
+
+- name: Install RackHD from local source
+  copy: ../../* ansible_env.HOME
+
+- name: Npm install Repos
+  npm: path="{{ ansible_env.HOME }}/src/{{ item }}"
+       production=yes
+  with_items:
+    - on-syslog
+    - on-tftp
+    - on-dhcp-proxy
+    - on-taskgraph
+    - on-http
+    - on-wss
+
+- name: Make common static directory
+  file: path="{{ ansible_env.HOME }}/src/on-http/static/http/common" state=directory
+
+- name: Npm install apidoc
+  shell: "npm install apidoc"
+  args:
+    chdir: "{{ ansible_env.HOME }}/src/on-http"
+
+- name: Render 1.1 API docs for local reference
+  shell: "npm run apidoc"
+  args:
+    chdir: "{{ ansible_env.HOME }}/src/on-http"
+
+- name: Generate hosted task documentation
+  shell: "npm run taskdoc"
+  args:
+    chdir: "{{ ansible_env.HOME }}/src/on-http"
+
+- name: set HTTP static directory for RackHD
+  set_fact: http_static_directory="{{ ansible_env.HOME }}/src/on-http/static/http"
+
+- name: set TFTP static directory for RackHD
+  set_fact: tftp_static_directory="{{ ansible_env.HOME }}/src/on-tftp/static/tftp"

--- a/packer/ansible/roles/localsource/tasks/main.yml
+++ b/packer/ansible/roles/localsource/tasks/main.yml
@@ -7,7 +7,18 @@
   sudo: yes
 
 - name: Install RackHD from local source
-  copy: ../../* ansible_env.HOME
+  copy: src="../../{{ item }}" dest="{{ ansible_env.HOME }}/src/{{ item }}"
+  with_items:
+    - on-core
+    - on-tasks
+    - on-http
+    - on-tftp
+    - on-dhcp-proxy
+    - on-taskgraph
+    - on-syslog
+    - on-wss
+    - on-tools
+    - on-imagebuilder
 
 - name: Npm install Repos
   npm: path="{{ ansible_env.HOME }}/src/{{ item }}"

--- a/test/fit_tests/deploy/rackhd_source_install.py
+++ b/test/fit_tests/deploy/rackhd_source_install.py
@@ -123,7 +123,7 @@ class rackhd_source_install(fit_common.unittest.TestCase):
         print "**** Run RackHD Ansible installer."
         self.assertEqual(fit_common.remote_shell(PROXYVARS +
                                                  "cd ~/rackhd/packer/ansible/;"
-                                                 "ansible-playbook -i 'local,' -c local rackhd_local.yml",
+                                                 "ansible-playbook -i 'local,' -c local rackhd_source.yml",
                                                  timeout=2000,
                                                  )['exitcode'], 0, "RackHD Install failure.")
 


### PR DESCRIPTION
RAC-3712: This PR creates a new Ansible installer playbook that installs RackHD from the local source tree. This is needed to support installation from a selected PR or development branch from FIT deployment. The script rackhd_source_install.py creates the source tree from a repo list, the playbook rackhd_source.yml then uses that source instance to install RackHD.

@RackHD/corecommitters 
@hohene 
@johren 
@diontje 
