### PR TITLE
rac-3802 bring larval logging and stream monitors to public space

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,7 @@
+on-skupack
+myenv_*
+log_output
+startup.sh
+nohup.out
+*~
+auth.json

--- a/test/HWIMO-BUILD
+++ b/test/HWIMO-BUILD
@@ -56,14 +56,8 @@ fi
 # create virtual environment in tests/myenv_hwimobuild
 echo "Installing Virtual Environment..."
 rm -rf myenv_hwimobuild
-virtualenv --no-site-packages myenv_hwimobuild
-source myenv_hwimobuild/bin/activate
-echo "Installing Python Modules..."
-pip install -r requirements.txt > pipinstall.log
-if [ $? != 0 ]
-then
-  cat pipinstall.log
-fi
+./mkenv.sh hwimobuild
+source myenv_hwimobuild
 
 set -x
 set -o pipefail

--- a/test/README.md
+++ b/test/README.md
@@ -20,9 +20,8 @@ Test harness may be run on appliance host (localhost), or third party machine.
 Deployment scripts must be run under third party Ubuntu Linux host.
 Tests require the following virtual environment commands be executed:
 
-    virtualenv .venv
-    source .venv/bin/activate
-    pip install -r requirements.txt
+    ./mkenv.sh
+    source myenv_fit
 
 
 ## Directory Organization
@@ -32,6 +31,8 @@ The FIT test framework is under RackHD/test
 - 'tests' is the test 'harness'
 - 'common' contains any common library functions
 - 'deploy' contains deployment and installation scripts
+- 'stream-monitor' contains a nose-plugin to help with monitoring various
+   streams (logs/amqp) and providing services around that
 - 'templates' contains script templates for making new tests
 - 'util' contains non-test utilities
 
@@ -141,8 +142,9 @@ Use the following commands to initialize the server and run a Smoke Test:
 
     vagrant ssh dev
     sudo bash
-    source .venv/bin/activate
     cd fit_tests/test
+    ./mkenv.sh vagrant
+    source myenv_vagrant
     python run_tests.py -stack vagrant -test deploy/rackhd_stack_init.py -v 4
     python run_tests.py -test tests -group smoke
 

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -30,10 +30,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             sudo apt-get -y update
             sudo apt-get -y install python-pip
             sudo apt-get -y install virtualenv
-            virtualenv .venv
-            source .venv/bin/activate
-            pip install -r fit_tests/requirements.txt
             cd fit_tests/test
+            ./mkenv.sh vagrant
+            source myenv_vagrant
             python run_tests.py -test deploy/rackhd_source_install.py -v 9
             python run_tests.py -test deploy/rackhd_stack_init.py:rackhd_stack_init.test01_preload_sku_packs -stack vagrant -v 9
         SHELL

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,15 +1,25 @@
 amqp==1.4.8
+ansible==1.8.4
 anyjson==0.3.3
-kombu==3.0.30
-logging==0.4.9.6
+gevent==1.1.2
+greenlet==0.4.10
 jsonmerge==1.2.1
 jsonschema==2.4.0
-proboscis==1.2.6.0
-requests==2.9.0
+kombu==3.0.30
 nose==1.3.7
 nosedep>=0.4
-pexpect==3.3
 on-http_api1_1>=1.0.0
 on-http_api2_0>=1.0.2
 on_http_redfish_1_0>=1.0.0
