### PR TITLE
RAC-3817 capture nose stuff

### DIFF
--- a/test/stream-monitor/sm_plugin/stream_monitor.py
+++ b/test/stream-monitor/sm_plugin/stream_monitor.py
@@ -3,11 +3,17 @@ import os
 from nose.plugins import Plugin
 from stream_sources import LoggingMarker
 import sys
+from nose.pyversion import format_exception
+from nose.plugins.xunit import Tee
+from nose import SkipTest
+from StringIO import StringIO
+from logging import ERROR, WARNING
 
 
 class StreamMonitorPlugin(Plugin):
     _singleton = None
     name = "stream-monitor"
+    encoding = 'UTF-8'
     def __init__(self, *args, **kwargs):
         assert StreamMonitorPlugin._singleton is None, \
             "infrastructure fault: more than one StreamMonitorPlugin exists"
@@ -18,6 +24,9 @@ class StreamMonitorPlugin(Plugin):
         # self.__print_to = sys.stderr
         # todo: use nose plugin debug options.
         self.__stream_plugins = {}
+        self.__capture_stack = []
+        self.__current_stdout = None
+        self.__current_stderr = None
         super(StreamMonitorPlugin, self).__init__(*args, **kwargs)
 
     @classmethod
@@ -71,9 +80,13 @@ class StreamMonitorPlugin(Plugin):
     def beforeTest(self, test):
         # order is beforeTest->startTest->stopTest->afterTest
         self.__take_step('beforeTest', test=test)
+        self.__start_capture()
 
     def afterTest(self, test):
         self.__take_step('afterTest', test=test)
+        self.__end_capture()
+        self.__current_stdout = None
+        self.__current_stderr = None
 
     def startTest(self, test):
         self.__take_step('startTest', test=test)
@@ -84,6 +97,85 @@ class StreamMonitorPlugin(Plugin):
         self.__take_step('stopTest', test=test)
         for pg in self.__stream_plugins.values():
             pg.handle_stop_test(test)
+
+    def __start_capture(self):
+        """
+        __start_capture and __end_capture bracket a zone of time that we might want to
+        dump captured information from. E.G. we normally don't WANT to see stdout and stderr
+        from "test_did_this_work()"... unless they fail. In which case, we want to see them!
+
+        Both capture and logcapture report all this at the END of the entire run, however.
+        This is great and very handy (since they are all there at the end of the run). But,
+        in the context of looking at a single test, it's really annoying. So, this logic
+        is stolen from the xunit plugin (which does capture better than capture!). We are
+        basically tucking away stdout/stderrs while letting the data flow to prior levels
+        using the Tee. 
+        """
+        self.__capture_stack.append((sys.stdout, sys.stderr))
+        self.__current_stdout = StringIO()
+        self.__current_stderr = StringIO()
+        sys.stdout = Tee(self.encoding, self.__current_stdout, sys.stdout)
+        sys.stderr = Tee(self.encoding, self.__current_stderr, sys.stderr)
+
+    def __end_capture(self):
+        if self.__capture_stack:
+            sys.stdout, sys.stderr = self.__capture_stack.pop()
+
+    def __get_captured_stdout(self):
+        if self.__current_stdout:
+            value = self.__current_stdout.getvalue()
+            if value:
+                return value
+        return ''
+
+    def __get_captured_stderr(self):
+        if self.__current_stderr:
+            value = self.__current_stderr.getvalue()
+            if value:
+                return value
+        return ''
+
+    def startContext(self, context):
+        self.__start_capture()
+
+    def stopContext(self, context):
+        self.__end_capture()
+
+    def addError(self, test, err):
+        """
+        Handle capturing data on an error being seen. If the "error"
+        is a Skip, we don't care at this point. Otherwise,
+        we want to grab our stdout, stderr, and traceback and asking
+        logging to record all this stuff about the error.
+
+        Note: since 'errors' are related to _running_ the test (vs the
+        test deciding to fail because of an incorrect value), we asking
+        logging to record it as an error.
+        """
+        if issubclass(err[0], SkipTest):
+            # Nothing to see here...
+            return
+
+        self.__propagate_capture(ERROR, 'ERROR', test, err)
+
+    def addFailure(self, test, err):
+        """
+        Handle capturing data on a failure being seen. This covers the case
+        of a test deciding it failed, so we record as a warning level.
+        """
+        self.__propagate_capture(WARNING, 'FAIL', test, err)
+
+    def __propagate_capture(self, log_level, cap_type, test, err):
+        """
+        Common routine to recover capture data and asking logging to
+        deal with it nicely.
+        """
+        tb = format_exception(err, self.encoding)
+        sout = self.__get_captured_stdout()
+        serr = self.__get_captured_stderr()
+        for pg in self.__stream_plugins.values():
+            if hasattr(pg, 'handle_capture'):
+                pg.handle_capture(log_level, cap_type, test, sout, serr, tb)
 
 
 def smp_get_stream_monitor_plugin():

--- a/test/stream-monitor/stream_sources/log_type.py
+++ b/test/stream-monitor/stream_sources/log_type.py
@@ -5,6 +5,7 @@ from .monitor_abc import StreamMonitorABC
 import sys
 from itertools import count
 
+
 class LoggingMarker(StreamMonitorABC):
     _all_blocks = 0
 
@@ -41,6 +42,7 @@ class LoggingMarker(StreamMonitorABC):
         self.__test_cnt += 1
 
     def __mark_all_in_logger(self, level, logger, msg, args, exc_info=None, extra=None):
+        # Note: 'handlers' only exists on Logger() instances.
         handlers = getattr(logger, 'handlers', [])
         if len(handlers) == 0:
             return  # Nothing to do!
@@ -60,6 +62,46 @@ class LoggingMarker(StreamMonitorABC):
         record = logger.makeRecord(logger.name, level, fn, lno, msg, args, exc_info, func, extra)
         for handler in handlers:
             handler.handle(record)
