### PR TITLE
rac-3789 run_last.d symlink should be relative rather than absolute

### DIFF
--- a/test/stream-monitor/flogging/__init__.py
+++ b/test/stream-monitor/flogging/__init__.py
@@ -2,4 +2,5 @@ from infra_logging import *
 from logger_sets import get_loggers
 
 all = ['getLogger', 'getInfraRunLogger', 'getInfraDataLogger',
-       'getTestRunLogger', 'getTestDataLogger', 'get_loggers', 'logger_config_api']
+       'getTestRunLogger', 'getTestDataLogger', 'get_loggers',
+       'logger_get_logging_dir', 'logger_config_api']

--- a/test/stream-monitor/flogging/infra_logging.py
+++ b/test/stream-monitor/flogging/infra_logging.py
@@ -143,18 +143,23 @@ class _LoggerSetup(object):
             shutil.rmtree(trim_name)
 
         ts_ext = datetime.now().strftime('%Y-%m-%d_%X')
-        self.__lg_run_dir = os.path.join(lg_base_dir, 'run_{0}.d'.format(ts_ext))
+        run_name = 'run_{0}.d'.format(ts_ext)
+        self.__lg_run_dir = os.path.join(lg_base_dir, run_name)
         self.__prelog(logging.INFO, "this runs logging dir %s", self.__lg_run_dir)
         self.__makedirs_dash_p(os.path.join(self.__lg_run_dir))
 
         # now deal with and easy to use 'last'
-        last_name = os.path.join(lg_base_dir, 'run_last.d')
-        if os.path.islink(last_name):
-            os.unlink(last_name)
+        last_name = 'run_last.d'
+        last_path = os.path.join(lg_base_dir, last_name)
+        if os.path.islink(last_path):
+            os.unlink(last_path)
 
-        assert not os.path.lexists(last_name), \
+        assert not os.path.lexists(last_path), \
             "'{0}' still existed after unlink. Check for file/dir and remove manually".format(last_name)
-        os.symlink(self.__lg_run_dir, last_name)
+        cur_dir = os.getcwd()
+        os.chdir(lg_base_dir)
+        os.symlink(run_name, last_name)
+        os.chdir(cur_dir)
 
         self.__infra_run_lgn = os.path.join(self.__lg_run_dir, 'infra_run.log')
         self.__infra_data_lgn = os.path.join(self.__lg_run_dir, 'infra_data.log')
@@ -291,6 +296,12 @@ class _LoggerSetup(object):
     def set_level(self, new_level):
         pass
 
+    def get_logging_dir(self):
+        """
+        Right now mostly for test-test, but may enter infra-use later
+        """
+        return self.__lg_run_dir
+
 
 setLoggerClass(_LevelLoggerClass)
 
@@ -325,3 +336,5 @@ _logger_setup_instance = _LoggerSetup()
 def logger_config_api(verbosity):
     _logger_setup_instance.set_level(verbosity)
 
+def logger_get_logging_dir():
+    return _logger_setup_instance.get_logging_dir()

--- a/test/stream-monitor/mkenv.sh
+++ b/test/stream-monitor/mkenv.sh
@@ -49,6 +49,9 @@ source .venv/${env_name}/bin/activate
 # Use locally sourced pip configuration
 export PIP_CONFIG_FILE=`pwd`/pip.conf
 
+# Update local-pip to latest
+pip install --upgrade pip
+
 # Install all required packages
 pip install -r requirements.txt
 

--- a/test/stream-monitor/requirements.txt
+++ b/test/stream-monitor/requirements.txt
@@ -1,4 +1,3 @@
 gevent==1.1.2
 greenlet==0.4.10
 nose==1.3.7
-wheel==0.24.0

--- a/test/stream-monitor/sm_plugin/__init__.py
+++ b/test/stream-monitor/sm_plugin/__init__.py
@@ -1,3 +1,3 @@
-from stream_monitor import StreamMonitorPlugin
+from stream_monitor import StreamMonitorPlugin, smp_get_stream_monitor_plugin
 
-__all__ = [ 'StreamMonitorPlugin' ]
+__all__ = [ StreamMonitorPlugin, smp_get_stream_monitor_plugin ]

--- a/test/stream-monitor/sm_plugin/stream_monitor.py
+++ b/test/stream-monitor/sm_plugin/stream_monitor.py
@@ -20,6 +20,12 @@ class StreamMonitorPlugin(Plugin):
         self.__stream_plugins = {}
         super(StreamMonitorPlugin, self).__init__(*args, **kwargs)
 
+    @classmethod
+    def get_singleton_instance(klass):
+        assert klass._singleton is not None, \
+            "Attempt to retrieve singleton before first instance created"
+        return klass._singleton
+
     def _self_test_print_step_enable(self):
         self.__save_call_sequence = []
 
