### PR TITLE
Corrections to Vagrantfile

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -65,7 +65,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         target.ssh.username = "vagrant"
         target.ssh.password = "vagrant"
         target.vm.network "private_network", ip: "172.31.128.1", virtualbox__intnet: "closednet"
-        target.ssh.forward_agent = truei
+        target.ssh.forward_agent = true
         target.vm.network "forwarded_port", guest: 8080, host: 8080
         target.vm.network "forwarded_port", guest: 9080, host: 9080
         target.vm.network "forwarded_port", guest: 9090, host: 9090

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -30,11 +30,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             sudo apt-get -y update
             sudo apt-get -y install python-pip
             sudo apt-get -y install virtualenv
-            cd fit_tests/test
+            cd test
             ./mkenv.sh vagrant
             source myenv_vagrant
-            python run_tests.py -test deploy/rackhd_source_install.py -v 9
-            python run_tests.py -test deploy/rackhd_stack_init.py:rackhd_stack_init.test01_preload_sku_packs -stack vagrant -v 9
+            python run_tests.py -test deploy/rackhd_source_install.py -v 9;echo
+            python run_tests.py -test deploy/rackhd_stack_init.py:rackhd_stack_init.test01_preload_sku_packs -stack vagrant -v 9;echo
         SHELL
     end
 
@@ -65,7 +65,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         target.ssh.username = "vagrant"
         target.ssh.password = "vagrant"
         target.vm.network "private_network", ip: "172.31.128.1", virtualbox__intnet: "closednet"
-        target.ssh.forward_agent = true
+        target.ssh.forward_agent = truei
+        target.vm.network "forwarded_port", guest: 8080, host: 8080
+        target.vm.network "forwarded_port", guest: 9080, host: 9080
+        target.vm.network "forwarded_port", guest: 9090, host: 9090
+        target.vm.network "forwarded_port", guest: 443, host: 443
         target.vm.provision "shell", inline: <<-SHELL
             git clone https://github.com/RackHD/RackHD fit_tests
         SHELL


### PR DESCRIPTION
The FIT Vagrantfile broke when the fit_tests path was removed. This is a required correction to execute Vagrant FIT deploy/test.

These are the corrections:
- the path was changed from fit_tests/test to test
- the 'echo' statement was added at the end of the test commands because Vagrant stops script processing when it receives an non-zero exit code. This ensures that script processing continues even with a minor error.
- Port mapping was added to the template section to match the dev section.

@hohene @johren @jimturnquist @diontje @larry-dean @keedya