+
+    def __capture_to_log(self, lg, log_level, cap_type, test, sout, serr, tb):
+        """
+        Common routine to push capture data into a logger at a given level.
+        Note: this, along with "handle_capture" are a bit of a stop-gap for
+        RAC-3869. Well, technically this is a solution for this one case, but
+        RAC-3869 covers the general logcapture case, and this would make use
+        of its abilities rather than manually walking loggers in handle_capture
+        and dealing with propagate in such a hacky fashion here.
+        """
+        save_propagate = lg.propagate
+        try:
+            lg.propagate = 0
+            lg.log(log_level, '------start captured data for %s in %s', cap_type, test)
+            lg.log(log_level, 'stdout: %s', sout)
+            lg.log(log_level, 'stderr: %s', serr)
+            lg.log(log_level, 'traceback: %s', tb)
+            lg.log(log_level, '------end captured data for %s in %s', cap_type, test)
+        except:
+            lg.propagate = save_propagate
+            raise
+        lg.propagate = save_propagate
+
+    def handle_capture(self, log_level, cap_type, test, sout, serr, traceback):
+        """
+        StreamMonitorPlugin call-if-present method to handle moving
+        post-test capture data (in the case of error or failures) into
+        the logs. We decide which loggers to add to (currently hard coded
+        to the infra.run, test.run, and the root), and then use __capture_to_log to
+        do the common work.
+        """
+        irlg = real_getLogger('infra.run')
+        self.__capture_to_log(irlg, log_level, cap_type, test, sout, serr,
+                              traceback)
+        trlg = real_getLogger('test.run')
+        self.__capture_to_log(trlg, log_level, cap_type, test, sout, serr,
+                              traceback)
+        root = real_getLogger()
+        self.__capture_to_log(root, log_level, cap_type, test, sout, serr,
+                              traceback)
 
     def __mark_logger_block(self, logger, bracket, level, fmat, *args, **kwargs):
         if bracket:

--- a/test/stream-monitor/test/plugin_test_helper.py
+++ b/test/stream-monitor/test/plugin_test_helper.py
@@ -1,0 +1,99 @@
+import unittest, os
+import sys
+from nose.plugins import PluginTester
+from sm_plugin import StreamMonitorPlugin
+
+
+class _BaseStreamMonitorPluginTester(PluginTester, unittest.TestCase):
+    activate = '--with-stream-monitor'
+    _smp = StreamMonitorPlugin()
+    _smp._self_test_print_step_enable()
+    _expect_nose_success = True
+    plugins = [_smp]
+    def runTest(self):
+        # This is called once for each class derived from it. We don't really
+        # have access to much other than success/failure and the raw string output
+        # for -all- the tests that were run in the derived class.
+
+        # We print out the output from the run tests, trusting in the capture
+        # code to hide it. 
+        print '*' * 70
+        for what in self.output:
+            print ">", what.rstrip()
+        print '*' * 70
+
+        # Now check for success (_expect_nose_success can be set by a subclass
+        # to mark that it expects an error to occur, and then let it handle its
+        # own checking inside its verify)
+        if self._expect_nose_success:
+            self.assertTrue(self.nose.success, 
+                            '----a contained test or tests failed----')
+            
+
+        self.__call_sequence = self._smp._self_test_sequence_seen()
+        self.verify()
+        assert len(self.__call_sequence) == 0, \
+            'still had call-items left at end {0}'.format(self.__call_sequence)
+
+    def verify(self):
+        raise NotImplementedError()
+
+    def _check_sequence_pre_test(self):
+        self.__check_next('options', ['parser', 'env'])
+        self.__check_next('configure', ['options', 'conf'])
+        self.__check_next('begin', [])
+
+    def _check_sequences(self, methods, test_class, test_file):
+        for method in methods:
+            test_name = '{0} ({1}.{2})'.format(method, test_file, test_class)
+            self._check_sequence_test(test_name)
+
+    def _check_sequence_test(self, test_name):
+        self.__check_next('beforeTest', ['test'], {'test': test_name})
+        self.__check_next('startTest', ['test'], {'test': test_name})
+        self.__check_next('stopTest', ['test'], {'test': test_name})
+        self.__check_next('afterTest', ['test'], {'test': test_name})
+
+    def _check_sequence_post_test(self):
+        log_dict = self.__check_next('finalize', ['result'])
+        # todo: poke into log_dict for run/errors/failures.
+        # (it's like {'result': <nose.result.TextTestResult run=1 errors=0 failures=0>})
+
+    def __check_next(self, step_name, required_keys, match_dict=None):
+        if len(self.__call_sequence) == 0:
+            next_thing = ( 'no-more-steps-found', {} )
+        else:
+            next_thing = self.__call_sequence[0]
+            self.__call_sequence = self.__call_sequence[1:]
+
+        next_name, next_args = next_thing
+        assert step_name == next_name, \
+            "Was expecting step '{0}', but got '{1}'.".format(step_name, next_name)
+        rset = set(required_keys)
+        naset = set(next_args.keys())
+        req_not_there = rset - naset
+        assert len(req_not_there) == 0, \
+            "Required key(s) missing: {0} from {1} on step {2}".format(
+                req_not_there, naset, step_name)
+        there_not_req = naset - rset
+        assert len(there_not_req) == 0, \
+            "Extra key(s): {0} beyond {1} on step {2}".format(
+                there_not_req, rset, step_name)
+
+        if match_dict is not None:
+            for arg_key, arg_str in match_dict.items():
+                assert arg_key in next_args, \
+                    "Argument {0} was supposed to have value {1} but was missing".format(
+                        arg_key, arg_str)
+                m_str = str(next_args[arg_key])
+                assert arg_str == m_str, \
+                    "Argument {0} was supposed to have value '{1}' but was '{2}'".format(
+                        arg_key, arg_str, m_str)
+
+
+def resolve_helper_class():
+    return _BaseStreamMonitorPluginTester
+
+def resolve_suitepath(*args):
+    support = os.path.join(os.path.dirname(__file__), 'support')
+    return os.path.join(support, *args)

