### PR TITLE
add ova build boot wait

### DIFF
--- a/packer/template-ubuntu-14.04.json
+++ b/packer/template-ubuntu-14.04.json
@@ -140,7 +140,7 @@
           " -- <wait>",
           "<enter><wait>"
         ],
-        "boot_wait": "10s",
+        "boot_wait": "20s",
         "headless": true,
         "disk_size": 40960,
         "guest_os_type": "ubuntu-64",

--- a/packer/template-ubuntu-16.04.json
+++ b/packer/template-ubuntu-16.04.json
@@ -143,7 +143,7 @@
           " -- <wait>",
           "<enter><wait>"
         ],
-        "boot_wait": "10s",
+        "boot_wait": "20s",
         "headless": true,
         "disk_size": 40960,
         "guest_os_type": "ubuntu-64",


### PR DESCRIPTION
Otherwise build will fail in low performace machine.

boot-wait-time is the wait time for pc to enter CD/ISO install interface since power on.

If the machine performace is too bad, 10s will be not enough, and OS installation will hang at some interface.

And then packer build will hang forever.

```
==> vmware-iso: Starting HTTP server on port 8377
==> vmware-iso: Starting virtual machine...
    vmware-iso: The VM will be run headless, without a GUI. If you want to
    vmware-iso: view the screen of the VM, connect via VNC without a password to
    vmware-iso: 127.0.0.1:5931
==> vmware-iso: Waiting 10s for boot...
==> vmware-iso: Connecting to VM via VNC
==> vmware-iso: Typing the boot command over VNC...
==> vmware-iso: Waiting for SSH to become available...               
```
SSH will never become available.

@panpan0000 @PengTian0 