@@ -45,7 +51,7 @@ class StreamMonitorPlugin(Plugin):
         super(StreamMonitorPlugin, self).configure(options,conf)
         if not self.enabled:
             return
-        if conf.options.collect_only:
+        if getattr(conf.options, 'collect_only', False):
             # we don't want to be spitting stuff out during -list!
             self.enabled = False
 
@@ -78,3 +84,12 @@ class StreamMonitorPlugin(Plugin):
         self.__take_step('stopTest', test=test)
         for pg in self.__stream_plugins.values():
             pg.handle_stop_test(test)
+
+
+def smp_get_stream_monitor_plugin():
+    """
+    Get the plugin that nose will have created. ONLY nose should 
+    create the main instance!
+    """
+    smp = StreamMonitorPlugin.get_singleton_instance()
+    return smp

--- a/test/stream-monitor/test/test_infra_logging.py
+++ b/test/stream-monitor/test/test_infra_logging.py
@@ -1,0 +1,41 @@
+"""
+Copyright 2016, EMC, Inc.
+
+This file contains (very very crude, at the moment!) self
+tests of the logging infrastructure.
+"""
+import flogging
+import os
+from unittest import TestCase
+
+class TestInfraLogging(TestCase):
+    def test_canary(self):
+        """canary test to make sure tests are being picked up"""
+        pass
+
+    def setUp(self):
+        self.__lg_full_path = flogging.logger_get_logging_dir()
+        self.__lg_container_path = os.path.dirname(self.__lg_full_path)
+        self.__lg_sym_path = os.path.join(self.__lg_container_path, 'run_last.d')
+
+    def test_symlink_exists(self):
+        """test run_last.d symlink exists"""
+        # lexists returns True for anything that exists (even a broken link)
+        self.assertTrue(os.path.lexists(self.__lg_sym_path),
+                        "'{0}' does not exist on filesystem".format(self.__lg_sym_path))
+        # the next check weeds outs out non-links as bad
+        self.assertTrue(os.path.islink(self.__lg_sym_path),
+                        "'{0}' exists but is not a link".format(self.__lg_sym_path))
+        # and finally, use .exists, which is like lexists except that it returns False for
+        # broken links.
+        self.assertTrue(os.path.exists(self.__lg_sym_path),
+                        "'{0}' is a link that exists, but what it points to does not exist".format(self.__lg_sym_path))
+
+
+    def test_symlink_is_relative(self):
+        """test run_last.d symlink is relative and not absolute"""
+        # note test_symlink_exists probes all forms of existence
+        sym_target = os.readlink(self.__lg_sym_path)
+        self.assertFalse(sym_target.startswith('/'),
+                         "'{0}'->'{1}' is an absolute path and must be relative".format(
+                             self.__lg_sym_path, sym_target))

--- a/test/stream-monitor/test/test_stream_base.py
+++ b/test/stream-monitor/test/test_stream_base.py
@@ -1,13 +1,13 @@
 import unittest, os
 import sys
 from nose.plugins import PluginTester
-from sm_plugin import StreamMonitorPlugin
+from sm_plugin import smp_get_stream_monitor_plugin
 
 support = os.path.join(os.path.dirname(__file__), 'support')
 
 class _TestStreamMonitorPluginTester(PluginTester, unittest.TestCase):
     activate = '--with-stream-monitor'
-    _smp = StreamMonitorPlugin()
+    _smp = smp_get_stream_monitor_plugin()
     _smp._self_test_print_step_enable()
     plugins = [_smp]
     def runTest(self):


### PR DESCRIPTION
NOTE: this is a rebase of https://github.com/RackHD/RackHD/pull/554 , since I managed to completely mess up trying to rebase THAT pr. @hohene and @gpaulos have +1'ed that PR. If you two could "approve" this rebase, and then we just need a @RackHD/corecommitters please.

Primary changes:
* changed abs symlink to be a link within the same dir
* added logger_get_logging_dir to infra-logging (for test use)

TDD changes:
* added test_infra_logging.py as location for tests of the infra-logging stuff.
** added setup to ask infra-logging (via the logger_get_logging_dir from above) where to look
** added canary test to make sure tests are being invoked
** added test to check the run_last.d is there, is a symlink, and points to something valid
** added fail-before-change, pass-after-change test to make sure the symlink doesn't start with a '/'. I.E., it's relative.
* changed test_stream_base to use nose-created singleton for StreamMonitorPlugin instance.

Nearby-changes:
* change both test and test/stream-monitor's mkenv.sh's to upgrade the venv pip. This speeds up generation of the virtual-env's signifigently and appears to finally get rid of errors based on trying to compile things.
* removed wheel pinned to 0.24.0 from requirements.txt (this is taken care of automagically)
* removed bogus __name__ == '__main__' code from infra_logging.py