--- a/test/stream-monitor/test/support/stream-source/logging/backtrace/test_backtrace.py
+++ b/test/stream-monitor/test/support/stream-source/logging/backtrace/test_backtrace.py
@@ -1,0 +1,12 @@
+import unittest
+from logging import getLogger
+
+class TestLoggerBacktrace(unittest.TestCase):
+    def setUp(self):
+        self.__lg = getLogger('infra.run')
+        super(TestLoggerBacktrace, self).setUp()
+
+    def test_backtrace_from_oops(self):
+        # the next statement will fail because "i_dont_exist" does not exist :)
+        _ = i_dont_exist
+

--- a/test/stream-monitor/test/support/stream-source/logging/stderr_errcap/test_stderr_errcap.py
+++ b/test/stream-monitor/test/support/stream-source/logging/stderr_errcap/test_stderr_errcap.py
@@ -1,0 +1,15 @@
+import unittest
+import sys
+
+class TestLoggerStderrError(unittest.TestCase):
+    def setUp(self):
+        print >>sys.stderr, "STDERR-MATCH-DATA: {0} setUp".format(self.__class__.__name__)
+        super(TestLoggerStderrError, self).setUp()
+
+    def test_stderr_from_testcase(self):
+        print >>sys.stderr, "STDERR-MATCH-DATA: {0} test_stderr_from_testcase".format(self.__class__.__name__)
+        raise Exception("error in test rather than fail type thing")
+
+    def test_no_stderr_from_testcase(self):
+        print >>sys.stderr, "STDERR-MUST-NOT-SEE: {0} test_no_stderr_from_testcase".format(self.__class__.__name__)
+

--- a/test/stream-monitor/test/support/stream-source/logging/stderr_failcap/test_stderr_failcap.py
+++ b/test/stream-monitor/test/support/stream-source/logging/stderr_failcap/test_stderr_failcap.py
@@ -1,0 +1,15 @@
+import unittest
+import sys
+
+class TestLoggerStderrFail(unittest.TestCase):
+    def setUp(self):
+        print >>sys.stderr, "STDERR-MATCH-DATA: {0} setUp".format(self.__class__.__name__)
+        super(TestLoggerStderrFail, self).setUp()
+
+    def test_stderr_from_testcase(self):
+        print >>sys.stderr, "STDERR-MATCH-DATA: {0} test_stderr_from_testcase".format(self.__class__.__name__)
+        self.assertTrue(False, "failed test to check against")
+
+    def test_no_stderr_from_testcase(self):
+        print >>sys.stderr, "STDERR-MUST-NOT-SEE: {0} test_no_stderr_from_testcase".format(self.__class__.__name__)
+

--- a/test/stream-monitor/test/support/stream-source/logging/stderr_nocap/test_stderr_nocap.py
+++ b/test/stream-monitor/test/support/stream-source/logging/stderr_nocap/test_stderr_nocap.py
@@ -1,0 +1,11 @@
+import unittest
+
+class TestLoggerStderrNoError(unittest.TestCase):
+    # should not see anything from this class.
+    def setUp(self):
+        print "STDERR-MATCH-DATA: {0} setUp".format(self.__class__.__name__)
+        super(TestLoggerStderrNoError, self).setUp()
+
+    def test_stderr_from_testcase(self):
+        print "STDERR-MATCH-DATA: {0} test_stderr_from_testcase".format(self.__class__.__name__)
+

--- a/test/stream-monitor/test/support/stream-source/logging/stdout_errcap/test_stdout_errcap.py
+++ b/test/stream-monitor/test/support/stream-source/logging/stdout_errcap/test_stdout_errcap.py
@@ -1,0 +1,14 @@
+import unittest
+
+class TestLoggerStdoutError(unittest.TestCase):
+    def setUp(self):
+        print "STDOUT-MATCH-DATA: {0} setUp".format(self.__class__.__name__)
+        super(TestLoggerStdoutError, self).setUp()
+
+    def test_stdout_from_testcase(self):
+        print "STDOUT-MATCH-DATA: {0} test_stdout_from_testcase".format(self.__class__.__name__)
+        raise Exception("error in test rather than fail type thing")
+
+    def test_no_stdout_from_testcase(self):
+        print "STDOUT-MUST-NOT-SEE: {0} test_no_stdout_from_testcase".format(self.__class__.__name__)
+

--- a/test/stream-monitor/test/support/stream-source/logging/stdout_failcap/test_stdout_failcap.py
+++ b/test/stream-monitor/test/support/stream-source/logging/stdout_failcap/test_stdout_failcap.py
@@ -1,0 +1,14 @@
+import unittest
+
+class TestLoggerStdoutFail(unittest.TestCase):
+    def setUp(self):
+        print "STDOUT-MATCH-DATA: {0} setUp".format(self.__class__.__name__)
+        super(TestLoggerStdoutFail, self).setUp()
+
+    def test_stdout_from_testcase(self):
+        print "STDOUT-MATCH-DATA: {0} test_stdout_from_testcase".format(self.__class__.__name__)
+        self.assertTrue(False, "failed test to check against")
+
+    def test_no_stdout_from_testcase(self):
+        print "STDOUT-MUST-NOT-SEE: {0} test_no_stdout_from_testcase".format(self.__class__.__name__)
+

--- a/test/stream-monitor/test/support/stream-source/logging/stdout_nocap/test_stdout_nocap.py
+++ b/test/stream-monitor/test/support/stream-source/logging/stdout_nocap/test_stdout_nocap.py
@@ -1,0 +1,11 @@
+import unittest
+
+class TestLoggerStdoutNoError(unittest.TestCase):
+    # should not see anything from this class.
+    def setUp(self):
+        print "STDOUT-MATCH-DATA: {0} setUp".format(self.__class__.__name__)
+        super(TestLoggerStdoutNoError, self).setUp()
+
+    def test_stdout_from_testcase(self):
+        print "STDOUT-MATCH-DATA: {0} test_stdout_from_testcase".format(self.__class__.__name__)
+

