### PR TITLE
Bugfix api templates

### DIFF
--- a/test/tests/rackhd11/test_rackhd11_api_templates.py
+++ b/test/tests/rackhd11/test_rackhd11_api_templates.py
@@ -29,14 +29,6 @@ class rackhd11_api_templates(fit_common.unittest.TestCase):
     def test_api_11_templates_library_ID(self):
         api_data = fit_common.rackhdapi("/api/1.1/templates/library")
         self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
-        for item in api_data['json']:
-            lib_data = fit_common.rackhdapi("/api/1.1/templates/library/" + item['name'])
-            self.assertEqual(lib_data['status'], 200, "Was expecting code 200. Got " + str(lib_data['status']))
-            # check required fields
-            for subitem in ['contents', 'createdAt', 'id', 'name', 'updatedAt']:
-                if fit_common.VERBOSITY >= 2:
-                    print "Checking:", item['name'], subitem
-                self.assertGreater(len(item[subitem]), 0, subitem + ' field error')
 
 if __name__ == '__main__':
     fit_common.unittest.main()

--- a/test/tests/rackhd11/test_rackhd11_api_templates.py
+++ b/test/tests/rackhd11/test_rackhd11_api_templates.py
@@ -17,7 +17,9 @@ from nose.plugins.attrib import attr
 @attr(all=True, regression=True, smoke=True)
 class rackhd11_api_templates(fit_common.unittest.TestCase):
     def setUp(self):
-        fit_common.rackhdapi("/api/1.1/templates/library/testid", action="delete")
+        # this clears out any existing instance of 'testid' template
+        # template 'delete' not supported in API 1.1, using 2.0
+        fit_common.rackhdapi("/api/2.0/templates/library/testid", action="delete")
 
     def test_api_11_templates_library(self):
         api_data = fit_common.rackhdapi("/api/1.1/templates/library")
@@ -30,12 +32,15 @@ class rackhd11_api_templates(fit_common.unittest.TestCase):
                 self.assertGreater(len(item[subitem]), 0, subitem + ' field error')
 
     def test_api_11_templates_library_ID_put_get_delete(self):
-            api_data = fit_common.rackhdapi("/api/1.1/templates/library/testid?scope=global", action="text-put", payload="null")
-            self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
-            api_data = fit_common.rackhdapi("/api/1.1/templates/library/testid")
-            self.assertIn(api_data['json']['contents'], "null", "Data 'null' was not returned.")
-            self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
-            api_data = fit_common.rackhdapi("/api/1.1/templates/library/testid", action="delete")
+        # this test creates a dummy template called 'testid', checks it, then deletes it
+        api_data = fit_common.rackhdapi("/api/1.1/templates/library/testid?scope=global", action="text-put", payload="null")
+        self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
+        api_data = fit_common.rackhdapi("/api/1.1/templates/library/testid")
+        self.assertIn(api_data['json']['contents'], "null", "Data 'null' was not returned.")
+        self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
+        # template 'delete' not supported in API 1.1, using 2.0
+        api_data = fit_common.rackhdapi("/api/2.0/templates/library/testid", action="delete")
+        self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
 
 if __name__ == '__main__':
     fit_common.unittest.main()

--- a/test/tests/rackhd11/test_rackhd11_api_templates.py
+++ b/test/tests/rackhd11/test_rackhd11_api_templates.py
@@ -16,6 +16,9 @@ import fit_common
 from nose.plugins.attrib import attr
 @attr(all=True, regression=True, smoke=True)
 class rackhd11_api_templates(fit_common.unittest.TestCase):
+    def setUp(self):
+        fit_common.rackhdapi("/api/1.1/templates/library/testid", action="delete")
+
     def test_api_11_templates_library(self):
         api_data = fit_common.rackhdapi("/api/1.1/templates/library")
         self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
@@ -26,9 +29,13 @@ class rackhd11_api_templates(fit_common.unittest.TestCase):
                     print "Checking:", item['name'], subitem
                 self.assertGreater(len(item[subitem]), 0, subitem + ' field error')
 
