### PR TITLE
RAC-3748

### DIFF
--- a/test/common/mkcfg.py
+++ b/test/common/mkcfg.py
@@ -9,96 +9,103 @@ import json
 
 #pylint: disable=invalid-name
 
+class mkcfgException(Exception):
+    pass
+
 class mkcfg(object):
 
     """
     Manages a RackHD test configuration
 
-    Singleton object creation:
-    cfg = mkcfg(config_dir, json_config_files, arg_list)
+    # Singleton object creation:
+    mkcfg()
 
-    Access the singleton
+    # Access the singleton
     cfg = mkcfg()
 
-    Methods:
-        add : adds additional test configurations to an existing
-              mkcfg object.  Individual dictionary values will be
-              overwritten by the inbound json_config_file values.
+    # add a list of json configs
+    cfg.add_from_file_list(json_config_file_list)
 
-              Example:
-              cfg = mkcfg(config_dir, json_config_files, arg_list)
-              cfg.add(stack_config_file)
+    # add a single json config
+    cfg.add_from_file_list(json_config_file_list)
 
-        get : returns the config dictionary
+    # add a json config from dict
+    cfg.add_from_dict(config_dict)
 
-              Example:
-              myconfig_dict = cfg.get()
+    # write out configuration
+    cfg.generate()
 
-        get_path : returns the config dictionary
+    # retrieve the config as a dict
+    cfg_dict = cfg.get()
 
-              Example:
-              config_path = cfg.get_path()
+    # retrieve the path to saved configuration
+    cfg_dict = cfg.get_path()
 
-        destroy : destroys the singleton to allow for a new configuration
-
-              Example:
-              cfg.destroy()
     """
 
     # mkcfg is a singleton
     __metaclass__ = Singleton
 
     config_env = 'FIT_CONFIG'
-    default_composition = ['rackhd_default.json', 'credentials_default.json']
 
-    def __init__(self, config_dir=None, json_config_list=None, arg_list=None):
+    def __init__(self, config_dir='config'):
 
-        # handle default mutable types
-        if json_config_list is None:
-            json_config_list = []
-        if arg_list is None:
-            arg_list = []
-
-        self.generated_config_path = None
-        self.config_dict = dict()
-        self.config_dir = config_dir
-        self.generated_dir = self.config_dir + '/generated'
         config_path = os.environ.get(self.config_env)
-        if not config_path:
-            # no test configuration from environment.  create the config
-            self.add(json_config_list, arg_list)
-        else:
+
+        if config_path:
             # load up an existing configuration
+            print "*** Reloading config file: " + config_path
             self.generated_config_path = config_path
             self.config_dict = self.__read_config(self.generated_config_path)
+            self.config_dir = self.config_dict['cmd-args-list']['config']
+            self.generated_dir = self.config_dir + '/generated'
+        else:
+            # prepare for creation of new configuration
+            self.generated_config_path = None
+            self.config_dict = dict()
+            self.config_dir = config_dir
+            self.generated_dir = self.config_dir + '/generated'
+            config_path = os.environ.get(self.config_env)
 
-    def add(self, json_config_list, arg_list=None):
+    def add_from_file_list(self, json_config_list):
         """
-        add a test configuration
+        add a list of json configuration files
+        :param json_config_list: file list
+        :return: None
+        """
+        for json_config in json_config_list:
+            self.add_from_file(json_config)
 
-        :config_dir: path to configuration files
-        :param config_list: list of json configurations to be applied in order
-        :param arg_list: command-line arguments
+    def add_from_file(self, json_config, key=None):
+        """
+        add a single json configuration file
+        :param json_config: json config file
+        :return: None
+        """
+        config_dict = self.__read_config(self.config_dir + '/' + json_config)
+        if key:
+            if key in config_dict:
+                config_dict = config_dict[key]
+            else:
+                raise mkcfgException('unknown key = ' + key)
+        self.__merge(config_dict)
+
+    def add_from_dict(self, add_dict):
+        """
+        merge a dictionary into config dict
+        :param add_dict:
         :return:
         """
-        # apply schema overlays
-        schema = {'mergeStrategy': 'objectMerge'}
-        for json_config in json_config_list:
-            self.config_dict = jsonmerge.merge(self.config_dict,
-                                               self.__read_config(self.config_dir + '/' + json_config),
-                                               schema)
+        self.__merge(add_dict)
 