--- a/test/stream-monitor/test/support/stream-source/logging/two_pass/test_two_log_pass.py
+++ b/test/stream-monitor/test/support/stream-source/logging/two_pass/test_two_log_pass.py
@@ -4,7 +4,7 @@ from logging import getLogger
 class TestTwoLoggerTest(unittest.TestCase):
     def setUp(self):
         self.__lg = getLogger('infra.run')
-        super(TestOneLoggerTest, self).setUp()
+        super(TestTwoLoggerTest, self).setUp()
 
     def test_one_of_two_to_run(self):
         self.__lg.warning('test_one_of_two_to_run')

--- a/test/stream-monitor/test/test_log_stream.py
+++ b/test/stream-monitor/test/test_log_stream.py
@@ -1,89 +1,345 @@
-import unittest, os
+import plugin_test_helper
+import os
+import re
 import sys
-from nose.plugins import PluginTester
-from sm_plugin import StreamMonitorPlugin
 
-support = os.path.join(os.path.dirname(__file__), 'support')
+class _TempLogfileObserver(object):
+    """
+    We don't HAVE the stupid stream monitors yet, so this hack allows
+    us to do basic content testing on the log files infra-logging generated.
 
-# todo: this can probably be shared amongst the different stream handlers?
-class _TestStreamMonitorPluginTester(PluginTester, unittest.TestCase):
-    activate = '--with-stream-monitor'
-    _smp = StreamMonitorPlugin()
-    _smp._self_test_print_step_enable()
-    plugins = [_smp]
-    def runTest(self):
-        print '*' * 70
-        print str(self.output)
-        print '*' * 70
-        self.__call_sequence = self._smp._self_test_sequence_seen()
-        self.verify()
-        assert len(self.__call_sequence) == 0, \
-            'still had call-items left at end {0}'.format(self.__call_sequence)
+    This class gets the logging dir from flogging, figures out where we "are" in
+    the file at the moment, and is then able to do simple regex checking in the
+    data from that point forward (kinda like an "tail -f x.log | fgrep <patterns>")
+    """
+    def __init__(self, lg_name):
+        # defer import till here in order to avoid messing up infra-logging
+        # during test loads
+        from flogging import logger_get_logging_dir
+        self.__full_name = os.path.join(logger_get_logging_dir(), lg_name)
+        self.__current_length = os.stat(self.__full_name).st_size
 
-    def verify(self):
-        raise NotImplementedError()
+    def __get_tail_chunk(self):
+        log_data = ''
+        with open(self.__full_name, 'r') as log_file:
+            log_file.seek(self.__current_length)
+            log_data = log_file.read()
+        return log_data
 
-    def _check_sequence_pre_test(self):
-        self.__check_next('options', ['parser', 'env'])
-        self.__check_next('configure', ['options', 'conf'])
-        self.__check_next('begin', [])
+    def check_for_line(self, test, line_re, exp_count):
+        fdata = self.__get_tail_chunk()
+        matches = 0
+        re_matcher = re.compile(line_re)
+        for line in fdata.split('\n'):
+            if re_matcher.search(line):
+                matches += 1
 
-    def _check_sequence_test(self, test_name):
-        self.__check_next('beforeTest', ['test'], {'test': test_name})
-        self.__check_next('startTest', ['test'], {'test': test_name})
-        self.__check_next('stopTest', ['test'], {'test': test_name})
-        self.__check_next('afterTest', ['test'], {'test': test_name})
+        test.assertTrue(
+            matches == exp_count, 
+            'Saw {0} rather than expected {1} of "{2}" in {3}, raw=[[[{4}]]]'.format(
+                matches, exp_count, line_re, self.__full_name, fdata))
+        
 
-    def _check_sequence_post_test(self):
-        log_dict = self.__check_next('finalize', ['result'])
-        # todo: poke into log_dict for run/errors/failures.
-        # (it's like {'result': <nose.result.TextTestResult run=1 errors=0 failures=0>})
+class _TempLogfileChecker(object):
+    """
+    Crude logfile checker that holds the "business logic" to check for backtraces and
+    capture stdout or stderr contents (or lack thereof!)
+    """
+    def __init__(self, file_name):
+        self.__lf_observer = _TempLogfileObserver(file_name)
 
-    def __check_next(self, step_name, required_keys, match_dict=None):
-        if len(self.__call_sequence) == 0:
-            next_thing = ( 'no-more-steps-found', {} )
-        else:
-            next_thing = self.__call_sequence[0]
-            self.__call_sequence = self.__call_sequence[1:]
+    def __check_line(self, test, line_re, exp_count):
+        self.__lf_observer.check_for_line(test, line_re, exp_count)
+                
+    def check_backtrace(self, test, ltype, suitepath, test_class, test_file, test_method, exp_count):
+        full_file = os.path.join(suitepath, test_file)
+        tb_line = '{0}\straceback: Traceback \(most recent call last\):'.format(ltype)
+        self.__check_line(test, tb_line, exp_count)
+        file_line = 'File "{0}", line \d+, in {1}'.format(full_file, test_method)
+        self.__check_line(test, file_line, exp_count)
 
