### PR TITLE
RackHD debian package depends on on-imagebuilder.deb

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,6 +20,7 @@ Depends: ${misc:Depends},
          on-syslog,
          on-taskgraph,
          on-tftp,
+         on-imagebuilder,
          rabbitmq-server
 Description: base package for all of RackHD
  uber package for all rackhd installation

--- a/debian/postinst
+++ b/debian/postinst
@@ -6,34 +6,6 @@ set -e
 SERVICES=("on-http" "on-taskgraph" "on-dhcp-proxy" "on-tftp" "on-syslog")
 
 #############################################
-# Copy the PXE image and micro kernel from bintray 
-#############################################
-copy_RackHD_static_bins(){
-    echo "[INFO] Will Copy static files, it will take a while"
-    mkdir -p /var/renasar/on-tftp/static/tftp
-    cd /var/renasar/on-tftp/static/tftp
-
-    for file in $(echo "\
-        monorail.ipxe \
-        monorail-undionly.kpxe \
-        monorail-efi64-snponly.efi \
-        monorail-efi32-snponly.efi");do
-    wget --no-check-certificate "https://dl.bintray.com/rackhd/binary/ipxe/$file" 
-    done
-
-    mkdir -p /var/renasar/on-http/static/http/common
-    cd /var/renasar/on-http/static/http/common
-
-    for file in $(echo "\
-        base.trusty.3.16.0-25-generic.squashfs.img \
-        discovery.overlay.cpio.gz \
-        initrd.img-3.16.0-25-generic \
-        vmlinuz-3.16.0-25-generic");do
-    wget --no-check-certificate "https://dl.bintray.com/rackhd/binary/builds/$file"
-    done
-}
-
-#############################################
 # Stop on-xxx 
 # Use Rackhd service to manager the status of on-xxx services
 #############################################
@@ -43,7 +15,6 @@ stop_component_services(){
     done
 }
 
-copy_RackHD_static_bins
 stop_component_services
 
 # Automatically added by dh_installinit


### PR DESCRIPTION
**Background**:
Now the static files built by on-imagebuilder is out of version control.
And RackHD always downloads these files from a fixed url.

We are going to release on-imagebuilder.deb to control the version of these static files.
RackHD will depend on the package to get specified version of static files.

**Test**:
Build debian packages:
http://rackhdci.lss.emc.com/job/BuildRelease/job/Build/job/debian-build/
Install rackhd (depends on on-imagebuilder) on clean ubuntu 14.04 and 16.04 successfully.