-        # add test-config section
-        if 'test-config' not in self.config_dict:
-            self.config_dict['test-config'] = dict()
-
-        # add cmd-line-args section
-        if 'cmd-line-args' not in self.config_dict:
-            if arg_list:
-                self.config_dict['cmd-line-args'] = arg_list
-
+    def generate(self):
+        """
+        generate a configuration file
+        :return: None
+        """
         self.generated_config_path = self.__write_config_file()
         os.environ[self.config_env] = self.generated_config_path
+        print "*** Created config file: " + self.generated_config_path
 
     def get(self):
         """
@@ -121,13 +128,22 @@ class mkcfg(object):
         """
         Singleton.purge(mkcfg)
 
+    def __merge(self, json_blob):
+        """
+        json merge a json blob into config_dict
+        :param json_blob:
+        :return:
+        """
+        schema = {'mergeStrategy': 'objectMerge'}
+        self.config_dict = jsonmerge.merge(self.config_dict, json_blob, schema)
+
     def __write_config_file(self, prepend=''):
         """
         write a json configuration file with a timestamped name
         :return:
         """
         timestr = prepend + time.strftime("%Y%m%d-%H%M%S")
-        config_path = self.generated_dir + '/' + timestr
+        config_path = self.generated_dir + '/' + 'fit-config-' + timestr
         with open(config_path, 'w') as outf:
             json.dump(self.config_dict, outf, indent=4, sort_keys=True)
         return config_path
@@ -194,25 +210,30 @@ if __name__ == "__main__":
 
     # specify a sample argument list
     ARGS_LIST = {
-        "v": "v_value",
-        "config": "config_value",
-        "stack": "stack_value",
-        "ora": "ora_value",
-        "bmc": "bmc_value",
-        "sku": "sku_value",
-        "obmmac": "obmmac_value",
-        "nodeid": "nodeid_value",
-        "http": 8080,
-        "https": 443
+        "cmd-arg-list": {
+            "v": "v_value",
+            "config": "config_value",
+            "stack": "stack_value",
+            "ora": "ora_value",
+            "bmc": "bmc_value",
+            "sku": "sku_value",
+            "obmmac": "obmmac_value",
+            "nodeid": "nodeid_value",
+            "http": 8080,
+            "https": 443
+        }
     }
 
     # Test config creation
-    cfg = mkcfg(config_dir_arg, json_config_files_arg, ARGS_LIST)
+    cfg = mkcfg(config_dir_arg)
+
+    cfg.add_from_file_list(json_config_files_arg)
+    cfg.add_from_dict(ARGS_LIST)
     cfg.dump()
+    cfg.generate()
 
     # Dump out the configuration path.  We should be able to access with cfg object
     print "path = " + mkcfg().get_path()
-    cfg.dump()
 
     # Get config singleton object and compare dictionaries
     cfg2 = mkcfg()

--- a/test/config/cit_default.json
+++ b/test/config/cit_default.json
@@ -1,0 +1,28 @@
+{
+  "cit-config": {
+    "_comment": "CIT-specific configuration",
+    "RACKHD_TEST_LOGLVL": "WARNING",
+    "RACKHD_HOST": "localhost",
+    "RACKHD_PORT": 9090,
+    "RACKHD_PORT_AUTH": 9093,
+    "RACKHD_HTTPD_PORT": 9010,
+    "RACKHD_AMQP_URL": "amqp://localhost:9091",
+    "RACKHD_SSH_USER": "vagrant",
+    "RACKHD_SSH_PASSWORD": "vagrant",
+    "RACKHD_SSH_PORT": 2222,
+    "RACKHD_USER_AUTH_PORT": 8443,
+    "RACKHD_GLOBAL_OBM_SERVICE_NAME": "ipmi-obm-service",
+    "RACKHD_BASE_REPO_URL": "http://172.31.128.1:8080",
+    "RACKHD_SMB_USER": "onrack",
+    "RACKHD_SMB_PASSWORD": "onrack",
+    "RACKHD_SMB_WINDOWS_REPO_PATH": "\\172.31.128.1\\windowsServer2012",
+    "RACKHD_SAMPLE_PAYLOADS_PATH": "../example/samples/",
+    "RACKHD_CENTOS_REPO_PATH": "http://172.31.128.1:8080/repo/centos",
+    "RACKHD_ESXI_REPO_PATH": "http://172.31.128.1:8080/repo/esxi",
+    "RACKHD_UBUNTU_REPO_PATH": "http://172.31.128.1:8080/repo/ubuntu",
+    "RACKHD_SUSE_REPO_PATH": "http://172.31.128.1:8080/repo/suse",
+    "RACKHD_WINPE_REPO_PATH": "http://172.31.128.1:8080/repo/winpe",
+    "RACKHD_REDFISH_URL": "https://192.168.1.100/redfish/v1",
+    "RACKHD_REDFISH_EMC_OEM": false
+  }
+}