-        next_name, next_args = next_thing
-        assert step_name == next_name, \
-            "Was expecting step '{0}', but got '{1}'.".format(step_name, next_name)
-        rset = set(required_keys)
-        naset = set(next_args.keys())
-        req_not_there = rset - naset
-        assert len(req_not_there) == 0, \
-            "Required key(s) missing: {0} from {1} on step {2}".format(
-                req_not_there, naset, step_name)
-        there_not_req = naset - rset
-        assert len(there_not_req) == 0, \
-            "Extra key(s): {0} beyond {1} on step {2}".format(
-                there_not_req, rset, step_name)
+    def check_capture(self, test, cap_type, cap_level, test_class, test_method, exp_count):
+        """
+        param test: test-case (to do test.assertEqual on)
+        param cap_type: 'stdout' or 'stderr'
+        param cap_level: 'ERROR' or 'WARNING'
+        param test_class: test class name
+        param test_method: method name in test class
+        param exp_count: expected sightings in file
+        
+        """
+        eline = '{0}\s{1}:'.format(cap_level, cap_type)
+        self.__check_line(test, eline, exp_count)
+        # Need to check for expected match-data and NOT match data.
+        self.__check_match_data(test, cap_type, test_class, test_method, exp_count)
 
-        if match_dict is not None:
-            for arg_key, arg_str in match_dict.items():
-                assert arg_key in next_args, \
-                    "Argument {0} was supposed to have value {1} but was missing".format(
-                        arg_key, arg_str)
-                m_str = str(next_args[arg_key])
-                assert arg_str == m_str, \
-                    "Argument {0} was supposed to have value '{1}' but was '{2}'".format(
-                        arg_key, arg_str, m_str)
+    def __check_match_data(self, test, which_out, test_class, test_method, exp_count):
+        md_prefix = '{0}-MATCH-DATA: {1}'.format(which_out.upper(), test_class)
+        # Make sure setUp shows up in the one we want.
+        # todo: stream-monitor when we get to it should be able to grab all stdout:
+        #  for example.
+        setup_re = '{0}: {1} setUp'.format(which_out, md_prefix)
+        self.__check_line(test, setup_re, exp_count)
+        method_re = '{0} {1}'.format(md_prefix, test_method)
+        self.__check_line(test, method_re, exp_count)
+        # should see NONE of these:
+        no_see_re = '{0}-MUST-NOT-SEE:'.format(which_out.upper())
+        self.__check_line(test, no_see_re, 0)
+        
 
-class TestSMPLogginSingleOk(_TestStreamMonitorPluginTester):
-    suitepath = os.path.join(support, 'stream-source', 'logging', 'one_pass')
+class TestSMPLoggingSingleOk(plugin_test_helper.resolve_helper_class()):
+    suitepath = plugin_test_helper.resolve_suitepath('stream-source', 'logging', 'one_pass')
 
     def verify(self):
         self._check_sequence_pre_test()
         self._check_sequence_test('test_single_log_to_run (test_one_log_pass.TestOneLoggerTest)')
         self._check_sequence_post_test()
 
-class TestSMPLogginTwoOk(_TestStreamMonitorPluginTester):
-    suitepath = os.path.join(support, 'stream-source', 'logging', 'two_pass')
+class TestSMPLoggingTwoOk(plugin_test_helper.resolve_helper_class()):
+    suitepath = plugin_test_helper.resolve_suitepath('stream-source', 'logging', 'two_pass')
+    _test_file = 'test_two_log_pass'
+    _test_class = 'TestTwoLoggerTest'
+    _test_methods = ['test_one_of_two_to_run','test_two_of_two_to_run']
 
     def verify(self):
         self._check_sequence_pre_test()
-        self._check_sequence_test('test_one_of_two_to_run (test_two_log_pass.TestTwoLoggerTest)')
-        self._check_sequence_test('test_two_of_two_to_run (test_two_log_pass.TestTwoLoggerTest)')
+        self._check_sequences(self._test_methods, self._test_class, self._test_file)
         self._check_sequence_post_test()
