### PR TITLE
Encapsulate config.ini inside global_config.json.

### DIFF
--- a/test/common/fit_common.py
+++ b/test/common/fit_common.py
@@ -877,6 +877,7 @@ def run_nose(nosepath):
                              'export HTTP=' + str(ARGS_LIST['http']) + ';' +
                              'export HTTPS=' + str(ARGS_LIST['https']) + ';' +
                              'export PORT=' + str(ARGS_LIST['port']) + ';' +
+                             'export FIT_CONFIG=' + CONFIG_PATH + "global_config.json" + ';' +
                              'nosetests ' + noseopts + ' --xunit-file ' + xmlfile + ' ' + pathspec
                          ], shell=True)
     exitcode = 0

--- a/test/config/auth.py
+++ b/test/config/auth.py
@@ -2,5 +2,5 @@ from settings import defaults
 
 SSH_USER = defaults['RACKHD_SSH_USER']
 SSH_PASSWORD = defaults['RACKHD_SSH_PASSWORD']
-SSH_PORT = defaults['RACKHD_SSH_PORT']
-USER_AUTH_PORT = defaults['RACKHD_USER_AUTH_PORT']
+SSH_PORT = str(defaults['RACKHD_SSH_PORT'])
+USER_AUTH_PORT = str(defaults['RACKHD_USER_AUTH_PORT'])

--- a/test/config/global_config.json
+++ b/test/config/global_config.json
@@ -1,4 +1,30 @@
 {
+  "cit-config": {
+    "_comment": "CIT-specific configuration",
+    "RACKHD_TEST_LOGLVL": "WARNING",
+    "RACKHD_HOST": "localhost",
+    "RACKHD_PORT": 9090,
+    "RACKHD_PORT_AUTH": 9093,
+    "RACKHD_HTTPD_PORT": 9010,
+    "RACKHD_AMQP_URL": "amqp://localhost:9091",
+    "RACKHD_SSH_USER": "vagrant",
+    "RACKHD_SSH_PASSWORD": "vagrant",
+    "RACKHD_SSH_PORT": 2222,
+    "RACKHD_USER_AUTH_PORT": 8443,
+    "RACKHD_GLOBAL_OBM_SERVICE_NAME": "ipmi-obm-service",
+    "RACKHD_BASE_REPO_URL": "http://172.31.128.1:8080",
+    "RACKHD_SMB_USER": "onrack",
+    "RACKHD_SMB_PASSWORD": "onrack",
+    "RACKHD_SMB_WINDOWS_REPO_PATH": "\\172.31.128.1\\windowsServer2012",
+    "RACKHD_SAMPLE_PAYLOADS_PATH": "../example/samples/",
+    "RACKHD_CENTOS_REPO_PATH": "http://172.31.128.1:8080/repo/centos",
+    "RACKHD_ESXI_REPO_PATH": "http://172.31.128.1:8080/repo/esxi",
+    "RACKHD_UBUNTU_REPO_PATH": "http://172.31.128.1:8080/repo/ubuntu",
+    "RACKHD_SUSE_REPO_PATH": "http://172.31.128.1:8080/repo/suse",
+    "RACKHD_WINPE_REPO_PATH": "http://172.31.128.1:8080/repo/winpe",
+    "RACKHD_REDFISH_URL": "https://192.168.1.100/redfish/v1",
+    "RACKHD_REDFISH_EMC_OEM": false
+  },
   "credentials": {
     "_comment": "This is the list of credentials for each type of node or service",
     "hyper": [

--- a/test/config/settings.py
+++ b/test/config/settings.py
@@ -2,18 +2,28 @@ from imp import load_source
 from getpass import getpass
 from base64 import b64encode, b64decode
 import logging
+import json
 import os, sys
 import ConfigParser
 
-CONFIG = 'config/config.ini'
-for v in sys.argv:
-    if 'config' in v:
-        CONFIG = v.split('=')[1:]
-config_parser = ConfigParser.RawConfigParser()
-config_parser.read(CONFIG)
-defaults = {}
-for k,v in config_parser.items('DEFAULT'):
-    defaults[k.upper()] = v
+# Check for fit-based configuration
+CONFIG = os.environ.get('FIT_CONFIG', None)
+if CONFIG:
+    # Load FIT configuration (.json format)
+    with open(CONFIG) as config_file:
+        config_blob = json.load(config_file)
+        defaults = config_blob['cit-config']
+else:
+    # Load CIT configuration (.ini format)
+    CONFIG = 'config/config.ini'
+    for v in sys.argv:
+        if 'config' in v:
+            CONFIG = v.split('=')[1:]
+    config_parser = ConfigParser.RawConfigParser()
+    config_parser.read(CONFIG)
+    defaults = {}
+    for k,v in config_parser.items('DEFAULT'):
+        defaults[k.upper()] = v
 
 HOST_IP = defaults['RACKHD_HOST']
 HOST_PORT = defaults['RACKHD_PORT']


### PR DESCRIPTION
This is a change that moves towards combining cit and fit
configurations.  This will not be the final solution but allows
both cit and fit to read from a common file.

Note: if any Jenkins jobs are using 'run.py --config=X.ini', we will need to update those to make use of the different configuration file.

Tested with:

python run.py --show-plan
python run.py --group="pollers_api2.tests"
python run.py --config="local.json" --group="pollers_api2.tests"
python run_tests.py -stack 1 -test util/display_rackhd_nodes.py
python run_tests.py -stack 1 -test deploy/rackhd_stack_init.py -list
python run_tests.py -stack 1 -test tests/compute/test_rackhd11_computenode_pollers.py


@RackHD/corecommitters @gpaulos @johren @larry-dean  @stuart-stanley @amymullins 