--- a/test/config/install_default.json
+++ b/test/config/install_default.json
@@ -1,25 +1,27 @@
 {
-  "template": "ora-ubuntu-1604.ova",
-  "install": {
-    "rackhd":       {"repo":"https://github.com/rackhd/rackhd","branch":"master"},
-    "on-core":      {"repo":"https://github.com/rackhd/on-core","branch":"master"},
-    "on-dhcp-proxy":{"repo":"https://github.com/rackhd/on-dhcp-proxy","branch":"master"},
-    "on-http":      {"repo":"https://github.com/rackhd/on-http","branch":"master"},
-    "on-statsd":    {"repo":"https://github.com/rackhd/on-statsd","branch":"master"},
-    "on-syslog":    {"repo":"https://github.com/rackhd/on-syslog","branch":"master"},
-    "on-tasks":     {"repo":"https://github.com/rackhd/on-tasks","branch":"master"},
-    "on-taskgraph": {"repo":"https://github.com/rackhd/on-taskgraph","branch":"master"},
-    "on-tftp":      {"repo":"https://github.com/rackhd/on-tftp","branch":"master"},
-    "on-tools":     {"repo":"https://github.com/rackhd/on-tools","branch":"master"},
-    "on-imagebuilder": {"repo":"https://github.com/rackhd/on-imagebuilder","branch":"master"},
-    "on-wss":       {"repo":"https://github.com/rackhd/on-wss","branch":"master"}
-    },
-  "skupack": [
-    "https://github.com/RackHD/on-skupack"
-    ],
-  "proxy": {
-    "url": "",
-    "host": "",
-    "port": ""
-  }
+  "test-config": {
+      "template": "ora-ubuntu-1604.ova",
+      "install": {
+        "rackhd":       {"repo":"https://github.com/rackhd/rackhd","branch":"master"},
+        "on-core":      {"repo":"https://github.com/rackhd/on-core","branch":"master"},
+        "on-dhcp-proxy":{"repo":"https://github.com/rackhd/on-dhcp-proxy","branch":"master"},
+        "on-http":      {"repo":"https://github.com/rackhd/on-http","branch":"master"},
+        "on-statsd":    {"repo":"https://github.com/rackhd/on-statsd","branch":"master"},
+        "on-syslog":    {"repo":"https://github.com/rackhd/on-syslog","branch":"master"},
+        "on-tasks":     {"repo":"https://github.com/rackhd/on-tasks","branch":"master"},
+        "on-taskgraph": {"repo":"https://github.com/rackhd/on-taskgraph","branch":"master"},
+        "on-tftp":      {"repo":"https://github.com/rackhd/on-tftp","branch":"master"},
+        "on-tools":     {"repo":"https://github.com/rackhd/on-tools","branch":"master"},
+        "on-imagebuilder": {"repo":"https://github.com/rackhd/on-imagebuilder","branch":"master"},
+        "on-wss":       {"repo":"https://github.com/rackhd/on-wss","branch":"master"}
+        },
+      "skupack": [
+        "https://github.com/RackHD/on-skupack"
+        ],
+      "proxy": {
+        "url": "",
+        "host": "",
+        "port": ""
+      }
+    }
 }

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -5,98 +5,19 @@ Copyright 2016, EMC, Inc
 
 Author(s):
 George Paulos