+
+class _BacktraceBase(plugin_test_helper.resolve_helper_class()):
+    """
+    Kind of a first stab at a more general plugin tester. I want to use
+    the same suitepath based test file, but I want to have a test for each
+    log file and so on. 
+
+    subclasses need to define klass._backtrace_finder_file and
+    klass._backtrace_finger_count. This base class will verify that the
+    backtrace appears in that file the expected number of times
+    """
+    suitepath = plugin_test_helper.resolve_suitepath('stream-source', 'logging', 'backtrace')
+    _test_file = 'test_backtrace'
+    _test_class = 'TestLoggerBacktrace'
+    _test_methods = ['test_backtrace_from_oops']
+    _expect_nose_success = False
+
+    def setUp(self):
+        self.__logfile_checker = _TempLogfileChecker(self._backtrace_finder_file)
+        super(_BacktraceBase, self).setUp()
+        
+    def verify(self):
+        self.__logfile_checker.check_backtrace(
+            self, 'ERROR', self.suitepath, self._test_class,
+            self._test_file + '.py', self._test_methods[0],
+            self._backtrace_finder_count)
+
+        self._check_sequence_pre_test()
+        self._check_sequences(self._test_methods, self._test_class, self._test_file)
+        self._check_sequence_post_test()
+
+class TestSMPLoggingBacktrace_all_all_error(_BacktraceBase):
+    _backtrace_finder_file = 'all_all.log'
+    _backtrace_finder_count = 2
+
+class TestSMPLoggingBacktrace_infra_run_error(_BacktraceBase):
+    _backtrace_finder_file = 'infra_run.log'
+    _backtrace_finder_count = 1
+
+class TestSMPLoggingBacktrace_test_run_error(_BacktraceBase):
+    _backtrace_finder_file = 'test_run.log'
+    _backtrace_finder_count = 1
+
+class TestSMPLoggingBacktrace_infra_data_error(_BacktraceBase):
+    _backtrace_finder_file = 'infra_data.log'
+    _backtrace_finder_count = 0
+
+class TestSMPLoggingBacktrace_test_data_error(_BacktraceBase):
+    _backtrace_finder_file = 'test_data.log'
+    _backtrace_finder_count = 0
+
+class TestSMPLoggingBacktrace_console_capture_error(_BacktraceBase):
+    _backtrace_finder_file = 'console_capture.log'
+    _backtrace_finder_count = 1
+
+class _CaptureBase(plugin_test_helper.resolve_helper_class()):
+    _capture_method = None
+    def setUp(self):
+        self.__logfile_checker = _TempLogfileChecker(self._capture_finder_file)
+        super(_CaptureBase, self).setUp()
+        
+    def verify(self):
+        if self._capture_method is None:
+            cm = self._test_methods[0]  # default to first
+        else:
+            cm = self._capture_method
+        self.__logfile_checker.check_capture(
+            self, self._capture_type, self._capture_level, self._test_class, cm, 
+            self._capture_finder_count)
+
+        self._check_sequence_pre_test()
+        self._check_sequences(self._test_methods, self._test_class, self._test_file)
+        self._check_sequence_post_test()
+
+class _StdoutNoCaptureBase(_CaptureBase):
+    suitepath = plugin_test_helper.resolve_suitepath('stream-source', 'logging', 'stdout_nocap')
+    _test_file = 'test_stdout_nocap'
+    _test_class = 'TestLoggerStdoutNoError'
+    _test_methods = ['test_stdout_from_testcase']
+    _capture_type = 'stdout'
+    _capture_level = 'ERROR'  # doesn't really matter, since counts are all zero.
+    _capture_finder_count = 0
+    _expect_nose_success = False
+
+class TestSMPLoggingStdout_all_all_no_error(_StdoutNoCaptureBase):
+    _capture_finder_file = 'all_all.log'
+class TestSMPLoggingStdout_infra_run_no_error(_StdoutNoCaptureBase):
+    _capture_finder_file = 'infra_run.log'
+class TestSMPLoggingStdout_infra_data_no_error(_StdoutNoCaptureBase):
+    _capture_finder_file = 'infra_data.log'
+class TestSMPLoggingStdout_test_run_no_error(_StdoutNoCaptureBase):
+    _capture_finder_file = 'test_run.log'
+class TestSMPLoggingStdout_test_data_no_error(_StdoutNoCaptureBase):
+    _capture_finder_file = 'test_data.log'
+class TestSMPLoggingStdout_console_capture_no_error(_StdoutNoCaptureBase):
+    _capture_finder_file = 'console_capture.log'
+
+
+class _StdoutErrCaptureBase(_CaptureBase):
+    suitepath = plugin_test_helper.resolve_suitepath('stream-source', 'logging', 'stdout_errcap')
+    _test_file = 'test_stdout_errcap'
+    _test_class = 'TestLoggerStdoutError'
+    _test_methods = ['test_no_stdout_from_testcase', 'test_stdout_from_testcase']
+    _capture_type = 'stdout'
+    _capture_level = 'ERROR'
+    _capture_method = 'test_stdout_from_testcase'
+    _expect_nose_success = False
+
+class TestSMPLoggingStdout_all_all_error(_StdoutErrCaptureBase):
+    _capture_finder_file = 'all_all.log'
+    _capture_finder_count = 2
+class TestSMPLoggingStdout_infra_run_error(_StdoutErrCaptureBase):
+    _capture_finder_file = 'infra_run.log'
+    _capture_finder_count = 1
+class TestSMPLoggingStdout_infra_data_error(_StdoutErrCaptureBase):
+    _capture_finder_file = 'infra_data.log'
+    _capture_finder_count = 0
+class TestSMPLoggingStdout_test_run_error(_StdoutErrCaptureBase):
+    _capture_finder_file = 'test_run.log'
+    _capture_finder_count = 1
+class TestSMPLoggingStdout_infra_data_error(_StdoutErrCaptureBase):
+    _capture_finder_file = 'test_data.log'
+    _capture_finder_count = 0
+class TestSMPLoggingStdout_console_capture_error(_StdoutErrCaptureBase):
+    _capture_finder_file = 'console_capture.log'
+    _capture_finder_count = 1
+
+class _StdoutFailCaptureBase(_CaptureBase):
+    suitepath = plugin_test_helper.resolve_suitepath('stream-source', 'logging', 'stdout_failcap')
+    _test_file = 'test_stdout_failcap'
+    _test_class = 'TestLoggerStdoutFail'
+    _test_methods = ['test_no_stdout_from_testcase', 'test_stdout_from_testcase']
+    _capture_type = 'stdout'
+    _capture_level = 'WARNING'
+    _capture_method = 'test_stdout_from_testcase'
+    _expect_nose_success = False
+
+class TestSMPLoggingStdout_all_all_fail(_StdoutFailCaptureBase):
+    _capture_finder_file = 'all_all.log'
+    _capture_finder_count = 2
+class TestSMPLoggingStdout_infra_run_fail(_StdoutFailCaptureBase):
+    _capture_finder_file = 'infra_run.log'
+    _capture_finder_count = 1
+class TestSMPLoggingStdout_infra_data_fail(_StdoutFailCaptureBase):
+    _capture_finder_file = 'infra_data.log'
+    _capture_finder_count = 0
+class TestSMPLoggingStdout_test_run_fail(_StdoutFailCaptureBase):
+    _capture_finder_file = 'test_run.log'
+    _capture_finder_count = 1
+class TestSMPLoggingStdout_infra_data_fail(_StdoutFailCaptureBase):
+    _capture_finder_file = 'test_data.log'
+    _capture_finder_count = 0
+class TestSMPLoggingStdout_console_capture_fail(_StdoutFailCaptureBase):
+    _capture_finder_file = 'console_capture.log'
+    _capture_finder_count = 1
+
+class _StderrNoCaptureBase(_CaptureBase):
+    suitepath = plugin_test_helper.resolve_suitepath('stream-source', 'logging', 'stderr_nocap')
+    _test_file = 'test_stderr_nocap'
+    _test_class = 'TestLoggerStderrNoError'
+    _test_methods = ['test_stderr_from_testcase']
+    _capture_type = 'stderr'
+    _capture_level = 'ERROR'  # doesn't really matter, since counts are all zero.
+    _capture_finder_count = 0
+    _expect_nose_success = False
+
+class TestSMPLoggingStderr_all_all_no_error(_StderrNoCaptureBase):
+    _capture_finder_file = 'all_all.log'
+class TestSMPLoggingStderr_infra_run_no_error(_StderrNoCaptureBase):
+    _capture_finder_file = 'infra_run.log'
+class TestSMPLoggingStderr_infra_data_no_error(_StderrNoCaptureBase):
+    _capture_finder_file = 'infra_data.log'
+class TestSMPLoggingStderr_test_run_no_error(_StderrNoCaptureBase):
+    _capture_finder_file = 'test_run.log'
+class TestSMPLoggingStderr_test_data_no_error(_StderrNoCaptureBase):
+    _capture_finder_file = 'test_data.log'
+class TestSMPLoggingStderr_console_capture_no_error(_StderrNoCaptureBase):
+    _capture_finder_file = 'console_capture.log'
+
+
+class _StderrErrCaptureBase(_CaptureBase):
+    suitepath = plugin_test_helper.resolve_suitepath('stream-source', 'logging', 'stderr_errcap')
+    _test_file = 'test_stderr_errcap'
+    _test_class = 'TestLoggerStderrError'
+    _test_methods = ['test_no_stderr_from_testcase', 'test_stderr_from_testcase']
+    _capture_type = 'stderr'
+    _capture_level = 'ERROR'
+    _capture_method = 'test_stderr_from_testcase'
+    _expect_nose_success = False
+
+class TestSMPLoggingStderr_all_all_error(_StderrErrCaptureBase):
+    _capture_finder_file = 'all_all.log'
+    _capture_finder_count = 2
+class TestSMPLoggingStderr_infra_run_error(_StderrErrCaptureBase):
+    _capture_finder_file = 'infra_run.log'
+    _capture_finder_count = 1
+class TestSMPLoggingStderr_infra_data_error(_StderrErrCaptureBase):
+    _capture_finder_file = 'infra_data.log'
+    _capture_finder_count = 0
+class TestSMPLoggingStderr_test_run_error(_StderrErrCaptureBase):
+    _capture_finder_file = 'test_run.log'
+    _capture_finder_count = 1
+class TestSMPLoggingStderr_infra_data_error(_StderrErrCaptureBase):
+    _capture_finder_file = 'test_data.log'
+    _capture_finder_count = 0
+class TestSMPLoggingStderr_console_capture_error(_StderrErrCaptureBase):
+    _capture_finder_file = 'console_capture.log'
+    _capture_finder_count = 1
+
+class _StderrFailCaptureBase(_CaptureBase):
+    suitepath = plugin_test_helper.resolve_suitepath('stream-source', 'logging', 'stderr_failcap')
+    _test_file = 'test_stderr_failcap'
+    _test_class = 'TestLoggerStderrFail'
+    _test_methods = ['test_no_stderr_from_testcase', 'test_stderr_from_testcase']
+    _capture_type = 'stderr'
+    _capture_level = 'WARNING'
+    _capture_method = 'test_stderr_from_testcase'
+    _expect_nose_success = False
+
+class TestSMPLoggingStderr_all_all_fail(_StderrFailCaptureBase):
+    _capture_finder_file = 'all_all.log'
+    _capture_finder_count = 2
+class TestSMPLoggingStderr_infra_run_fail(_StderrFailCaptureBase):
+    _capture_finder_file = 'infra_run.log'
+    _capture_finder_count = 1
+class TestSMPLoggingStderr_infra_data_fail(_StderrFailCaptureBase):
+    _capture_finder_file = 'infra_data.log'
+    _capture_finder_count = 0
+class TestSMPLoggingStderr_test_run_fail(_StderrFailCaptureBase):
+    _capture_finder_file = 'test_run.log'
+    _capture_finder_count = 1
+class TestSMPLoggingStderr_infra_data_fail(_StderrFailCaptureBase):
+    _capture_finder_file = 'test_data.log'
+    _capture_finder_count = 0
+class TestSMPLoggingStderr_console_capture_fail(_StderrFailCaptureBase):
+    _capture_finder_file = 'console_capture.log'
+    _capture_finder_count = 1
 

