### PR TITLE
 rac-3789 run_last.d symlink should be relative rather than absolute

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,6 +20,7 @@ Depends: ${misc:Depends},
          on-syslog,
          on-taskgraph,
          on-tftp,
+         on-imagebuilder,
          rabbitmq-server
 Description: base package for all of RackHD
  uber package for all rackhd installation

--- a/debian/postinst
+++ b/debian/postinst
@@ -6,34 +6,6 @@ set -e
 SERVICES=("on-http" "on-taskgraph" "on-dhcp-proxy" "on-tftp" "on-syslog")
 
 #############################################
-# Copy the PXE image and micro kernel from bintray 
-#############################################
-copy_RackHD_static_bins(){
-    echo "[INFO] Will Copy static files, it will take a while"
-    mkdir -p /var/renasar/on-tftp/static/tftp
-    cd /var/renasar/on-tftp/static/tftp
-
-    for file in $(echo "\
-        monorail.ipxe \
-        monorail-undionly.kpxe \
-        monorail-efi64-snponly.efi \
-        monorail-efi32-snponly.efi");do
-    wget --no-check-certificate "https://dl.bintray.com/rackhd/binary/ipxe/$file" 
-    done
-
-    mkdir -p /var/renasar/on-http/static/http/common
-    cd /var/renasar/on-http/static/http/common
-
-    for file in $(echo "\
-        base.trusty.3.16.0-25-generic.squashfs.img \
-        discovery.overlay.cpio.gz \
-        initrd.img-3.16.0-25-generic \
-        vmlinuz-3.16.0-25-generic");do
-    wget --no-check-certificate "https://dl.bintray.com/rackhd/binary/builds/$file"
-    done
-}
-
-#############################################
 # Stop on-xxx 
 # Use Rackhd service to manager the status of on-xxx services
 #############################################
@@ -43,7 +15,6 @@ stop_component_services(){
     done
 }
 
-copy_RackHD_static_bins
 stop_component_services
 
 # Automatically added by dh_installinit

