### PR TITLE
use on-imagebuilder.deb instead of raw static files

### DIFF
--- a/docker/files/Dockerfile
+++ b/docker/files/Dockerfile
@@ -1,32 +1,14 @@
-FROM alpine:latest
+FROM wheezy:latest
+
+RUN echo "deb https://dl.bintray.com/rackhd/debian trusty release" >> /etc/apt/sources.list
+RUN apt-get update
+RUN apt-get install on-imagebuilder
 
 RUN mkdir -p /RackHD/downloads
-
-ADD https://bintray.com/artifact/download/rackhd/binary/ipxe/monorail-efi32-snponly.efi \
-    /RackHD/downloads/monorail-efi32-snponly.efi
-ADD https://bintray.com/artifact/download/rackhd/binary/ipxe/monorail-efi64-snponly.efi \
-    /RackHD/downloads/monorail-efi64-snponly.efi
-ADD https://bintray.com/artifact/download/rackhd/binary/ipxe/monorail.ipxe \
-    /RackHD/downloads/monorail.ipxe
-ADD https://bintray.com/artifact/download/rackhd/binary/ipxe/monorail-undionly.kpxe \
-    /RackHD/downloads/monorail-undionly.kpxe
-ADD https://bintray.com/artifact/download/rackhd/binary/ipxe/monorail.intel.ipxe \
-    /RackHD/downloads/monorail.intel.ipxe
-
-ADD https://bintray.com/artifact/download/rackhd/binary/syslinux/undionly.kkpxe \
-    /RackHD/downloads/undionly.kkpxe
-
+COPY /var/renasar/on-tftp/static/tftp/* /RackHD/downloads
 
 RUN mkdir -p /RackHD/downloads/common
-
-ADD https://bintray.com/artifact/download/rackhd/binary/builds/base.trusty.3.16.0-25-generic.squashfs.img \
-    /RackHD/downloads/common/base.trusty.3.16.0-25-generic.squashfs.img
-ADD https://bintray.com/artifact/download/rackhd/binary/builds/discovery.overlay.cpio.gz \
-    /RackHD/downloads/common/discovery.overlay.cpio.gz
-ADD https://bintray.com/artifact/download/rackhd/binary/builds/initrd.img-3.16.0-25-generic \
-    /RackHD/downloads/common/initrd.img-3.16.0-25-generic
-ADD https://bintray.com/artifact/download/rackhd/binary/builds/vmlinuz-3.16.0-25-generic \
-    /RackHD/downloads/common/vmlinuz-3.16.0-25-generic
+COPY /var/renasar/on-http/static/http/common/* /RackHD/downloads/common
 
 VOLUME /RackHD/files
 


### PR DESCRIPTION
Docker used to download static files from bintray directly.
But now static files have been wrapped into on-imagebuilder.deb, so this Docker file should be modified.


skip ci

@panpan0000 @PengTian0 
