### PR TITLE
Add HOME into environment passed through subprocess.

### DIFF
--- a/test/common/fit_common.py
+++ b/test/common/fit_common.py
@@ -888,6 +888,7 @@ def run_nose(nosepath):
             'HTTPS':  str(ARGS_LIST['https']),
             'PORT':  str(ARGS_LIST['port']),
             'FIT_CONFIG': CONFIG_PATH + "global_config.json",
+            'HOME':  os.environ['HOME'],
             'PATH':  os.environ['PATH']
         }
         argv = ['nosetests']


### PR DESCRIPTION
Tested the following:

python run.py --show-plan
python run.py --group="pollers_api2.tests"
python run_tests.py -config dellemc-test/config-mn -stack 1 -test util/display_rackhd_nodes.py
python run_tests.py -config dellemc-test/config-mn -stack 1 -test deploy/rackhd_stack_init.py -list
python run_tests.py -config dellemc-test/config-mn -stack 1 -test tests/compute/test_rackhd11_computenode_pollers.py
python run_tests.py -config dellemc-test/config-mn -stack 1 -test tests -group smoke

@RackHD/corecommitters @gpaulos @hohene 