### PR TITLE
Updated Vagrantfile to support Jenkins automation

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -6,7 +6,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.provider 'virtualbox' do |vb|
-      vb.customize ['modifyvm', :id, '--cableconnected1', 'on']
+        vb.customize ['modifyvm', :id, '--cableconnected1', 'on']
     end
 
     # RackHD SERVER (Install and start RackHD server)
@@ -22,8 +22,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         target.vm.network "private_network", ip: "172.31.128.1", virtualbox__intnet: "closednet"
         target.ssh.forward_agent = true
         target.vm.network "forwarded_port", guest: 8080, host: 8080
-        target.vm.network "forwarded_port", guest: 9080, host: 9080
-        target.vm.network "forwarded_port", guest: 9090, host: 9090
         target.vm.network "forwarded_port", guest: 443, host: 443
         target.vm.provision "shell", inline: <<-SHELL
             git clone https://github.com/RackHD/RackHD fit_tests
@@ -32,10 +30,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             sudo apt-get -y install virtualenv
             virtualenv .venv
             source .venv/bin/activate
-            pip install -r fit_tests/requirements.txt
+            pip install -r fit_tests/test/requirements.txt
             cd fit_tests/test
-            python run_tests.py -test deploy/rackhd_source_install.py -v 9
-            python run_tests.py -test deploy/rackhd_stack_init.py:rackhd_stack_init.test01_preload_sku_packs -stack vagrant -v 9
+            python run_tests.py -test deploy/rackhd_source_install.py -config config.vagrant -v 9
+            python run_tests.py -test deploy/rackhd_stack_init.py:rackhd_stack_init.test01_preload_sku_packs -stack vagrant -v 9; echo
         SHELL
     end
 
@@ -55,22 +53,21 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         SHELL
     end
 
-    # RackHD SERVER TEMPLATE (RackHD installer downloaded but not installed)
-    config.vm.define "template", autostart: false do |target|
-        target.vm.box = "bento/ubuntu-16.04"
-        target.vm.provider "virtualbox" do |v|
+
+    # RackHD SERVER TEMPLATE (To be used by Jenkins)
+    config.vm.define "template", autostart: false do |template|
+        template.vm.box = "bento/ubuntu-16.04"
+        template.vm.provider "virtualbox" do |v|
             v.memory = 4096
             v.cpus = 4
             v.customize ["modifyvm", :id, "--nicpromisc2", "allow-all", "--ioapic", "on"]
         end
-        target.ssh.username = "vagrant"
-        target.ssh.password = "vagrant"
-        target.vm.network "private_network", ip: "172.31.128.1", virtualbox__intnet: "closednet"
-        target.ssh.forward_agent = true
-        target.vm.provision "shell", inline: <<-SHELL
-            git clone https://github.com/RackHD/RackHD fit_tests
-        SHELL
+        template.ssh.username = "vagrant"
+        template.ssh.password = "vagrant"
+        template.vm.network "private_network", ip: "172.31.128.1", virtualbox__intnet: "closednet"
+        template.ssh.forward_agent = true
+        template.vm.network "forwarded_port", guest: 8080, host: 8080
+        template.vm.network "forwarded_port", guest: 22, host: 2222, id: "ssh"
     end
-
 
 end


### PR DESCRIPTION
This PR contains the updated Vagrantfile script required for Jenkins FIT automation.
The 'template' section is the server template for Jenkins runs.
The 'dev' section is for local workstation-based Vagrant runs.
Vagrant scripts are idiosyncratic and I had to do some weird things to make it work. 

@hohene @johren @jimturnquist @diontje @larry-dean