--- a/test/stream-monitor/test/test_stream_base.py
+++ b/test/stream-monitor/test/test_stream_base.py
@@ -1,84 +1,18 @@
-import unittest, os
-import sys
-from nose.plugins import PluginTester
-from sm_plugin import smp_get_stream_monitor_plugin
+"""
+Copyright 2016, EMC, Inc.
+"""
+import plugin_test_helper
 
-support = os.path.join(os.path.dirname(__file__), 'support')
-
-class _TestStreamMonitorPluginTester(PluginTester, unittest.TestCase):
-    activate = '--with-stream-monitor'
-    _smp = smp_get_stream_monitor_plugin()
-    _smp._self_test_print_step_enable()
-    plugins = [_smp]
-    def runTest(self):
-        print '*' * 70
-        print str(self.output)
-        print '*' * 70
-        self.__call_sequence = self._smp._self_test_sequence_seen()
-        self.verify()
-        assert len(self.__call_sequence) == 0, \
-            'still had call-items left at end {0}'.format(self.__call_sequence)
-
-    def verify(self):
-        raise NotImplementedError()
-
-    def _check_sequence_pre_test(self):
-        self.__check_next('options', ['parser', 'env'])
-        self.__check_next('configure', ['options', 'conf'])
-        self.__check_next('begin', [])
-
-    def _check_sequence_test(self, test_name):
-        self.__check_next('beforeTest', ['test'], {'test': test_name})
-        self.__check_next('startTest', ['test'], {'test': test_name})
-        self.__check_next('stopTest', ['test'], {'test': test_name})
-        self.__check_next('afterTest', ['test'], {'test': test_name})
-
-    def _check_sequence_post_test(self):
-        log_dict = self.__check_next('finalize', ['result'])
-        # todo: poke into log_dict for run/errors/failures.
-        # (it's like {'result': <nose.result.TextTestResult run=1 errors=0 failures=0>})
-
-    def __check_next(self, step_name, required_keys, match_dict=None):
-        if len(self.__call_sequence) == 0:
-            next_thing = ( 'no-more-steps-found', {} )
-        else:
-            next_thing = self.__call_sequence[0]
-            self.__call_sequence = self.__call_sequence[1:]
-
-        next_name, next_args = next_thing
-        assert step_name == next_name, \
-            "Was expecting step '{0}', but got '{1}'.".format(step_name, next_name)
-        rset = set(required_keys)
-        naset = set(next_args.keys())
-        req_not_there = rset - naset
-        assert len(req_not_there) == 0, \
-            "Required key(s) missing: {0} from {1} on step {2}".format(
-                req_not_there, naset, step_name)
-        there_not_req = naset - rset
-        assert len(there_not_req) == 0, \
-            "Extra key(s): {0} beyond {1} on step {2}".format(
-                there_not_req, rset, step_name)
-
-        if match_dict is not None:
-            for arg_key, arg_str in match_dict.items():
-                assert arg_key in next_args, \
-                    "Argument {0} was supposed to have value {1} but was missing".format(
-                        arg_key, arg_str)
-                m_str = str(next_args[arg_key])
-                assert arg_str == m_str, \
-                    "Argument {0} was supposed to have value {1} but was {2}".format(
-                        arg_key, arg_str, m_str)
-
-class TestSMPSingleOkSequence(_TestStreamMonitorPluginTester):
-    suitepath = os.path.join(support, 'stream-base', 'one_pass')
+class TestSMPSingleOkSequence(plugin_test_helper.resolve_helper_class()):
+    suitepath = plugin_test_helper.resolve_suitepath('stream-base', 'one_pass')
 
     def verify(self):
         self._check_sequence_pre_test()
         self._check_sequence_test('test_one_pass.test_one')
         self._check_sequence_post_test()
 
