### PR TITLE
Kill dhcp attempt during first boot, if user assign admin ip in ovf template

### DIFF
--- a/packer/HWIMO-BUILD
+++ b/packer/HWIMO-BUILD
@@ -227,6 +227,7 @@ fi
 #  Reference: http://www.v-front.de/2014/01/building-self-configuring-nested-esxi.html
 #
 ###################################################################
+rm -f $"${BASENAME}.mf" # remove checksum file, otherwise, existing mf file will prevent ovftool coverting
 echo "covert to OVF"
 OVF=$"${BASENAME}.ovf"
 ovftool $OVA  $OVF

--- a/packer/ansible/rackhd_ci_builds.yml
+++ b/packer/ansible/rackhd_ci_builds.yml
@@ -11,6 +11,7 @@
     - node
     - isc-dhcp-server
     - monorail
+    - config_admin_ip
     - snmptool
     - ipmitool
     - integrationtest

--- a/packer/ansible/rackhd_release.yml
+++ b/packer/ansible/rackhd_release.yml
@@ -11,6 +11,7 @@
     - node
     - isc-dhcp-server
     - monorail
+    - config_admin_ip
     - snmptool
     - ipmitool
     - integrationtest

--- a/packer/ansible/roles/config_admin_ip/files/config_IP_with_OVF_ENV.sh
+++ b/packer/ansible/roles/config_admin_ip/files/config_IP_with_OVF_ENV.sh
@@ -156,6 +156,13 @@ then
     # add new primary setting( use echo ${PRIM_ETH_CFG} to eliminate the newlines to make 'sed' happy
     sed -i "s/iface lo inet loopback/iface lo inet loopback\n$( echo ${PRIM_ETH_CFG})/"  ${target_file}
     # Force restart primary nic ###
+    if [[ -f /run/network/ifup-${PRI_ETH}.pid ]]
+    then
+       DHCP_PID=$(cat /run/network/ifup-${PRI_ETH}.pid )
+       echo "process ${DHCP_PID} is already running to get DHCP for ${PRI_ETH}. But because user assign static IP ${IP}, so force kill the DHCP process.."
+       kill -9 ${DHCP_PID}
+       sleep 2  # wait a while for clean killing
+    fi
     ifdown ${PRI_ETH}
     ifup ${PRI_ETH}
 else


### PR DESCRIPTION
It depends on https://github.com/RackHD/RackHD/pull/530

-----

**Background**
the "IP setting from OVF Template" feature sometimes fail in 14.04 VM, for first boot.
error signature: 
the ifdown/ifup in ```packer/ansible/roles/config_admin_ip/files/config_IP_with_OVF_ENV.sh``` is very slow and finally fail.
error message:
```Ifdown : waiting for lock on /run/network/ifstate.eth0```

----

**root cause**

in Ubuntu 14.04, /etc/init/network**.conf will "ifup" the eth0 during booup( trying DHCP) , and it's non-blocking operation. 
so if eth0 in a non-DHCP network, the DHCP attemp will last for 5 mins(?). so even system boot up when login prompt shown, the "ifup"  process still running in the background.
the latter ifdown/ifup operation will fail.(  in the /run/network/ folder, it will shows eth0 stilling being cofig.  ```/run/network/ifup.eth0.pid``` )

---

Implementation:

:-)
```kill -9 $(cat /run/network/ifup.eth0.pid )```

---

Impact to 16.04

No impact. 16.04 systemd starting primary NIC, the DHCP process will be blocking (during boot up , it will wait as below )
![image](https://cloud.githubusercontent.com/assets/14049268/21248571/d90c5ea2-c372-11e6-99c8-23bf3ac3a13d.png)
so once the ```packer/ansible/roles/config_admin_ip/files/config_IP_with_OVF_ENV.sh```  invoked, the /run/network/ifup.ens32.pid will not exist. so script exits, no side-effect impact.


---

Test:

tested on 14.04 OVA and 16.04 OVA.


---

Jenkins:  depends on https://github.com/RackHD/RackHD/pull/530