-ansible==1.8.4
+pexpect==3.3
+proboscis==1.2.6.0
+requests==2.9.0
+
+# WARNING: do not just replace this file with "pip freeze > requirements.txt".
+# You need to keep the following line as is! (freeze will turn it into
+# a https/git reference)
+-e stream-monitor
+
+# WARNING: there is an ubuntu bug that causes a bad package to get listed when doing a freeze.
+#  Do NOT add 'package-resources==0.0.0' if you see it! I also see 'wheel=nnnnnn' showing up at times.
+#  That's kind of infra also, so don't add it either!

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 '''
 Copyright 2016, EMC, Inc

--- a/test/setup.cfg
+++ b/test/setup.cfg
@@ -1,0 +1,3 @@
+[nosetests]
+with-stream-monitor=1
+exe=1

--- a/test/stream-monitor/.gitignore
+++ b/test/stream-monitor/.gitignore
@@ -1,0 +1,1 @@
+stream_monitors.egg-info/

--- a/test/stream-monitor/README.md
+++ b/test/stream-monitor/README.md
@@ -1,0 +1,22 @@
+# observer plugin for nose
+
+To run right now:
+./mkenv.sh
+source myenv_fit
+nosetests -v
+
+
+Note, if you want to be able to work with the code "live" (rather 
+than running nosetest on the working), do a
+python setup.py develop
+
+This will allow you to do stuff like:
+python
+>>> import sm_plugin
+
+and so on. The 'develop' mode sets stuff up so that you work on the
+code and it is instantly reflected in the environment rather than
+having to reinstall it over and over again.
+
+
+

--- a/test/stream-monitor/flogging/__init__.py
+++ b/test/stream-monitor/flogging/__init__.py
@@ -1,0 +1,5 @@
+from infra_logging import *
+from logger_sets import get_loggers
+
+all = ['getLogger', 'getInfraRunLogger', 'getInfraDataLogger',
+       'getTestRunLogger', 'getTestDataLogger', 'get_loggers', 'logger_config_api']

--- a/test/stream-monitor/flogging/infra_logging.py
+++ b/test/stream-monitor/flogging/infra_logging.py
@@ -94,6 +94,7 @@ class _LevelLoggerClass(Logger):
 
 
 class _LoggerSetup(object):
+    _SAVED_LOGDIR_COUNT=10
     def __init__(self):
         self.__prelog_data = []
         self.__do_dirs()
@@ -135,7 +136,7 @@ class _LoggerSetup(object):
                 matches[key] = file_name
 
         keys = sorted(matches.keys(), reverse=True)
-        trim_these = keys[3:]
+        trim_these = keys[self._SAVED_LOGDIR_COUNT:]
         for trim_inx in trim_these:
             trim_name = os.path.join(lg_base_dir, matches[trim_inx])
             self.__prelog(logging.INFO, 'removing previous logging dir %s', trim_name)

--- a/test/stream-monitor/flogging/infra_logging.py
+++ b/test/stream-monitor/flogging/infra_logging.py
@@ -1,0 +1,326 @@
+"""
+Copyright 2016, EMC, Inc.
+
+This file contains the mechanisms to do logging from within
+the test infrastructure.
+
+todo: this is the 1st shot. More stories are stacked up to add readmes, examples, et al.
+"""
+from logging import Logger, setLoggerClass, _levelNames, addLevelName
+from datetime import datetime
+import logging
+import logging.config
+import logging.handlers
+import re
+import gevent
+import os
+import errno
+import shutil
+
+import sys
+
+class _GeventInfoFilter(logging.Filter):
+    _main_greenlet = gevent.getcurrent()
+    def __init__(self, *args, **kwargs):
+        super(_GeventInfoFilter, self).__init__(*args, **kwargs)
+
+        # determine the root of the tree we are running from. Quick and
+        # ugly right now (might be nice to 'hunt' upwards for root files etc,
+        # but since this particular file is not likely to move around, this
+        # may be all we need.
+        our_dir = os.path.dirname(os.path.abspath(__file__))
+        # pop up two levels to the 'fit_tests' directory.
+        test_dir = os.path.dirname(os.path.dirname(our_dir))
+        self.__path_trim = test_dir + '/'
+
+    # todo: trim 'pathname' to root of tree, not global
+    #  and log shortening event (to keep abs context)
+    # todo: add logger name to output
+    def filter(self, record):
+        pname = record.pathname
+        if record.pathname.startswith(self.__path_trim):
+            record.pathname = record.pathname[len(self.__path_trim):]
+        cur = gevent.getcurrent()
+        if cur == self._main_greenlet:
+            gname = 'gl-main'
+        else:
+            gname = getattr(cur, 'log_facility', str(cur))
+        record.greenlet = '{0!s}'.format(gname)
+        return True
+
+
+class _LevelLoggerClass(Logger):
+    _log_call_matcher = re.compile(r'''^(?P<base>[a-zA-Z]\w*?)_(?P<post_num>\d)$''')
+    def __getattr__(self, key):
+        """
+        We intercept getattrs and map look for entries of the form:
+          levelname_0 to levelname_9 and map them to a call to self._log at that
+        the base level for levelname plus or minus the value of the _n part
+        of the attribute. An example is easier to understand:
+        A Logger instance has a .debug() method, which uses the int value
+        of DEBUG to check/emit. DEBUG happens to be equal to the int 10.
+        debug_0 ends up mapping to the int value 10 (DEBUG - 0)
+        debug_5 ends up mapping to the int value 5  (DEBUG - 5)
+        debug_9 ends up mapping to the int value 1  (DEBUG - 9)
+
+        Since the logging system treats higher int values as "more important"
+        (e.g. CRITICAL is 50), this means debug_9 would be used to represent
+        finer-grained (more detailed) information than straight DEBUG.
+
+        This code matches anything for the form alpha-chars_n, which ends
+        up handling the following methods:
+        critical, fatal, error, warning, warn, info, debug, exception
+
+        Note that those base methods are resolved directly, and this method
+        is not called for those.
+        """
+        attr_match = self._log_call_matcher.match(key)
+        if attr_match is None:
+            m = "'{0}' object has no attribute '{1}'".format(self.__name__, key)
+            raise AttributeError(m)
+
+        base_name = attr_match.group("base").upper()
+        val_adj = int(attr_match.group("post_num"))
+        actual_value = _levelNames[base_name] - val_adj
+
+        def wrapper(msg, *args, **kw):
+            return self._log(actual_value, msg, args, kw)
+
+        # We return a wrapper function, since we are being asked to resolve
+        # the method, not call it. The above wrapper allows us to return
+        # something callable that still allows us to inject the calculated
+        # level-value.
+        return wrapper
+
+
+class _LoggerSetup(object):
+    def __init__(self):
+        self.__prelog_data = []
+        self.__do_dirs()
+        self.__do_level_names()
+        self.__do_config()
+        lg = getInfraRunLogger()
+        for level, fmat, args, kwargs in self.__prelog_data:
+            lg.log(level, fmat, *args, **kwargs)
+
+    def __prelog(self, level, fmat, *args, **kwargs):
+        self.__prelog_data.append( (level, fmat, args, kwargs) )
+
+    def __makedirs_dash_p(self, *args, **kwargs):
+        try:
+            os.makedirs(*args, **kwargs)
+        except OSError, e:
+            # be happy if someone already created the path
+            if e.errno != errno.EEXIST:
+                raise
+
+    def __do_dirs(self):
+        our_dir = os.path.dirname(os.path.abspath(__file__))
+        test_dir = os.path.dirname(os.path.dirname(our_dir))
+        lg_base_dir = os.path.join(test_dir, 'log_output')
+        self.__makedirs_dash_p(lg_base_dir)
+        dirs_in_log = os.listdir(lg_base_dir)
+        matcher = re.compile(r'''^                            # SOL
+                             run_                             # 'run_'
+                             (?P<run_date>\d\d\d\d-\d\d-\d\d  # 2016-11-18
+                             _                                # '_'
+                             \d\d:\d\d:\d\d)                  # 23:11:00
+                             \.d$''',                         # '.d' EOL
+                             re.VERBOSE)
+        matches = {}
+        for file_name in dirs_in_log:
+            m = matcher.match(file_name)
+            if m is not None:
+                key = m.group("run_date")
+                matches[key] = file_name
+
+        keys = sorted(matches.keys(), reverse=True)
+        trim_these = keys[3:]
+        for trim_inx in trim_these:
+            trim_name = os.path.join(lg_base_dir, matches[trim_inx])
+            self.__prelog(logging.INFO, 'removing previous logging dir %s', trim_name)
+            shutil.rmtree(trim_name)
+
+        ts_ext = datetime.now().strftime('%Y-%m-%d_%X')
+        self.__lg_run_dir = os.path.join(lg_base_dir, 'run_{0}.d'.format(ts_ext))
+        self.__prelog(logging.INFO, "this runs logging dir %s", self.__lg_run_dir)
+        self.__makedirs_dash_p(os.path.join(self.__lg_run_dir))
+
+        # now deal with and easy to use 'last'
+        last_name = os.path.join(lg_base_dir, 'run_last.d')
+        if os.path.islink(last_name):
+            os.unlink(last_name)
+
+        assert not os.path.lexists(last_name), \
+            "'{0}' still existed after unlink. Check for file/dir and remove manually".format(last_name)
+        os.symlink(self.__lg_run_dir, last_name)
+
+        self.__infra_run_lgn = os.path.join(self.__lg_run_dir, 'infra_run.log')
+        self.__infra_data_lgn = os.path.join(self.__lg_run_dir, 'infra_data.log')
+        self.__test_run_lgn = os.path.join(self.__lg_run_dir, 'test_run.log')
+        self.__test_data_lgn = os.path.join(self.__lg_run_dir, 'test_data.log')
+        # all_all -> both _infra and _test AND both _run and _data.
+        self.__combined_all_all_lgn = os.path.join(self.__lg_run_dir, 'all_all.log')
+        self.__console_capture_lgn = os.path.join(self.__lg_run_dir,
+                                                  'console_capture.log')
+
+    def __do_level_names(self):
+        lvl_copy = dict(_levelNames)
+        for adj in xrange(0,10):
+            for lvl_key, lvl_value in lvl_copy.items():
+                if isinstance(lvl_key, str) and lvl_key != 'NOTSET':
+                    new_name = "{0}_{1}".format(lvl_key, adj)
+                    new_val = lvl_value - adj
+                    # Note: we can't insert our overlap (DEBUG_0 == DEBUG)
+                    # here without changing what _appears_ in the log to be the _0
+                    # version. We let __getattr__ mapping handle this case.
+                    if new_val != lvl_value:
+                        addLevelName(new_val, new_name)
+
+    def __do_config(self):
+        # todo: NOT have this stuff show up in nosetests w/o -v or something
+        # base config dict. Must conform to
+        # https://docs.python.org/2/library/logging.config.html#logging-config-dictschema
+        cdict = {
+            'version': 1,
+            'filters': {
+                'ctx_add_filter': {
+                    '()' : _GeventInfoFilter
+                }
+            },
+            'handlers': {
+                'console': {
+                    # catch all. May not need to exist?
+                    'level': 'INFO',
+                    'class': 'logging.StreamHandler',
+                    'filters': ['ctx_add_filter'],
+                    'formatter': 'simple'
+                },
+                'console-capture': {
+                    'level': 'INFO',
+                    'class': 'logging.handlers.RotatingFileHandler',
+                    'filename': self.__console_capture_lgn,
+                    'filters': ['ctx_add_filter'],
+                    'formatter': 'simple'
+                },
+                'infra-run': {
+                    # the test infrastructure code (not the tests themselves)
+                    # I.E., like logging about logging :)
+                    'level': 'DEBUG',
+                    'class': 'logging.handlers.RotatingFileHandler',
+                    'filename': self.__infra_run_lgn,
+                    'filters': ['ctx_add_filter'],
+                    'formatter': 'simple'
+                },
+                'infra-data': {
+                    # test infra data. for example, storing of expect stuff
+                    'level': 'DEBUG',
+                    'class': 'logging.handlers.RotatingFileHandler',
+                    'filename': self.__infra_data_lgn,
+                    'filters': ['ctx_add_filter'],
+                    'formatter': 'simple'
+                },
+                'test-run': {
+                    # test-run code. I.E., where tests can say "I'm doing X"
+                    'level': 'DEBUG',
+                    'class': 'logging.handlers.RotatingFileHandler',
+                    'filename': self.__test_run_lgn,
+                    'filters': ['ctx_add_filter'],
+                    'formatter': 'simple'
+                },
+                'test-data': {
+                    # raw data from actual tests. Like the infra-data
+                    'level': 'DEBUG',
+                    'class': 'logging.handlers.RotatingFileHandler',
+                    'filename': self.__test_data_lgn,
+                    'filters': ['ctx_add_filter'],
+                    'formatter': 'simple'
+                },
+                'combined-all-all': {
+                    # put the works into a single file
+                    'level': 'DEBUG',
+                    'class': 'logging.handlers.RotatingFileHandler',
+                    'filename': self.__combined_all_all_lgn,
+                    'filters': ['ctx_add_filter'],
+                    'formatter': 'simple'
+                },
+            },
+            'loggers': {
+                '': {
+                    'handlers': ['console', 'console-capture'],
+                    'propagate': True,
+                    'level': 'INFO',
+                    'stream': 'ext://sys.stdout'
+                },
+                'infra.run': {
+                    'handlers': ['infra-run', 'combined-all-all'],
+                    'propagate': True,
+                    'level': 'DEBUG',
+                },
+                'infra.data': {
+                    'handlers': ['infra-data', 'combined-all-all'],
+                    'propagate': True,
+                    'level': 'DEBUG',
+                },
+                'test.run': {
+                    'handlers': ['test-run', 'combined-all-all'],
+                    'propagate': True,
+                    'level': 'DEBUG',
+                },
+                'test.data': {
+                    'handlers': ['test-data', 'combined-all-all'],
+                    'propagate': True,
+                    'level': 'DEBUG',
+                }
+            },
+            'formatters': {
+                'simple': {
+                    'format': '%(asctime)s %(process)d %(processName)s '
+                              '%(pathname)s:%(funcName)s@%(lineno)d %(greenlet)s %(levelname)s %(message)s'
+                }
+            }
+        }
+        logging.config.dictConfig(cdict)
+        # And squelch the annoying root level urllib messages!
+        # (you do need both, alas). 
+        # todo: record this traffic in its own logfile?
+        logging.getLogger("urllib3").setLevel(logging.WARNING)
+        logging.getLogger("requests").setLevel(logging.WARNING)
+
+    def set_level(self, new_level):
+        pass
+
+
+setLoggerClass(_LevelLoggerClass)
+
+def getLogger(name=None):
+    if name is None:
+        rl = logging.getLogger()
+    else:
+        rl = logging.getLogger(name)
+    #rl = _GeventInfoAdapter(rl, {})
+    return rl
+
+def _getLoggerBase(names, name):
+    if name is not None:
+        names.append(name)
+    return getLogger('.'.join(names))
+
+def getInfraRunLogger(name=None):
+    return _getLoggerBase(['infra', 'run'], name)
+
+def getInfraDataLogger(name=None):
+    return _getLoggerBase(['infra', 'data'], name)
+
+def getTestRunLogger(name=None):
+    return _getLoggerBase(['test', 'run'], name)
+
+def getTestDataLogger(name=None):
+    return _getLoggerBase(['test', 'data'], name)
+
+
+_logger_setup_instance = _LoggerSetup()
+
+def logger_config_api(verbosity):
+    _logger_setup_instance.set_level(verbosity)
+

--- a/test/stream-monitor/flogging/logger_sets.py
+++ b/test/stream-monitor/flogging/logger_sets.py
@@ -1,0 +1,32 @@
+"""
+Copyright 2017, EMC, Inc.
+"""
+from .infra_logging import *
+
+# todo: document API (especially for common aka test-writer actor)
+class _LoggerSet(object):
+    def __init__(self, name=None):
+        self.irl = getInfraRunLogger(name=name)
+        self.idl = getInfraDataLogger(name=name)
+        self.trl = getTestRunLogger(name=name)
+        self.tdl = getTestDataLogger(name=name)
+        self.data_log = self.tdl
+
+    def __getattr__(self, key):
+        """
+        Complete hack mode to present a logging.Logger style
+        api with test-run-logger being the target. E.G.
+        x = _LoggerSet()
+        x.debug(...) is equiv to x.trl.debug(...)
+        """
+        if hasattr(self.trl, key):
+            return getattr(self.trl, key)
+
+        m = "'{0}' object has no attribute '{1}'".format(self.__name__, key)
+        raise AttributeError(m)
+
+
+def get_loggers(name=None):
+    # todo: auto-push test-file name into the name of the logger
+    return _LoggerSet(name=name)
+

--- a/test/stream-monitor/mkenv.sh
+++ b/test/stream-monitor/mkenv.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2015-2016, EMC, Inc.
+# Copyright 2016, EMC, Inc.
 
 #
 # Run this without options to create a virtual

--- a/test/stream-monitor/requirements.txt
+++ b/test/stream-monitor/requirements.txt
@@ -1,0 +1,4 @@
+gevent==1.1.2
+greenlet==0.4.10
+nose==1.3.7
+wheel==0.24.0

--- a/test/stream-monitor/setup.py
+++ b/test/stream-monitor/setup.py
@@ -1,0 +1,25 @@
+"""
+todo: add
+"""
+try:
+    import ez_setup
+    ez_setup.use_setuptools()
+except ImportError:
+    pass
+
+from setuptools import setup
+
+setup(
+    name='stream monitors',
+    version='0.1',
+    author='Stuart Stanley',
+    author_email = 'stuart.stanley@dell.com',
+    description = 'Stream-monitors and test-log-groupers',
+    license = 'Apache 2.0',
+    packages = ['sm_plugin', 'stream_sources', 'flogging'],
+    entry_points = {
+        'nose.plugins.0.10': [
+            'stream_monitor = sm_plugin:StreamMonitorPlugin'
+            ]
+        }
+    )

--- a/test/stream-monitor/sm_plugin/__init__.py
+++ b/test/stream-monitor/sm_plugin/__init__.py
@@ -1,0 +1,3 @@
+from stream_monitor import StreamMonitorPlugin
+
+__all__ = [ 'StreamMonitorPlugin' ]

--- a/test/stream-monitor/sm_plugin/stream_monitor.py
+++ b/test/stream-monitor/sm_plugin/stream_monitor.py
@@ -1,0 +1,80 @@
+import logging
+import os
+from nose.plugins import Plugin
+from stream_sources import LoggingMarker
+import sys
+
+
+class StreamMonitorPlugin(Plugin):
+    _singleton = None
+    name = "stream-monitor"
+    def __init__(self, *args, **kwargs):
+        assert StreamMonitorPlugin._singleton is None, \
+            "infrastructure fault: more than one StreamMonitorPlugin exists"
+        StreamMonitorPlugin._singleton = self
+        self.__save_call_sequence = None
+        self.__print_to = None
+        # Uncomment next line to view steps to console live
+        # self.__print_to = sys.stderr
+        # todo: use nose plugin debug options.
+        self.__stream_plugins = {}
+        super(StreamMonitorPlugin, self).__init__(*args, **kwargs)
+
+    def _self_test_print_step_enable(self):
+        self.__save_call_sequence = []
+
+    def _self_test_sequence_seen(self):
+        rl = self.__save_call_sequence
+        self.__save_call_sequence = []
+        return rl
+
+    def __take_step(self, name, **kwargs):
+        if self.__save_call_sequence is not None:
+            self.__save_call_sequence.append((name, kwargs))
+
+        if self.__print_to is not None:
+            print >>self.__print_to, 'ESTEP: {0} {1}'.format(name, kwargs)
+
+    def options(self, parser, env=os.environ):
+        self.__take_step('options', parser=parser, env=env)
+        self.__log = logging.getLogger('nose.plugins.streammonitor')
+        super(StreamMonitorPlugin, self).options(parser, env=env)
+
+    def configure(self, options, conf):
+        self.__take_step('configure', options=options, conf=conf)
+        super(StreamMonitorPlugin, self).configure(options,conf)
+        if not self.enabled:
+            return
+        if conf.options.collect_only:
+            # we don't want to be spitting stuff out during -list!
+            self.enabled = False
+
+    def finalize(self, result):
+        self.__take_step('finalize', result=result)
+        self.__log.info('Stream Monitor Report Complete')
+
+    def begin(self):
+        self.__take_step('begin')
+        # tood: check class "enabled_for_nose()"
+        if len(self.__stream_plugins) == 0:
+            self.__stream_plugins['logging'] = LoggingMarker()
+
+        for pg in self.__stream_plugins.values():
+            pg.handle_begin()
+
+    def beforeTest(self, test):
+        # order is beforeTest->startTest->stopTest->afterTest
+        self.__take_step('beforeTest', test=test)
+
+    def afterTest(self, test):
+        self.__take_step('afterTest', test=test)
+
+    def startTest(self, test):
+        self.__take_step('startTest', test=test)
+        for pg in self.__stream_plugins.values():
+            pg.handle_start_test(test)
+
+    def stopTest(self, test):
+        self.__take_step('stopTest', test=test)
+        for pg in self.__stream_plugins.values():
+            pg.handle_stop_test(test)

--- a/test/stream-monitor/stream_sources/__init__.py
+++ b/test/stream-monitor/stream_sources/__init__.py
@@ -1,0 +1,1 @@
+from log_type import LoggingMarker

--- a/test/stream-monitor/stream_sources/log_type.py
+++ b/test/stream-monitor/stream_sources/log_type.py
@@ -1,0 +1,100 @@
+from logging import Logger, DEBUG, INFO, getLoggerClass
+from logging import getLogger as real_getLogger
+from logging import _srcfile  # yes, this is evil. No, we don't have a choice.
+from .monitor_abc import StreamMonitorABC
+import sys
+
+class LoggingMarker(StreamMonitorABC):
+    _all_blocks = 0
+    def __init__(self):
+        # import HERE to prevent taking over logfiles for things
+        # like 'nosetests --help'.
+        import flogging
+        self.__print_to = None
+        # Uncomment next line to view steps to console live
+        # self.__print_to = sys.stderr
+        # todo: use nose plugin debug options
+        self.__loggers = self.__find_loggers()
+        self.__test_cnt = 0
+
+    @classmethod
+    def enabled_for_nose(self):
+        return True
+
+    def handle_begin(self):
+        self.__loggers = self.__find_loggers()
+        self.__mark_all_loggers(str(self._all_blocks), 'start-of-all-tests')
+        self._all_blocks += 1
+
+    def handle_start_test(self, test):
+        ts = '+{0}'.format(self.__test_cnt)
+        self.__mark_all_loggers(ts, '-------STARTING TEST: %s--------', str(test))
+
+    def handle_stop_test(self, test):
+        ts = '-{0}'.format(self.__test_cnt)
+        self.__test_cnt += 1
+        self.__mark_all_loggers(ts, '--------ENDING TEST: %s--------', str(test))
+
+    def __mark_all_in_logger(self, level, logger, msg, args, exc_info=None, extra=None):
+        handlers = getattr(logger, 'handlers', [])
+        if len(handlers) == 0:
+            return  # Nothing to do!
+        if _srcfile:
+            #IronPython doesn't track Python frames, so findCaller raises an
+            #exception on some versions of IronPython. We trap it here so that
+            #IronPython can use logging.
+            try:
+                fn, lno, func = logger.findCaller()
+            except ValueError:
+                fn, lno, func = "(unknown file)", 0, "(unknown function)"
+        else:
+            fn, lno, func = "(unknown file)", 0, "(unknown function)"
+        if exc_info:
+            if not isinstance(exc_info, tuple):
+                exc_info = sys.exc_info()
+        record = logger.makeRecord(logger.name, level, fn, lno, msg, args, exc_info, func, extra)
+        for handler in handlers:
+            handler.handle(record)
+
+    def __mark_logger_block(self, logger, bracket, level, fmat, *args, **kwargs):
+        # rep_cnt is used to fill in about X (20) chars with the repeated
+        # text.
+        rep_cnt = int(20/len(bracket))
+        self.__mark_all_in_logger(level, logger, bracket * rep_cnt, [])
+        self.__mark_all_in_logger(level, logger, fmat, args, **kwargs)
+        self.__mark_all_in_logger(level, logger, bracket * rep_cnt, [])
+
+    def __mark_all_loggers(self, bracket, fmat, *args, **kwargs):
+        root = real_getLogger()
+        self.__mark_logger_block(root, bracket, INFO, fmat, *args, **kwargs)
+        for logger in self.__loggers.values():
+            self.__mark_logger_block(logger, bracket, DEBUG, fmat, *args, **kwargs)
+
+    def __find_loggers(self):
+        ldict = Logger.manager.loggerDict
+        # todo: feature -> add test-name to all log handlers if we can.
+        observed_loggers = {}
+        observed_handlers = {}
+        # For now, only do our loggers. TODO: we need to be capturing ALL the
+        # loggers (not just ours), but we don't want 'mark alls' hitting the
+        # console because of them.
+        for lg_name, logger in ldict.items():
+            if lg_name not in ['infra.run', 'infra.data', 'test.run', 'test.data', '']:
+                if self.__print_to is not None:
+                    print >>self.__print_to, "SKIPPING {0}  -> {1}".format(lg_name, logger)
+            else:
+                if self.__print_to is not None:
+                    print >>self.__print_to, "OBSERVING {0}  -> {1}".format(lg_name, logger)
+                handlers = getattr(logger, 'handlers', None)
+                if handlers is None:
+                    if self.__print_to is not None:
+                        print >>self.__print_to, "   no handlers on {0} type {1}".format(logger, type(logger))
+                else:
+                    for handler in handlers:
+                        if self.__print_to is not None:
+                            print >>self.__print_to, "   handler = {0} {1}".format(handler, handler.get_name())
+                        observed_handlers[handler] = handler
+                observed_loggers[lg_name] = logger
+
+        return observed_loggers
+

--- a/test/stream-monitor/stream_sources/monitor_abc.py
+++ b/test/stream-monitor/stream_sources/monitor_abc.py
@@ -1,0 +1,7 @@
+# todo: ABC
+
+
+class StreamMonitorABC(object):
+    pass
+
+    # todo must implement @classmethod enabled_for_nose()

--- a/test/stream-monitor/test/support/stream-base/one_pass/test_one_pass.py
+++ b/test/stream-monitor/test/support/stream-base/one_pass/test_one_pass.py
@@ -1,0 +1,2 @@
+def test_one():
+    print "test_one"

--- a/test/stream-monitor/test/support/stream-base/two_pass/test_two_pass.py
+++ b/test/stream-monitor/test/support/stream-base/two_pass/test_two_pass.py
@@ -1,0 +1,5 @@
+def test_one_of_two_pass():
+    pass
+
+def test_two_of_two_pass():
+    pass

--- a/test/stream-monitor/test/support/stream-source/logging/one_pass/test_one_log_pass.py
+++ b/test/stream-monitor/test/support/stream-source/logging/one_pass/test_one_log_pass.py
@@ -1,0 +1,10 @@
+import unittest
+from logging import getLogger
+
+class TestOneLoggerTest(unittest.TestCase):
+    def setUp(self):
+        self.__lg = getLogger('infra.run')
+        super(TestOneLoggerTest, self).setUp()
+
+    def test_single_log_to_run(self):
+        self.__lg.warning('test_single_log_to_run')

--- a/test/stream-monitor/test/support/stream-source/logging/two_pass/test_two_log_pass.py
+++ b/test/stream-monitor/test/support/stream-source/logging/two_pass/test_two_log_pass.py
@@ -1,0 +1,13 @@
+import unittest
+from logging import getLogger
+
+class TestTwoLoggerTest(unittest.TestCase):
+    def setUp(self):
+        self.__lg = getLogger('infra.run')
+        super(TestOneLoggerTest, self).setUp()
+
+    def test_one_of_two_to_run(self):
+        self.__lg.warning('test_one_of_two_to_run')
+
+    def test_two_of_two_to_run(self):
+        self.__lg.warning('test_two_of_two_to_run')

--- a/test/stream-monitor/test/test_log_stream.py
+++ b/test/stream-monitor/test/test_log_stream.py
@@ -1,0 +1,89 @@
+import unittest, os
+import sys
+from nose.plugins import PluginTester
+from sm_plugin import StreamMonitorPlugin
+
+support = os.path.join(os.path.dirname(__file__), 'support')
+
+# todo: this can probably be shared amongst the different stream handlers?
+class _TestStreamMonitorPluginTester(PluginTester, unittest.TestCase):
+    activate = '--with-stream-monitor'
+    _smp = StreamMonitorPlugin()
+    _smp._self_test_print_step_enable()
+    plugins = [_smp]
+    def runTest(self):
+        print '*' * 70
+        print str(self.output)
+        print '*' * 70
+        self.__call_sequence = self._smp._self_test_sequence_seen()
+        self.verify()
+        assert len(self.__call_sequence) == 0, \
+            'still had call-items left at end {0}'.format(self.__call_sequence)
+
+    def verify(self):
+        raise NotImplementedError()
+
+    def _check_sequence_pre_test(self):
+        self.__check_next('options', ['parser', 'env'])
+        self.__check_next('configure', ['options', 'conf'])
+        self.__check_next('begin', [])
+
+    def _check_sequence_test(self, test_name):
+        self.__check_next('beforeTest', ['test'], {'test': test_name})
+        self.__check_next('startTest', ['test'], {'test': test_name})
+        self.__check_next('stopTest', ['test'], {'test': test_name})
+        self.__check_next('afterTest', ['test'], {'test': test_name})
+
+    def _check_sequence_post_test(self):
+        log_dict = self.__check_next('finalize', ['result'])
+        # todo: poke into log_dict for run/errors/failures.
+        # (it's like {'result': <nose.result.TextTestResult run=1 errors=0 failures=0>})
+
+    def __check_next(self, step_name, required_keys, match_dict=None):
+        if len(self.__call_sequence) == 0:
+            next_thing = ( 'no-more-steps-found', {} )
+        else:
+            next_thing = self.__call_sequence[0]
+            self.__call_sequence = self.__call_sequence[1:]
+
+        next_name, next_args = next_thing
+        assert step_name == next_name, \
+            "Was expecting step '{0}', but got '{1}'.".format(step_name, next_name)
+        rset = set(required_keys)
+        naset = set(next_args.keys())
+        req_not_there = rset - naset
+        assert len(req_not_there) == 0, \
+            "Required key(s) missing: {0} from {1} on step {2}".format(
+                req_not_there, naset, step_name)
+        there_not_req = naset - rset
+        assert len(there_not_req) == 0, \
+            "Extra key(s): {0} beyond {1} on step {2}".format(
+                there_not_req, rset, step_name)
+
+        if match_dict is not None:
+            for arg_key, arg_str in match_dict.items():
+                assert arg_key in next_args, \
+                    "Argument {0} was supposed to have value {1} but was missing".format(
+                        arg_key, arg_str)
+                m_str = str(next_args[arg_key])
+                assert arg_str == m_str, \
+                    "Argument {0} was supposed to have value '{1}' but was '{2}'".format(
+                        arg_key, arg_str, m_str)
+
+class TestSMPLogginSingleOk(_TestStreamMonitorPluginTester):
+    suitepath = os.path.join(support, 'stream-source', 'logging', 'one_pass')
+
+    def verify(self):
+        self._check_sequence_pre_test()
+        self._check_sequence_test('test_single_log_to_run (test_one_log_pass.TestOneLoggerTest)')
+        self._check_sequence_post_test()
+
+class TestSMPLogginTwoOk(_TestStreamMonitorPluginTester):
+    suitepath = os.path.join(support, 'stream-source', 'logging', 'two_pass')
+
+    def verify(self):
+        self._check_sequence_pre_test()
+        self._check_sequence_test('test_one_of_two_to_run (test_two_log_pass.TestTwoLoggerTest)')
+        self._check_sequence_test('test_two_of_two_to_run (test_two_log_pass.TestTwoLoggerTest)')
+        self._check_sequence_post_test()
+

--- a/test/stream-monitor/test/test_stream_base.py
+++ b/test/stream-monitor/test/test_stream_base.py
@@ -1,0 +1,87 @@
+import unittest, os
+import sys
+from nose.plugins import PluginTester
+from sm_plugin import StreamMonitorPlugin
+
+support = os.path.join(os.path.dirname(__file__), 'support')
+
+class _TestStreamMonitorPluginTester(PluginTester, unittest.TestCase):
+    activate = '--with-stream-monitor'
+    _smp = StreamMonitorPlugin()
+    _smp._self_test_print_step_enable()
+    plugins = [_smp]
+    def runTest(self):
+        print '*' * 70
+        print str(self.output)
+        print '*' * 70
+        self.__call_sequence = self._smp._self_test_sequence_seen()
+        self.verify()
+        assert len(self.__call_sequence) == 0, \
+            'still had call-items left at end {0}'.format(self.__call_sequence)
+
+    def verify(self):
+        raise NotImplementedError()
+
+    def _check_sequence_pre_test(self):
+        self.__check_next('options', ['parser', 'env'])
+        self.__check_next('configure', ['options', 'conf'])
+        self.__check_next('begin', [])
+
+    def _check_sequence_test(self, test_name):
+        self.__check_next('beforeTest', ['test'], {'test': test_name})
+        self.__check_next('startTest', ['test'], {'test': test_name})
+        self.__check_next('stopTest', ['test'], {'test': test_name})
+        self.__check_next('afterTest', ['test'], {'test': test_name})
+
+    def _check_sequence_post_test(self):
+        log_dict = self.__check_next('finalize', ['result'])
+        # todo: poke into log_dict for run/errors/failures.
+        # (it's like {'result': <nose.result.TextTestResult run=1 errors=0 failures=0>})
+
+    def __check_next(self, step_name, required_keys, match_dict=None):
+        if len(self.__call_sequence) == 0:
+            next_thing = ( 'no-more-steps-found', {} )
+        else:
+            next_thing = self.__call_sequence[0]
+            self.__call_sequence = self.__call_sequence[1:]
+
+        next_name, next_args = next_thing
+        assert step_name == next_name, \
+            "Was expecting step '{0}', but got '{1}'.".format(step_name, next_name)
+        rset = set(required_keys)
+        naset = set(next_args.keys())
+        req_not_there = rset - naset
+        assert len(req_not_there) == 0, \
+            "Required key(s) missing: {0} from {1} on step {2}".format(
+                req_not_there, naset, step_name)
+        there_not_req = naset - rset
+        assert len(there_not_req) == 0, \
+            "Extra key(s): {0} beyond {1} on step {2}".format(
+                there_not_req, rset, step_name)
+
+        if match_dict is not None:
+            for arg_key, arg_str in match_dict.items():
+                assert arg_key in next_args, \
+                    "Argument {0} was supposed to have value {1} but was missing".format(
+                        arg_key, arg_str)
+                m_str = str(next_args[arg_key])
+                assert arg_str == m_str, \
+                    "Argument {0} was supposed to have value {1} but was {2}".format(
+                        arg_key, arg_str, m_str)
+
+class TestSMPSingleOkSequence(_TestStreamMonitorPluginTester):
+    suitepath = os.path.join(support, 'stream-base', 'one_pass')
+
+    def verify(self):
+        self._check_sequence_pre_test()
+        self._check_sequence_test('test_one_pass.test_one')
+        self._check_sequence_post_test()
+
+class TestSMPDoubleOkSequence(_TestStreamMonitorPluginTester):
+    suitepath = os.path.join(support, 'stream-base', 'two_pass')
+
+    def verify(self):
+        self._check_sequence_pre_test()
+        self._check_sequence_test('test_two_pass.test_one_of_two_pass')
+        self._check_sequence_test('test_two_pass.test_two_of_two_pass')
+        self._check_sequence_post_test()


### PR DESCRIPTION
Change to common/fit_common.py
* bring in new "flogging" (fit-logging) module from stream-monitor plugin space
* added a merged file to flogging (all_all).
* adjust run_nose() method to:
** fix: not use lucky-scoping to get access to noseopts variable
** converted invocation to use built environment and args set (rather than monster subprocess string)
*** env passed in via official api
*** noseargs passed in the same
*** converted from dangerous string to list-of-args
* added run_from_module() method (see changes to tests/rackhd11/test_rackhd11_api_catalogs.py)

Everything under stream-monitor is basically the plugin from PR https://github.com/stuart-stanley/nose-observer-plugin/pull/1.
It contains four sub-dirs and some support files. This is implemented as a plugin for nose!
* support files:
** readme, mkenv.sh, and requirements.
* sm_plugin:
** the real plugin base. basically just enough smarts right now to orchestrate telling future stream-sources "test starting!" "test ending!" and so on.
* stream-sources: where all the actual stream "sources" will live. At the moment, this contains a (test harness) logging stream monitor:
** smart enough to detect our local-loggers
** able to inject additional log message to bracket test start/stops
** ...which also means those contact points will be available to use a common scanner (did I see XXX? Yeah? GO BOOM!) and so on.
* flogging is the code for:
** rac-263 (basic log handles for use in test areas)
** rac-264 (granular logging levels)
** this code is meant to be used from fit_tests via common/fit_common.py:get_loggers()

tests/rackhd11/test_rackhd11_api_catalogs.py shows an example conversion:
* bring in the multi-loggers holder
* convert a couple of prints to use them:
** use of "non-expert I'm just writing a test" simplified form of logger
** demo the use of debug_0, _1, and _2 (logger levels) vs just "debug"
* convert __name__ module invoker to use new run_from_module to nose this specific file

Stragglers:
* touched up requirements file
* Update Vagrant to use correct mkenv steps
* Update README to use correct mkenv steps.

Tested with:
python run.py --show-plan
python run.py --group="pollers_api2.tests"
python run_tests.py -stack 1 -test util/display_rackhd_nodes.py
python run_tests.py -stack 1 -test deploy/rackhd_stack_init.py -list
python run_tests.py -stack 1 -test tests -group smoke
python run_tests.py -stack 1 -test tests/api-cit/v2_0/nodes_tests_fit.py -list
python run_tests.py -stack 1 -test tests/api-cit/v2_0/nodes_tests_fit.py:NodesTests.test_07_node_catalogs
python run_tests.py -stack 1 -test tests/api-cit/v2_0/nodes_tests_fit.py
python run_tests.py -stack 1 -test tests -group nodes_api2_tests

@RackHD/corecommitters @johren @jimturnquist @stuart-stanley @gpaulos @hohene 
