### PR TITLE
No need to ```pm2 start``` since Vagrant Box >=1.0.0

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -39,8 +39,7 @@ Clone RackHD repo to your local machine.
     cd example
     # create the RackHD instance.
     vagrant up dev
-    # start the RackHD services
-    vagrant ssh dev -c "sudo pm2 start rackhd-pm2-config.yml"
+    # then the RackHD services will start during bootup (they are running as service since box version 1.0.0)
 
 ### LOCAL SOURCE
 


### PR DESCRIPTION
RackHD is running as service(all rackhd package are installed as deb package in packer now) since vagrant box >=1.0.0, so no need to pm2 start


@heckj @anhou @changev 