### PR TITLE
Add the ConfigAdminIP step to other ansible scripts

### DIFF
--- a/packer/ansible/rackhd_ci_builds.yml
+++ b/packer/ansible/rackhd_ci_builds.yml
@@ -11,6 +11,7 @@
     - node
     - isc-dhcp-server
     - monorail
+    - config_admin_ip
     - snmptool
     - ipmitool
     - integrationtest

--- a/packer/ansible/rackhd_release.yml
+++ b/packer/ansible/rackhd_release.yml
@@ -11,6 +11,7 @@
     - node
     - isc-dhcp-server
     - monorail
+    - config_admin_ip
     - snmptool
     - ipmitool
     - integrationtest


### PR DESCRIPTION
@changev @PengTian0 

Background:
the motivation of ConfigAdminIP feature  can be refereed in https://github.com/RackHD/RackHD/pull/484
later , more ansible playbook was introduced but this ConfigAdminIP feature didn't get into them.

FAQ:
it will not impact user who directlly run ansible-playbook ( not packer). the configAdminIP scripts during system startup will exist, because VMWareTool will not detect any OVF Template Variable.

What's Test:

use Jenkins job to build OVA using ansible ```rackhd_ci_builds.yml```
http://rackhdci.lss.emc.com/job/Maglev-BRI-Test/job/BuildRelease/job/ova-build/33/console