### PR TITLE
RAC-3883 keep new infra-logging from interfering with unconverted CIT tests' output

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -5,3 +5,4 @@ startup.sh
 nohup.out
 *~
 auth.json
+testfile

--- a/test/common/fit_common.py
+++ b/test/common/fit_common.py
@@ -21,7 +21,6 @@ import requests
 import pexpect
 import shutil
 import nose
-from flogging import get_loggers, logger_config_api
 
 # Globals
 
@@ -900,7 +899,7 @@ def run_nose(nosepath):
 
     exitcode = 0
     # set nose options
-    noseopts = ['--exe', '--with-nosedep']
+    noseopts = ['--exe', '--with-nosedep', '--with-stream-monitor']
     if ARGS_LIST['group'] != 'all' and ARGS_LIST['group'] != '':
         noseopts.append('-a')
         noseopts.append(str(ARGS_LIST['group']))

--- a/test/mkenv.sh
+++ b/test/mkenv.sh
@@ -49,6 +49,9 @@ source .venv/${env_name}/bin/activate
 # Use locally sourced pip configuration
 export PIP_CONFIG_FILE=`pwd`/pip.conf
 
+# Update local-pip to latest
+pip install -U pip
+
 # Install all required packages
 pip install -r requirements.txt
 

--- a/test/setup.cfg
+++ b/test/setup.cfg
@@ -1,3 +1,2 @@
 [nosetests]
-with-stream-monitor=1
 exe=1

--- a/test/tests/rackhd11/test_rackhd11_api_catalogs.py
+++ b/test/tests/rackhd11/test_rackhd11_api_catalogs.py
@@ -11,8 +11,9 @@ import sys
 import subprocess
 sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
+import flogging
 
-logs = fit_common.get_loggers()
+logs = flogging.get_loggers()
 
 # Local methods
 MON_NODES = fit_common.node_select()


### PR DESCRIPTION

General solution: make it so the places where infra-logging gets imported ONLY happen when running FIT tests. Changes made to do this:
* remove with-stream-monitor from setup.cfg. This keeps nose from auto-bringing in stream-monitor which in turns brings in the new logging infrastructure
* remove access to infra-logging from fit_common.py import-time. (This doesn't actually impact CIT interaction, but does keep us from double-rotating the log-dir and/or rotating them on "run_test.py --help"
* added "--with-stream-monitor" to sub-process invocation within fit-common. That means when we DO finally kick off the real nosetests via run_tests.py , the plugin is enabled and flogging comes on line
* changed tests/rackhd11/test_rackhd11_api_catalogs.py to directly grab flogging. See below for thoughts on that.
* added another random file some test generated to .gitignore.

Note that I'm a little iffy on having the test-file import flogging directly. I still think there might be an end-case for accidently double-rotating log-dir because of this. However, it's not one of the main paths (like Jenkins or the more common test-development flows).

@RackHD/corecommitters @johren @hohene @gpaulos @larry-dean @jimturnquist @keedya @panpan0000 @changev @anhou

NOTE: fairly high priority, since this makes diagnosing unconverted CIT test failures difficult!