### PR TITLE
Update stack init poweron nodes

### DIFF
--- a/test/deploy/rackhd_stack_init.py
+++ b/test/deploy/rackhd_stack_init.py
@@ -118,10 +118,11 @@ class rackhd_stack_init(unittest.TestCase):
         # no PDU case
         else:
             print '**** No supported PDU found, restarting nodes using IMPI.'
-            # Power off all nodes
-            self.assertNotEqual(fit_common.power_control_all_nodes("off"), 0, 'No BMC IP addresses found')
-            # Power on all nodes
-            self.assertNotEqual(fit_common.power_control_all_nodes("on"), 0, 'No BMC IP addresses found')
+            # Power cycle all nodes via IPMI, display warning if no nodes found
+            if fit_common.power_control_all_nodes("off") == 0:
+                fit_common.power_control_all_nodes("on")
+            else:
+                print '**** No BMC IP addresses found in arp table, continuing...'
 
     # Optionally install control switch node if present
     @unittest.skipUnless("control" in fit_common.STACK_CONFIG[fit_common.ARGS_LIST['stack']], "")

--- a/test/deploy/rackhd_stack_init.py
+++ b/test/deploy/rackhd_stack_init.py
@@ -117,12 +117,13 @@ class rackhd_stack_init(unittest.TestCase):
             fit_common.countdown(30)
         # no PDU case
         else:
-            print '**** No supported PDU found, restarting nodes using IMPI.'
             # Power cycle all nodes via IPMI, display warning if no nodes found
             if fit_common.power_control_all_nodes("off") == 0:
-                fit_common.power_control_all_nodes("on")
+                print '**** No supported PDU found, restarting nodes using IMPI.'
             else:
-                print '**** No BMC IP addresses found in arp table, continuing...'
+                print '**** No BMC IP addresses found in arp table, continuing without node restart.'
+            # power on all nodes under any circumstances
+            fit_common.power_control_all_nodes("on")
 
     # Optionally install control switch node if present
     @unittest.skipUnless("control" in fit_common.STACK_CONFIG[fit_common.ARGS_LIST['stack']], "")


### PR DESCRIPTION
This PR suppresses a spurious test failure in the CIT/FIT Jenkins run. 

Removed the assert for IMPI node restart because the arp table is empty on the Vagrant host. This is not a test but a setup step which is not necessary in the CIT/FIT environment. If the call to fit_common.power_control_all_nodes() returns nonzero, it will print a warning but not issue an assert. 

@hohene @johren @jimturnquist @diontje @larry-dean @keedya