-    def test_api_11_templates_library_ID(self):
-        api_data = fit_common.rackhdapi("/api/1.1/templates/library")
-        self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
+    def test_api_11_templates_library_ID_put_get_delete(self):
+            api_data = fit_common.rackhdapi("/api/1.1/templates/library/testid?scope=global", action="text-put", payload="null")
+            self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
+            api_data = fit_common.rackhdapi("/api/1.1/templates/library/testid")
+            self.assertIn(api_data['json']['contents'], "null", "Data 'null' was not returned.")
+            self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
+            api_data = fit_common.rackhdapi("/api/1.1/templates/library/testid", action="delete")
 
 if __name__ == '__main__':
     fit_common.unittest.main()

--- a/test/tests/rackhd20/test_rackhd20_api_templates.py
+++ b/test/tests/rackhd20/test_rackhd20_api_templates.py
@@ -17,6 +17,7 @@ from nose.plugins.attrib import attr
 @attr(all=True, regression=True, smoke=True)
 class rackhd20_api_templates(fit_common.unittest.TestCase):
     def setUp(self):
+        # this clears out any existing instance of 'testid' template
         fit_common.rackhdapi("/api/2.0/templates/library/testid", action="delete")
 
     def test_api_20_templates_metadata(self):
@@ -42,12 +43,14 @@ class rackhd20_api_templates(fit_common.unittest.TestCase):
                 self.assertGreater(len(item[subitem]), 0, subitem + ' field error')
 
     def test_api_20_templates_library_ID_put_get_delete(self):
+        # this test creates a dummy template called 'testid', checks it, then deletes it
         api_data = fit_common.rackhdapi("/api/2.0/templates/library/testid?scope=global", action="text-put", payload="null")
         self.assertEqual(api_data['status'], 201, "Was expecting code 201. Got " + str(api_data['status']))
         api_data = fit_common.rackhdapi("/api/2.0/templates/library/testid")
         self.assertEqual(api_data['text'], "null", "Data 'null' was not returned.")
         self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
         api_data = fit_common.rackhdapi("/api/2.0/templates/library/testid", action="delete")
+        self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
 
 if __name__ == '__main__':
     fit_common.unittest.main()

--- a/test/tests/rackhd20/test_rackhd20_api_templates.py
+++ b/test/tests/rackhd20/test_rackhd20_api_templates.py
@@ -17,7 +17,8 @@ from nose.plugins.attrib import attr
 @attr(all=True, regression=True, smoke=True)
 class rackhd20_api_templates(fit_common.unittest.TestCase):
     def setUp(self):
-        api_data = fit_common.rackhdapi("/api/2.0/templates/library/testid", action="delete")
+        fit_common.rackhdapi("/api/2.0/templates/library/testid", action="delete")
+
     def test_api_20_templates_metadata(self):
         api_data = fit_common.rackhdapi("/api/2.0/templates/metadata")
         self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))

--- a/test/tests/rackhd20/test_rackhd20_api_templates.py
+++ b/test/tests/rackhd20/test_rackhd20_api_templates.py
@@ -40,13 +40,6 @@ class rackhd20_api_templates(fit_common.unittest.TestCase):
                     print "Checking:", item['name'], subitem
                 self.assertGreater(len(item[subitem]), 0, subitem + ' field error')
 
-    def test_api_20_templates_library_ID_get(self):
-        api_data = fit_common.rackhdapi("/api/2.0/templates/metadata")
-        self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
-        for item in api_data['json']:
-            lib_data = fit_common.rackhdapi("/api/2.0/templates/library/" + item['name'])
-            self.assertEqual(lib_data['status'], 200, "Was expecting code 200. Got " + str(lib_data['status']))
-
     def test_api_20_templates_library_ID_put_get_delete(self):
         api_data = fit_common.rackhdapi("/api/2.0/templates/library/testid?scope=global", action="text-put", payload="null")
         self.assertEqual(api_data['status'], 201, "Was expecting code 201. Got " + str(api_data['status']))


### PR DESCRIPTION
The api/x.x/templates command has been revised since the original tests were checked in. 

This PR applies corrections to these tests.

The GET api/x.x/templates command is no longer valid without a name spec.

@hohene @johren @jimturnquist @diontje @larry-dean