--- a/packer/HWIMO-BUILD
+++ b/packer/HWIMO-BUILD
@@ -115,7 +115,8 @@ CFG_FILE=template.cfg
 # parameter file pass to packer
 echo {                                                > $CFG_FILE
 echo  \"playbook\": \"${ANSIBLE_PLAYBOOK}\",         >> $CFG_FILE
-echo  \"vm_name\": \"${VM_NAME}\"                    >> $CFG_FILE
+echo  \"vm_name\": \"${VM_NAME}\",                   >> $CFG_FILE
+echo  \"rackhd_version\": \"${RACKHD_VERSION}\"      >> $CFG_FILE
 
 if [[ $IS_UPLOAD_ATLAS == true ]]
 then

--- a/packer/ansible/roles/rackhd-builds/tasks/main.yml
+++ b/packer/ansible/roles/rackhd-builds/tasks/main.yml
@@ -7,12 +7,12 @@
 - apt: pkg=python-pycurl state=present
   sudo: yes
 
-- apt_repository: repo="deb https://dl.bintray.com/rackhd-mirror/debian trusty main"
+- apt_repository: repo="deb https://dl.bintray.com/rackhd/debian trusty main"
                   state=present
   sudo: yes
   when: (is_release is undefined) or (not is_release)
 
-- apt_repository: repo="deb https://dl.bintray.com/rackhd-mirror/debian trusty release"
+- apt_repository: repo="deb https://dl.bintray.com/rackhd/debian trusty release"
                   state=present
   sudo: yes
   when: (is_relaese is not undefined) and is_release

--- a/packer/template-ubuntu-14.04.json
+++ b/packer/template-ubuntu-14.04.json
@@ -9,7 +9,8 @@
         "atlas_version": "",
         "atlas_token": "{{env `ATLAS_TOKEN`}}",
         "vm_name" : "rackhd-vm",
-        "playbook": "rackhd_package"
+        "playbook": "rackhd_package",
+        "rackhd_version": ""
     },
     "provisioners": [
         {
@@ -54,7 +55,7 @@
             "inventory_groups": "local",
             "playbook_file": "ansible/{{user `playbook`}}.yml",
             "playbook_dir": "ansible",
-            "extra_arguments": [ "--extra-vars \"rackhd_version={{user `version`}}\"" ]
+            "extra_arguments": [ "--extra-vars \"rackhd_version={{user `rackhd_version`}}\"" ]
         },
         {
             "type": "shell",

--- a/packer/template-ubuntu-16.04.json
+++ b/packer/template-ubuntu-16.04.json
@@ -9,7 +9,8 @@
         "atlas_version": "",
         "atlas_token": "{{env `ATLAS_TOKEN`}}",
         "vm_name" : "rackhd-vm",
-        "playbook": "rackhd_package"
+        "playbook": "rackhd_package",
+        "rackhd_version": ""
     },
     "provisioners": [
         {
@@ -54,7 +55,7 @@
             "inventory_groups": "local",
             "playbook_file": "ansible/{{user `playbook`}}.yml",
             "playbook_dir": "ansible",
-            "extra_arguments": [ "--extra-vars \"rackhd_version={{user `version`}}\"" ]
+            "extra_arguments": [ "--extra-vars \"rackhd_version={{user `rackhd_version`}}\"" ]
         },
         {
             "type": "shell",

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -5,3 +5,4 @@ startup.sh
 nohup.out
 *~
 auth.json
+testfile

--- a/test/common/fit_common.py
+++ b/test/common/fit_common.py
@@ -888,6 +888,7 @@ def run_nose(nosepath):
             'HTTPS':  str(ARGS_LIST['https']),
             'PORT':  str(ARGS_LIST['port']),
             'FIT_CONFIG': CONFIG_PATH + "global_config.json",
+            'HOME':  os.environ['HOME'],
             'PATH':  os.environ['PATH']
         }
         argv = ['nosetests']

--- a/test/common/fit_common.py
+++ b/test/common/fit_common.py
@@ -21,7 +21,6 @@ import requests
 import pexpect
 import shutil
 import nose
-from flogging import get_loggers, logger_config_api
 
 # Globals
 
@@ -900,7 +899,7 @@ def run_nose(nosepath):
 
     exitcode = 0
     # set nose options
-    noseopts = ['--exe', '--with-nosedep']
+    noseopts = ['--exe', '--with-nosedep', '--with-stream-monitor']
     if ARGS_LIST['group'] != 'all' and ARGS_LIST['group'] != '':
         noseopts.append('-a')
         noseopts.append(str(ARGS_LIST['group']))

--- a/test/deploy/rackhd_stack_init.py
+++ b/test/deploy/rackhd_stack_init.py
@@ -117,11 +117,13 @@ class rackhd_stack_init(unittest.TestCase):
             fit_common.countdown(30)
         # no PDU case
         else:
-            print '**** No supported PDU found, restarting nodes using IMPI.'
-            # Power off all nodes
-            self.assertNotEqual(fit_common.power_control_all_nodes("off"), 0, 'No BMC IP addresses found')
-            # Power on all nodes
-            self.assertNotEqual(fit_common.power_control_all_nodes("on"), 0, 'No BMC IP addresses found')
+            # Power cycle all nodes via IPMI, display warning if no nodes found
+            if fit_common.power_control_all_nodes("off") == 0:
+                print '**** No supported PDU found, restarting nodes using IMPI.'
+            else:
+                print '**** No BMC IP addresses found in arp table, continuing without node restart.'
+            # power on all nodes under any circumstances
+            fit_common.power_control_all_nodes("on")
 
     # Optionally install control switch node if present
     @unittest.skipUnless("control" in fit_common.STACK_CONFIG[fit_common.ARGS_LIST['stack']], "")

--- a/test/mkenv.sh
+++ b/test/mkenv.sh
@@ -50,7 +50,7 @@ source .venv/${env_name}/bin/activate
 export PIP_CONFIG_FILE=`pwd`/pip.conf
 
 # Update local-pip to latest
-pip install -U pip
+pip install --upgrade pip
 
 # Install all required packages
 pip install -r requirements.txt

--- a/test/mkenv.sh
+++ b/test/mkenv.sh
@@ -49,6 +49,9 @@ source .venv/${env_name}/bin/activate
 # Use locally sourced pip configuration
 export PIP_CONFIG_FILE=`pwd`/pip.conf
 
+# Update local-pip to latest
+pip install -U pip
+
 # Install all required packages
 pip install -r requirements.txt
 

--- a/test/setup.cfg
+++ b/test/setup.cfg
@@ -1,3 +1,2 @@
 [nosetests]
-with-stream-monitor=1
 exe=1

--- a/test/stream-monitor/flogging/__init__.py
+++ b/test/stream-monitor/flogging/__init__.py
@@ -2,4 +2,5 @@ from infra_logging import *
 from logger_sets import get_loggers
 
 all = ['getLogger', 'getInfraRunLogger', 'getInfraDataLogger',
-       'getTestRunLogger', 'getTestDataLogger', 'get_loggers', 'logger_config_api']
+       'getTestRunLogger', 'getTestDataLogger', 'get_loggers',
+       'logger_get_logging_dir', 'logger_config_api']

--- a/test/stream-monitor/flogging/infra_logging.py
+++ b/test/stream-monitor/flogging/infra_logging.py
@@ -143,18 +143,23 @@ class _LoggerSetup(object):
             shutil.rmtree(trim_name)
 
         ts_ext = datetime.now().strftime('%Y-%m-%d_%X')
-        self.__lg_run_dir = os.path.join(lg_base_dir, 'run_{0}.d'.format(ts_ext))
+        run_name = 'run_{0}.d'.format(ts_ext)
+        self.__lg_run_dir = os.path.join(lg_base_dir, run_name)
         self.__prelog(logging.INFO, "this runs logging dir %s", self.__lg_run_dir)
         self.__makedirs_dash_p(os.path.join(self.__lg_run_dir))
 
         # now deal with and easy to use 'last'
-        last_name = os.path.join(lg_base_dir, 'run_last.d')
-        if os.path.islink(last_name):
-            os.unlink(last_name)
+        last_name = 'run_last.d'
+        last_path = os.path.join(lg_base_dir, last_name)
+        if os.path.islink(last_path):
+            os.unlink(last_path)
 
-        assert not os.path.lexists(last_name), \
+        assert not os.path.lexists(last_path), \
             "'{0}' still existed after unlink. Check for file/dir and remove manually".format(last_name)
-        os.symlink(self.__lg_run_dir, last_name)
+        cur_dir = os.getcwd()
+        os.chdir(lg_base_dir)
+        os.symlink(run_name, last_name)
+        os.chdir(cur_dir)
 
         self.__infra_run_lgn = os.path.join(self.__lg_run_dir, 'infra_run.log')
         self.__infra_data_lgn = os.path.join(self.__lg_run_dir, 'infra_data.log')
@@ -291,6 +296,11 @@ class _LoggerSetup(object):
     def set_level(self, new_level):
         pass
 
+    def get_logging_dir(self):
+        """
+        Right now mostly for test-test, but may enter infra-use later
+        """
+        return self.__lg_run_dir
 
 setLoggerClass(_LevelLoggerClass)
 
@@ -325,3 +335,5 @@ _logger_setup_instance = _LoggerSetup()
 def logger_config_api(verbosity):
     _logger_setup_instance.set_level(verbosity)
 
+def logger_get_logging_dir():
+    return _logger_setup_instance.get_logging_dir()

--- a/test/stream-monitor/mkenv.sh
+++ b/test/stream-monitor/mkenv.sh
@@ -49,6 +49,9 @@ source .venv/${env_name}/bin/activate
 # Use locally sourced pip configuration
 export PIP_CONFIG_FILE=`pwd`/pip.conf
 
+# Update local-pip to latest
+pip install --upgrade pip
+
 # Install all required packages
 pip install -r requirements.txt
 

--- a/test/stream-monitor/requirements.txt
+++ b/test/stream-monitor/requirements.txt
@@ -1,4 +1,3 @@
 gevent==1.1.2
 greenlet==0.4.10
 nose==1.3.7
-wheel==0.24.0

--- a/test/stream-monitor/sm_plugin/__init__.py
+++ b/test/stream-monitor/sm_plugin/__init__.py
@@ -1,3 +1,3 @@
-from stream_monitor import StreamMonitorPlugin
+from stream_monitor import StreamMonitorPlugin, smp_get_stream_monitor_plugin
 
-__all__ = [ 'StreamMonitorPlugin' ]
+__all__ = [ StreamMonitorPlugin, smp_get_stream_monitor_plugin ]

--- a/test/stream-monitor/sm_plugin/stream_monitor.py
+++ b/test/stream-monitor/sm_plugin/stream_monitor.py
@@ -20,6 +20,12 @@ class StreamMonitorPlugin(Plugin):
         self.__stream_plugins = {}
         super(StreamMonitorPlugin, self).__init__(*args, **kwargs)
 
+    @classmethod
+    def get_singleton_instance(klass):
+        assert klass._singleton is not None, \
+            "Attempt to retrieve singleton before first instance created"
+        return klass._singleton
+
     def _self_test_print_step_enable(self):
         self.__save_call_sequence = []
 
@@ -45,7 +51,7 @@ class StreamMonitorPlugin(Plugin):
         super(StreamMonitorPlugin, self).configure(options,conf)
         if not self.enabled:
             return
-        if conf.options.collect_only:
+        if getattr(conf.options, 'collect_only', False):
             # we don't want to be spitting stuff out during -list!
             self.enabled = False
 
@@ -78,3 +84,12 @@ class StreamMonitorPlugin(Plugin):
         self.__take_step('stopTest', test=test)
         for pg in self.__stream_plugins.values():
             pg.handle_stop_test(test)
+
+
+def smp_get_stream_monitor_plugin():
+    """
+    Get the plugin that nose will have created. ONLY nose should 
+    create the main instance!
+    """
+    smp = StreamMonitorPlugin.get_singleton_instance()
+    return smp

--- a/test/stream-monitor/test/test_infra_logging.py
+++ b/test/stream-monitor/test/test_infra_logging.py
@@ -1,0 +1,41 @@
+"""
+Copyright 2016, EMC, Inc.
+
+This file contains (very very crude, at the moment!) self
+tests of the logging infrastructure.
+"""
+import flogging
+import os
+from unittest import TestCase
+
+class TestInfraLogging(TestCase):
+    def test_canary(self):
+        """canary test to make sure tests are being picked up"""
+        pass
+
+    def setUp(self):
+        self.__lg_full_path = flogging.logger_get_logging_dir()
+        self.__lg_container_path = os.path.dirname(self.__lg_full_path)
+        self.__lg_sym_path = os.path.join(self.__lg_container_path, 'run_last.d')
+
+    def test_symlink_exists(self):
+        """test run_last.d symlink exists"""
+        # lexists returns True for anything that exists (even a broken link)
+        self.assertTrue(os.path.lexists(self.__lg_sym_path),
+                        "'{0}' does not exist on filesystem".format(self.__lg_sym_path))
+        # the next check weeds outs out non-links as bad
+        self.assertTrue(os.path.islink(self.__lg_sym_path),
+                        "'{0}' exists but is not a link".format(self.__lg_sym_path))
+        # and finally, use .exists, which is like lexists except that it returns False for
+        # broken links.
+        self.assertTrue(os.path.exists(self.__lg_sym_path),
+                        "'{0}' is a link that exists, but what it points to does not exist".format(self.__lg_sym_path))
+
+
+    def test_symlink_is_relative(self):
+        """test run_last.d symlink is relative and not absolute"""
+        # note test_symlink_exists probes all forms of existence
+        sym_target = os.readlink(self.__lg_sym_path)
+        self.assertFalse(sym_target.startswith('/'),
+                         "'{0}'->'{1}' is an absolute path and must be relative".format(
+                             self.__lg_sym_path, sym_target))

--- a/test/stream-monitor/test/test_stream_base.py
+++ b/test/stream-monitor/test/test_stream_base.py
@@ -1,13 +1,13 @@
 import unittest, os
 import sys
 from nose.plugins import PluginTester
-from sm_plugin import StreamMonitorPlugin
+from sm_plugin import smp_get_stream_monitor_plugin
 
 support = os.path.join(os.path.dirname(__file__), 'support')
 
 class _TestStreamMonitorPluginTester(PluginTester, unittest.TestCase):
     activate = '--with-stream-monitor'
-    _smp = StreamMonitorPlugin()
+    _smp = smp_get_stream_monitor_plugin()
     _smp._self_test_print_step_enable()
     plugins = [_smp]
     def runTest(self):

--- a/test/tests/rackhd11/test_rackhd11_api_catalogs.py
+++ b/test/tests/rackhd11/test_rackhd11_api_catalogs.py
@@ -11,8 +11,9 @@ import sys
 import subprocess
 sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
+import flogging
 
-logs = fit_common.get_loggers()
+logs = flogging.get_loggers()
 
 # Local methods
 MON_NODES = fit_common.node_select()

--- a/test/tests/rackhd11/test_rackhd11_api_misc.py
+++ b/test/tests/rackhd11/test_rackhd11_api_misc.py
@@ -15,7 +15,7 @@ import fit_common
 
 # Select test group here using @attr
 from nose.plugins.attrib import attr
-@attr(all=True, regression=True, smoke=True)
+@attr(all=True)
 class rackhd11_api_misc(fit_common.unittest.TestCase):
     def test_api_11_docs_page(self):
         api_data = fit_common.rackhdapi('/docs')

--- a/test/tests/rackhd11/test_rackhd11_api_templates.py
+++ b/test/tests/rackhd11/test_rackhd11_api_templates.py
@@ -16,6 +16,11 @@ import fit_common
 from nose.plugins.attrib import attr
 @attr(all=True, regression=True, smoke=True)
 class rackhd11_api_templates(fit_common.unittest.TestCase):
+    def setUp(self):
+        # this clears out any existing instance of 'testid' template
+        # template 'delete' not supported in API 1.1, using 2.0
+        fit_common.rackhdapi("/api/2.0/templates/library/testid", action="delete")
+
     def test_api_11_templates_library(self):
         api_data = fit_common.rackhdapi("/api/1.1/templates/library")
         self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
@@ -26,17 +31,16 @@ class rackhd11_api_templates(fit_common.unittest.TestCase):
                     print "Checking:", item['name'], subitem
                 self.assertGreater(len(item[subitem]), 0, subitem + ' field error')
 
-    def test_api_11_templates_library_ID(self):
-        api_data = fit_common.rackhdapi("/api/1.1/templates/library")
+    def test_api_11_templates_library_ID_put_get_delete(self):
+        # this test creates a dummy template called 'testid', checks it, then deletes it
+        api_data = fit_common.rackhdapi("/api/1.1/templates/library/testid?scope=global", action="text-put", payload="null")
         self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
-        for item in api_data['json']:
-            lib_data = fit_common.rackhdapi("/api/1.1/templates/library/" + item['name'])
-            self.assertEqual(lib_data['status'], 200, "Was expecting code 200. Got " + str(lib_data['status']))
-            # check required fields
-            for subitem in ['contents', 'createdAt', 'id', 'name', 'updatedAt']:
-                if fit_common.VERBOSITY >= 2:
-                    print "Checking:", item['name'], subitem
-                self.assertGreater(len(item[subitem]), 0, subitem + ' field error')
+        api_data = fit_common.rackhdapi("/api/1.1/templates/library/testid")
+        self.assertIn(api_data['json']['contents'], "null", "Data 'null' was not returned.")
+        self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
+        # template 'delete' not supported in API 1.1, using 2.0
+        api_data = fit_common.rackhdapi("/api/2.0/templates/library/testid", action="delete")
+        self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
 
 if __name__ == '__main__':
     fit_common.unittest.main()

--- a/test/tests/rackhd20/test_rackhd20_api_misc.py
+++ b/test/tests/rackhd20/test_rackhd20_api_misc.py
@@ -15,7 +15,7 @@ import fit_common
 
 # Select test group here using @attr
 from nose.plugins.attrib import attr
-@attr(all=True, regression=True, smoke=True)
+@attr(all=True)
 class rackhd20_api_misc(fit_common.unittest.TestCase):
     def test_api_20_docs_page(self):
         api_data = fit_common.rackhdapi('/docs')

--- a/test/tests/rackhd20/test_rackhd20_api_templates.py
+++ b/test/tests/rackhd20/test_rackhd20_api_templates.py
@@ -17,7 +17,9 @@ from nose.plugins.attrib import attr
 @attr(all=True, regression=True, smoke=True)
 class rackhd20_api_templates(fit_common.unittest.TestCase):
     def setUp(self):
-        api_data = fit_common.rackhdapi("/api/2.0/templates/library/testid", action="delete")
+        # this clears out any existing instance of 'testid' template
+        fit_common.rackhdapi("/api/2.0/templates/library/testid", action="delete")
+
     def test_api_20_templates_metadata(self):
         api_data = fit_common.rackhdapi("/api/2.0/templates/metadata")
         self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
@@ -40,20 +42,15 @@ class rackhd20_api_templates(fit_common.unittest.TestCase):
                     print "Checking:", item['name'], subitem
                 self.assertGreater(len(item[subitem]), 0, subitem + ' field error')
 
-    def test_api_20_templates_library_ID_get(self):
-        api_data = fit_common.rackhdapi("/api/2.0/templates/metadata")
-        self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
-        for item in api_data['json']:
-            lib_data = fit_common.rackhdapi("/api/2.0/templates/library/" + item['name'])
-            self.assertEqual(lib_data['status'], 200, "Was expecting code 200. Got " + str(lib_data['status']))
-
     def test_api_20_templates_library_ID_put_get_delete(self):
+        # this test creates a dummy template called 'testid', checks it, then deletes it
         api_data = fit_common.rackhdapi("/api/2.0/templates/library/testid?scope=global", action="text-put", payload="null")
         self.assertEqual(api_data['status'], 201, "Was expecting code 201. Got " + str(api_data['status']))
         api_data = fit_common.rackhdapi("/api/2.0/templates/library/testid")
         self.assertEqual(api_data['text'], "null", "Data 'null' was not returned.")
         self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
         api_data = fit_common.rackhdapi("/api/2.0/templates/library/testid", action="delete")
+        self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
 
 if __name__ == '__main__':
     fit_common.unittest.main()


### PR DESCRIPTION
Primary changes:
* changed abs symlink to be a link within the same dir
* added logger_get_logging_dir to infra-logging (for test use)

TDD changes:
* fixed 'collect_only' check so it works when testing the plugins as well as when the plugin is used!
* added test_infra_logging.py as location for tests of the infra-logging stuff.
** added setup to ask infra-logging (via the logger_get_logging_dir from above) where to look
** added canary test to make sure tests are being invoked
** added test to check the run_last.d is there, is a symlink, and points to something valid
** added fail-before-change, pass-after-change test to make sure the symlink doesn't start with a '/'. I.E., it's relative.
* changed test_stream_base to use nose-created singleton for StreamMonitorPlugin instance.

Nearby-changes:
* change both test and test/stream-monitor's mkenv.sh's to upgrade the venv pip. This speeds up generation of the virtual-env's signifigently and appears to finally get rid of errors based on trying to compile things.
* removed wheel pinned to 0.24.0 from requirements.txt (this is taken care of automagically)
* removed bogus __name__ == '__main__' code from infra_logging.py


@RackHD/corecommitters @johren @hohene @gpaulos @larry-dean @jimturnquist @keedya @panpan0000 @changev @anhou 

(note: reviewer list built up from "people I think _might_ be interested in this" ;) )
This is NOT needed for phase-1, but should not hurt anything. It also paves the way to be able to test rac-3817 (getting captured data back to pre-pull-544 levels)