-class TestSMPDoubleOkSequence(_TestStreamMonitorPluginTester):
-    suitepath = os.path.join(support, 'stream-base', 'two_pass')
+class TestSMPDoubleOkSequence(plugin_test_helper.resolve_helper_class()):
+    suitepath = plugin_test_helper.resolve_suitepath('stream-base', 'two_pass')
 
     def verify(self):
         self._check_sequence_pre_test()


### PR DESCRIPTION
This is a re-submit of https://github.com/RackHD/RackHD/pull/558, which included the symlink changes in it (which came in under their own PR). @hohene and @gpaulos approved the nose-capture part of that PR already. @RackHD/corecommitters for merging please!

Note that the following stories have been opened to round out the abilities added here:
* RAC-3869 to handle retro-grabbing of DEBUG level log output and such
* RAC-3870 to getting the progress line data into a log entry instead of raw output
* RAC-3875 to capture data _after_ an error has occured (like for tearDown and such)

Note: xunit, capture, and logcapture all do similar things, but everyone reports AFTER all the tests are done. Handy for style of use, really annoying for say Jenkins jobs!

Primary changes:
* Basically stole the xunit logic to capture stdout/stderr
* on addError or addFailure: grab the captured stdout/stderr and call any stream-source that implements "handle_capture"
* added handle_capture to stream_sources/log_type
** Manually grab list of logs to inject into for now (RAC-3869 deals with less hard-coded style)
** Inject stdout, stderr, and the traceback into those logs. Routine disables propegation to avoid duplication right now. De-hacking that would come out of RAC-3869)

TDD support changes: (note, since we don't HAVE the stream-monitor code yet, this is fairly sloppy cut-and-paste work)
* Removed near duplicate code for _TestStreamMonitorTester and _TestStreamMonitorPluginTester and added put into _BaseStreamMonitorPluginTester
* Adjusted existing tests to reference _BaseStreamMonitorPluginTester via "plugin_test_helper.resolve_helper_class()"
* Added new abilities to _BaseStreamMonitorPluginTester:
** Allow for sub-classes to set "_expect_nose_success" to False to disable checking for if the tests they ran had errors or not
** Check for and report if the sub-tests failed!
** Added _check_sequences to auto-build name-of-test used in test-sequence checking (got tired of constantly making changes to lines like "self._check_sequence_test('test_one_of_two_to_run (test_two_log_pass.TestTwoLoggerTest)')" for the next test that just replaced the three names in there!)
** Added a resolve_suitepath to the module to limit the filesystem knowledge to one place.
** Added a resolve_helper_class() to the module to get access to _BaseStreamMonitorPluginTester (if I leave the _ off, nosetests tries to "test" it, which causes all sorts of trouble. We only want classes _derived_ from it tested!)
* And then we have the super-crude changes in test_log_stream.py to add _TempLogfileObserver and _TempLogfileChecker. These:
** basically implement a "tail -f <logfile> | egrep <pattern>" (the Observer)
** and the biz logic to check for proper existance (or non-existance) of backtrace, captured stdout, and captured stderr data in the monitored file
* Also created _BacktraceBase with a derived class for each logfile to check for proper backtrace data showing up (or not)
* Also create _CaptureBase with logic to handle checking for proper stdout OR stderr capture data. This is not used directly, but is subclassed by the following who fill in key class-values:
** _StdoutNoCaptureBase (tests that no stdout capture occurs when there are no errors)
** _StdoutErrCaptureBase (tests that an error (i.e., code error that causes exception) captures stdout
** _StdoutFailCaptureBase (tests that a fail (i.e., unittest.assertTrue() based tests failures rather than errors) captures stdout
** _StderrNoCaptureBase, _StderrErrCaptureBase, and _StderrFailCaptureBase which do the same thing as the above, but for stderr
* Each of the above implements a plugin-test-class for each logfile, which deals with "how many times should I find this?" for each logfile

This means we have tests for the following to be seen in files that are supposed to have them, or not if they aren't.