### PR TITLE
Remove API docs tests from smoke/regression

### DIFF
--- a/test/tests/rackhd11/test_rackhd11_api_misc.py
+++ b/test/tests/rackhd11/test_rackhd11_api_misc.py
@@ -15,7 +15,7 @@ import fit_common
 
 # Select test group here using @attr
 from nose.plugins.attrib import attr
-@attr(all=True, regression=True, smoke=True)
+@attr(all=True)
 class rackhd11_api_misc(fit_common.unittest.TestCase):
     def test_api_11_docs_page(self):
         api_data = fit_common.rackhdapi('/docs')

--- a/test/tests/rackhd20/test_rackhd20_api_misc.py
+++ b/test/tests/rackhd20/test_rackhd20_api_misc.py
@@ -15,7 +15,7 @@ import fit_common
 
 # Select test group here using @attr
 from nose.plugins.attrib import attr
-@attr(all=True, regression=True, smoke=True)
+@attr(all=True)
 class rackhd20_api_misc(fit_common.unittest.TestCase):
     def test_api_20_docs_page(self):
         api_data = fit_common.rackhdapi('/docs')


### PR DESCRIPTION
These tests are causing errors in the CIT/FIT production jobs because the production RackHD deployment does not install the docs pages. 

This just removes the tests from the smoke and regression jobs. They can still be run individually if desired.

@hohene @johren @jimturnquist @diontje @larry-dean @keedya 