-
-This Script runs nose tests with command-line arguments.
-
-usage: run_tests.py [-h] [-test TEST] [-group GROUP] [-stack STACK] [-ora ORA]
-                    [-version VERSION] [-xunit] [-list] [-sku SKU]
-                    [-obmmac OBMMAC | -nodeid NODEID] [-v V]
-
-Command Help
-
-optional arguments:
-  -h, --help        show this help message and exit
-  -test TEST        test to execute, default: tests/
-  -group GROUP      test group to execute: 'smoke', 'regression', 'extended',
-                    default: 'all'
-  -stack STACK      stack label (test bed), overrides -ora
-  -ora ORA          OnRack/RackHD appliance IP address or hostname, default:
-                    localhost
-  -version VERSION  OnRack version, example:onrack-release-0.3.0, default:
-                    onrack-devel
-  -xunit            generates xUnit XML report files
-  -list             generates test list only
-  -sku SKU          node SKU, example:Phoenix, default=all
-  -obmmac OBMMAC    node OBM MAC address, example:00:1e:67:b1:d5:64,
-                    default=all
-  -nodeid NODEID    node identifier string of a discovered node, example:
-                    56ddcf9a8eff16614e79ec74
-  -v V              Verbosity level of console output, default=0, Built Ins:
-                    0: No debug, 2: User script output, 4: rest calls and
-                    status info, 6: other common calls (ipmi, ssh), 9: all the
-                    rest
 '''
 
+# set path to common libraries
 import sys
 import subprocess
-import argparse
-# set path to common libraries
+
 sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
-
-# command line argument parser returns CMD_ARGS dict
-ARG_PARSER = argparse.ArgumentParser(description="Command Help")
-ARG_PARSER.add_argument("-test", default="tests/",
-                        help="test to execute, default: tests/")
-ARG_PARSER.add_argument("-config", default="config",
-                        help="config file location, default: config")
-ARG_PARSER.add_argument("-group", default="all",
-                        help="test group to execute: 'smoke', 'regression', 'extended', default: 'all'")
-ARG_PARSER.add_argument("-stack", default="None",
-                        help="stack label (test bed), overrides -ora")
-ARG_PARSER.add_argument("-ora", default="localhost",
-                        help="OnRack/RackHD appliance IP address or hostname, default: localhost")
-ARG_PARSER.add_argument("-version", default="onrack-devel",
-                        help="OnRack package install version, example:onrack-release-0.3.0, default: onrack-devel")
-ARG_PARSER.add_argument("-template", default=fit_common.GLOBAL_CONFIG['repos']['install']['template'],
-                        help="path or URL link to OVA template or OnRack OVA, default from global_config.json")
-ARG_PARSER.add_argument("-xunit", default="False", action="store_true",
-                        help="generates xUnit XML report files")
-ARG_PARSER.add_argument("-numvms", default=1, type=int,
-                        help="number of virtual machines for deployment on specified stack")
-ARG_PARSER.add_argument("-list", default="False", action="store_true",
-                        help="generates test list only")
-ARG_PARSER.add_argument("-sku", default="all",
-                        help="node SKU, example:Phoenix, default=all")
-GROUP = ARG_PARSER.add_mutually_exclusive_group(required=False)
-GROUP.add_argument("-obmmac", default="all",
-                        help="node OBM MAC address, example:00:1e:67:b1:d5:64")
-GROUP.add_argument("-nodeid", default="None",
-                     help="node identifier string of a discovered node, example: 56ddcf9a8eff16614e79ec74")
-GROUP2 = ARG_PARSER.add_mutually_exclusive_group(required=False)
-GROUP2.add_argument("-http", default="False", action="store_true",
-                        help="forces the tests to utilize the http API protocol")
-GROUP2.add_argument("-https", default="False", action="store_true",
-                        help="forces the tests to utilize the https API protocol")
-ARG_PARSER.add_argument("-port", default="None",
-                        help="API port number override, default from global_config.json")
-ARG_PARSER.add_argument("-v", default=1, type=int,
-                        help="Verbosity level of console output, default=0, Built Ins: " +
-                             "0: No debug, " +
-                             "2: User script output, " +
-                             "4: rest calls and status info, " +
-                             "6: other common calls (ipmi, ssh), " +
-                             "9: all the rest ")
-
-# parse arguments to CMD_ARGS dict
-CMD_ARGS = vars(ARG_PARSER.parse_args())
-# transfer argparse args to ARGS_LIST
-for keys in CMD_ARGS:
-    fit_common.ARGS_LIST[keys] = CMD_ARGS[keys]
+# validate command line args
+fit_common.mkargs()
 
 # Run tests
-EXITCODE = fit_common.run_nose(CMD_ARGS['test'])
-
+EXITCODE = fit_common.run_nose()
 exit(EXITCODE)
 


### PR DESCRIPTION
Transitional change that has both old-style and new-style
configurations in flight.

- Generate json configuration based on mkcfg module.
- Encapsulate previous global_config.json configuration generation
  inside function calls.
- Still use global_config.json as we convert over to mkcfg-style.
- Supports both run_tests.py style runs as well as direct test invocations.

verified the following:

python run_tests.py -config dellemc-test/config-mn -stack 1 -test util/display_rackhd_nodes.py
python run_tests.py -config dellemc-test/config-mn -stack 1 -test deploy/rackhd_stack_init.py -list
python run_tests.py -config dellemc-test/config-mn -stack 1 -test tests/compute/test_rackhd11_computenode_pollers.py
python run_tests.py -config dellemc-test/config-mn -stack 1 -test tests -group smoke
python run.py --show-plan
python run.py --group="pollers_api2.tests"
