### PR TITLE
rac-3777 verbosity ctl

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -39,9 +39,9 @@ The FIT test framework is under RackHD/test
 ## Configuration
 
 Default configuration file values can be found in the following files:
-    'config/rackhd_default.json'
-    'config/credentials_default.json'
-    'config/install_default.json'
+* 'config/rackhd_default.json'
+* 'config/credentials_default.json'
+* 'config/install_default.json'
 
 Stack definitions are set from the 'config/stack_config.json' file.
 An alternate configuration directory can be selected using the -config argument.
@@ -51,66 +51,60 @@ More details in config/README.md.
 
 All FIT tests can be run from the wrapper 'run_tests.py':
 
-    usage: run_tests.py [-h] [-test TEST] [-config CONFIG] [-group GROUP]
-                        [-stack STACK] [-ora ORA] [-version VERSION]
-                        [-template TEMPLATE] [-xunit] [-numvms NUMVMS] [-list]
-                        [-sku SKU] [-obmmac OBMMAC | -nodeid NODEID]
-                        [-http | -https] [-port PORT] [-v V]
+### --help output
+        usage: run_tests.py [-h] [-test TEST] [-config CONFIG] [-group GROUP]
+                            [-stack STACK] [-ora ORA] [-version VERSION]
+                            [-template TEMPLATE] [-xunit] [-numvms NUMVMS] [-list]
+                            [-sku SKU] [-obmmac OBMMAC | -nodeid NODEID]
+                            [-http | -https] [-port PORT] [-v V] [-nose-help]
 
-    Command Help
+        Command Help
 
-    optional arguments:
-      -h, --help          show this help message and exit
-      -test TEST          test to execute, default: tests/
-      -config CONFIG      config file location, default: config
-      -group GROUP        test group to execute: 'smoke', 'regression',
-                          'extended', default: 'all'
-      -stack STACK        stack label (test bed), overrides -ora
-      -ora ORA            OnRack/RackHD appliance IP address or hostname, default:
-                          localhost
-      -version VERSION    OnRack package install version, example:onrack-
-                          release-0.3.0, default: onrack-devel
-      -template TEMPLATE  path or URL link to OVA template or OnRack OVA
-      -xunit              generates xUnit XML report files
-      -numvms NUMVMS      number of virtual machines for deployment on specified
-                          stack
-      -list               generates test list only
-      -sku SKU            node SKU name, example: Quanta-T41, default=all
-      -obmmac OBMMAC      node OBM MAC address, example:00:1e:67:b1:d5:64
-      -nodeid NODEID      node identifier string of a discovered node, example:
-                          56ddcf9a8eff16614e79ec74
-      -http               forces the tests to utilize the http API protocol
-      -https              forces the tests to utilize the https API protocol
-      -port PORT          API port number override, default from
-                          install_config.json
-      -v V                Verbosity level of console output, default=1, Built Ins:
-                          0: No debug, 2: User script output, 4: rest calls and
-                          status info, 6: other common calls (ipmi, ssh), 9: all
-                          the rest
+        optional arguments:
+          -h, --help          show this help message and exit
+          -test TEST          test to execute, default: tests/
+          -config CONFIG      config file location, default: config
+          -group GROUP        test group to execute: 'smoke', 'regression',
+                              'extended', default: 'all'
+          -stack STACK        stack label (test bed), overrides -ora
+          -ora ORA            OnRack/RackHD appliance IP address or hostname, default:
+                              localhost
+          -version VERSION    OnRack package install version, example:onrack-
+                              release-0.3.0, default: onrack-devel
+          -template TEMPLATE  path or URL link to OVA template or OnRack OVA
+          -xunit              generates xUnit XML report files
+          -numvms NUMVMS      number of virtual machines for deployment on specified
+                              stack
+          -list               generates test list only
+          -sku SKU            node SKU name, example: Quanta-T41, default=all
+          -obmmac OBMMAC      node OBM MAC address, example:00:1e:67:b1:d5:64
+          -nodeid NODEID      node identifier string of a discovered node, example:
+                              56ddcf9a8eff16614e79ec74
+          -http               forces the tests to utilize the http API protocol
+          -https              forces the tests to utilize the https API protocol
+          -port PORT          API port number override, default from
+                              install_config.json
+          -v V                Verbosity level of console output, default=1, Built Ins:
+                              0: No debug, 2: Display infra.run and test.run DEBUG, 4:
+                              Display test.data (rest calls and status) DEBUG, 6:
+                              infra.data DEBUG (ipmi, ssh), 9: infra.* and test.* at
+                              DEBUG_9 (max output)
+          -nose-help          display help from underlying nosetests command,
+                              including additional log options
 
-When run_tests.py executes, a generated configuration will be created in the
-config/generated directory.  The name will appear in the run_test.py output.
 
-A previously generated configuration can be used again for a run_tests.py
-invocation by setting the environment variable FIT_CONFIG.
-
-This example will run the RackHD installer onto stack 1 via the wrapper script:
+### Example that will run the RackHD installer onto stack 1 via the wrapper script:
 
     python run_tests.py -stack 1 -test deploy/run_rackhd_installer.py
-    *** Created config file: config/generated/fit-config-20170118-160319
-    *** Using config file: config/generated/fit-config-20170118-160319
 
-The -stack or -ora argument can be omitted when running on the server or appliance. The test defaults to localhost:8080 for API calls.
-
-To run this exact test configuration again, the following could be done:
-    export FIT_CONFIG=config/generated/fit-config-20170118-160319
-    python run_tests.py
-
-This example will run the smoke test from the appliance node or the default Vagrant test bed:
+### Example will run the smoke test from the appliance node or the default Vagrant test bed:
 
     python run_tests.py -test tests -group smoke
 
+The -stack or -ora argument can be omitted when running on the server or appliance. The test defaults to localhost:8080 for API calls.
 
+
+### Example using nosetests
 Alternatively tests can be run directly from nose. Runtime parameters such as ORA address must be set in the environment.
 
 The following example will run all the entire test harness from a third party machine to ORA at 192.168.1.1:
@@ -119,7 +113,7 @@ The following example will run all the entire test harness from a third party ma
     nosetests -s tests
 
 
-## Running individual tests
+### Running individual tests
 
 Individual test scripts or tests may be executed using the following 'Nose' addressing scheme:
 
@@ -130,6 +124,24 @@ For example, to run the test 'test_rackhd11_api_catalogs' in script 'tests/rackh
 
     python run_tests.py -stack 11 -test tests/rackhd11/test_rackhd11_api_catalogs.py:rackhd11_api_catalogs.test_api_11_catalogs
 
+### Example of rerunning a test based on a previous run's configuration:
+
+When run_tests.py executes, a generated configuration will be created in the
+config/generated directory.  The name will appear in the run_test.py output.
+
+A previously generated configuration can be used again for a run_tests.py
+invocation by setting the environment variable FIT_CONFIG.
+
+This shows the config being generated:
+
+     python run_tests.py -stack 1 -test deploy/run_rackhd_installer.py
+     *** Created config file: config/generated/fit-config-20170118-160319
+     *** Using config file: config/generated/fit-config-20170118-160319
+
+This shows re-using the generated config:
+
+     export FIT_CONFIG=config/generated/fit-config-20170118-160319
+     python run_tests.py
 
 ## Running FIT tests on Vagrant RackHD
 
@@ -167,6 +179,12 @@ Use the following commands to initialize the server and run a Smoke Test:
 Note that any previously installed RackHD Vagrant boxes will prevent a new instance from running.
 Please remove any old RackHD VMs prior to executing this routine.
 
+## Hints and background for logging/debuging tests
+
+Please read 'stream_monitor/flogging/README.md' for information on the logging system.
+That file also contains a set of common "if you want this to happen, type this" at the top of the file and how
+the existing '-v' shortcut option maps to the loggers.
+
 ## Test conventions
 
 - Tests should be written using Python 'unittest' classes and methods.
@@ -189,7 +207,7 @@ The setUp and tearDown methods are useful ways to setup and clean out test-speci
     virtualenv .venv
     source .venv/bin/activate
     sudo pip install -r requirements.txt
-    
+
 ## Running the tests
 
 Run Vagrant environment
@@ -224,13 +242,13 @@ Run regression tests
 
     python run.py --config=/home/user/config.ini
 
-    
+
 ## HTTP proxy configuration:
 
 For OS installer related tests, optional HTTP proxies for accessing remote OS image repositories can be defined, see the [RackHD Configuration howto](http://rackhd.readthedocs.io/en/latest/rackhd/configuration.html?highlight=httpProxies#rackhd-configuration)
 
 ## Specifying test groups
-    
+
     To display the entire test plan and available test groups run:
 
     python run.py --show-plan
@@ -246,7 +264,7 @@ For OS installer related tests, optional HTTP proxies for accessing remote OS im
     Run only Redfish 1.0 compliant API related tests:
     python run.py --group=api-redfish-1.0
 
-## To reset the default target BMC user/password 
+## To reset the default target BMC user/password
 
     NOTE: only prompts for user/password when .passwd file is missing
 
@@ -255,45 +273,78 @@ For OS installer related tests, optional HTTP proxies for accessing remote OS im
     python run.py
     <enter BMC username and password>
 
+
+
 ## Running footprint benchmark test
 
+
+
 Footprint benchmark collects system data when running poller, node discovery and bootstrap.
+
 Details can be found in WIKI page:
+
 [proposal-footprint-benchmarks](https://github.com/RackHD/RackHD/wiki/proposal-footprint-benchmarks)
+
 The benchmark data collection process can also start/stop independently without binding to any test case,
 thus users can get the footprint info about any operations they carry out during this period of time.
 
 ###Precondition
 
+
+
 The machine running RackHD can use apt-get to install packages, which means it must have accessible sources.list
 
 In RackHD, compute nodes have been discovered, and pollers are running
 
+
+
 No external AMQP queue with the name "graph.finished" is listening RackHD
 
+
+
 Make sure the AMQP port in RackHD machine can be accessed by the test machine.
+
 If you are not using Vagrant, you can tunnel the port by the following command in RackHD
+
+
 
     sudo socat -d -d TCP4-LISTEN:55672,reuseaddr,fork TCP4:localhost:5672
 
+
+
 ###Settings
 
+
+
 Aside from Optional settings in the section above,
+
 following parameters are also required at the first time user issuing the test,
+
 and stored in .passwd
+
+
 
     localhost username and password: username and password that can run "apt-get install"
     in the machine running the test
 
+
 ###Running the tests
+
+
 
 Run poller|discovery|bootstrap tests
 
+
     python benchmark.py --group=poller|discovery|bootstrap
+
 
 Run all benchmark tests
 
+
+
     python benchmark.py
+
+
 
 Start|Stop benchmark data collection
 
@@ -305,14 +356,26 @@ Get the directory of the latest log data
 
 ###Getting result
 
+
+
 Footprint report is in ~/benchmark/(timestamp)/(case)/report.
+
+
 
 Report in html format can display its full function by
 
+
+
     chrome.exe --user-data-dir="C:/Chrome dev session" --allow-file-access-from-files
+
+
 
 to open the browser and drag the summary.html to it.
 
+
+
 Data summary and graph is shown by process and footprint matrix.
+
+
 
 Data in different time and cases can be selected to compare with the current one.

--- a/test/README.md
+++ b/test/README.md
@@ -84,11 +84,15 @@ All FIT tests can be run from the wrapper 'run_tests.py':
           -https              forces the tests to utilize the https API protocol
           -port PORT          API port number override, default from
                               install_config.json
-          -v V                Verbosity level of console output, default=1, Built Ins:
-                              0: No debug, 2: Display infra.run and test.run DEBUG, 4:
-                              Display test.data (rest calls and status) DEBUG, 6:
-                              infra.data DEBUG (ipmi, ssh), 9: infra.* and test.* at
-                              DEBUG_9 (max output)
+          -v V                Verbosity level of console and log output (see -nose-
+                              help for more options), Built Ins: 0: Minimal logging,
+                              1: Display ERROR and CRITICAL to console and to files,
+                              3: Display INFO to console and to files, 4: (default)
+                              Display INFO to console, and DEBUG to files, 5: Display
+                              infra.run and test.run DEBUG to both, 6: Add display of
+                              test.data (rest calls and status) DEBUG to both, 7: Add
+                              display of infra.data (ipmi, ssh) DEBUG to both, 9:
+                              Display infra.* and test.* at DEBUG_9 (max output)
           -nose-help          display help from underlying nosetests command,
                               including additional log options
 

--- a/test/stream-monitor/flogging/README.md
+++ b/test/stream-monitor/flogging/README.md
@@ -2,7 +2,7 @@
 
 This logging system is part of the overall 'stream_monitor' nose plugin, but can
 in theory work independently of that. This document starts with a set of examples
-for how someone working with run_test.py might accomplish different different
+for how someone working with run_test.py might accomplish different
 use-cases. After that, it goes on to describe the basic structure of
 the logging system, the options available to control it, and how to use it within FIT
 tests.
@@ -18,7 +18,7 @@ one for an overview of how python's logging system works, and how that is used f
 * console output (including the 'console_capture.log' mentioned in the files bullets) is limited to INFO and above. It is meant to show high-level status/flow by default, with the main logger files containing more detailed diagnostic/debug information for post-morterm and debug.
 * levels are based on syslog style DEBUG, INFO, WARNING, ERROR, and CRITICAL levels, but have been expanded:
     * There are now levels like {name}_0, {name}_1, through {name}_9. For example DEBUG_0, DEBUG_1, INFO_5 and so on.
-    * Each base name maps to {name}_5. For example 'INFO' and 'INFO_5' are the same.
+    * Each base name maps to {name}_2. For example 'INFO' and 'INFO_2' are the same.
 
 The following are "if you want to see _this_, use a command like _this_" recipes. In some cases, there is more
 than one way to accomplish the goal, often including use of the run_test.py's "-v" option. The latter may change
@@ -113,8 +113,8 @@ The default syslog based loglevels are limited to 'CRITICAL', 'ERROR', 'WARNING,
 the same problem all syslog derived system face of only having one level of, say, DEBUG.
 
 Luckily, the values assigned to the level names are DEBUG=10, INFO=20, and so on. The infra-logging system takes
-advantage of this, and adds entries for each primary level plus _0, _1, _2, through _9 where _5 is the same as the
-primary. I.E. DEBUG_5 is the same as plain DEBUG. So, a test writer can use the 'test.run' logger.debug_1(message)
+advantage of this, and adds entries for each primary level plus _0, _1, _2, through _9 where _2 is the same as the
+primary. I.E. DEBUG_2 is the same as plain DEBUG. So, a test writer can use the 'test.run' logger.debug_1(message)
 to indicate a message more verbose than logger.debug_0. Under default settings, this means that data flowing
 to the main log files include DEBUG_0 to DEBUG_5, leavning _6 to _9 for levels of debug/diagnostic information
 considered too verbose for including on every run. Note that because the logging is still syslog-like in
@@ -171,10 +171,10 @@ The following goes through each option and explains what it does:
                             Set a logger's capture threshold. Loggers are
                             evaluated before handlers.
 
-This will change the logger level. For example, '--sm-set-logger-level test.run DEBUG_5' will change the logger level
-from DEBUG(_0) to DEBUG_5. I.E. DEBUG_6 will still be dropped by the test.run logger. The way things are wired,
+This will change the logger level. For example, '--sm-set-logger-level test.run DEBUG_6' will change the logger level
+from DEBUG(_5) to DEBUG_6. I.E. DEBUG_7 will still be dropped by the test.run logger. The way things are wired,
 this only impacts the level of messages flowing to test_run.log and combined_all_all.log. The messages would still be
-dropped by the root-logger, since it is at INFO.
+dropped by the root-logger, since it is at INFO_5.
 
 Note that the logger name can be wild-carded: 'test.*' or 'test*' to change both test.run and test.data, or '*.data' to raise up the volume of data dumps.
 
@@ -197,8 +197,8 @@ Mostly, this is here for completeness, and for use 'behind the scenes' on the mo
 Doing a '--sm-set-combo-level console DEBUG' will go and change the handler level for 'console' AND all loggers
 feeding into it. Because 'console' is attached to the root logger, this ends up override ALL the
 loggers (that had been created at this point. That is a key limitation). Of course, this means that the console is
-being spammed with DEBUG output from everything. '--sm-set-combo-level console*:*.run DEBUG_5' will have the
-affect of of routing 'infra.run', and 'test.run' at DEBUG_5 to both the console and console_capture.
+being spammed with DEBUG output from everything. '--sm-set-combo-level console*:*.run DEBUG_6' will have the
+affect of of routing 'infra.run', and 'test.run' at DEBUG_6 to both the console and console_capture.
 
 Finally:
     --sm-set-file-level=('file-pattern', '[handler-name[:logger-name] [level-name-or-value]]')

--- a/test/stream-monitor/flogging/README.md
+++ b/test/stream-monitor/flogging/README.md
@@ -1,0 +1,254 @@
+# (FIT) Infra-structure logging component.
+
+This logging system is part of the overall 'stream_monitor' nose plugin, but can
+in theory work independently of that. This document starts with a set of examples
+for how someone working with run_test.py might accomplish different different
+use-cases. After that, it goes on to describe the basic structure of
+the logging system, the options available to control it, and how to use it within FIT
+tests.
+
+## Cheat-sheet of example run_test.py uses
+This is a "quick start" section to give you a set of "if you want to do this, type this." You may wish to skim two sections following this
+one for an overview of how python's logging system works, and how that is used for the testing system. A minimal set of information to use this is:
+
+* the logging system generates files in 'logging_output/run_<timedate-stamp.d' with a symlink from 'log_output/run_last.d' to the most recent.
+    * The files 'infra_run.log', 'infra_data.log', 'test_run.log', and 'test_data.log' each contain DEBUG and higher log data for each of those loggers respectively. These are the "main logger" files.
+    * The file 'all_all.log' contains all the lines from those four logs.
+    * The file 'console_capture.log' contains the same data sent to the real console. As an example, the contents of this file should match what is seen in the console-output for a Jenkins job.
+* console output (including the 'console_capture.log' mentioned in the files bullets) is limited to INFO and above. It is meant to show high-level status/flow by default, with the main logger files containing more detailed diagnostic/debug information for post-morterm and debug.
+* levels are based on syslog style DEBUG, INFO, WARNING, ERROR, and CRITICAL levels, but have been expanded:
+    * There are now levels like {name}_0, {name}_1, through {name}_9. For example DEBUG_0, DEBUG_1, INFO_5 and so on.
+    * Each base name maps to {name}_5. For example 'INFO' and 'INFO_5' are the same.
+
+The following are "if you want to see _this_, use a command like _this_" recipes. In some cases, there is more
+than one way to accomplish the goal, often including use of the run_test.py's "-v" option. The latter may change
+some as RAC-3984 is persued, but the goal of that ticket is to preserve this simple for of the current
+"-v" option and also make other "short cuts" available.
+
+### "I want to have every log statement show up in the log files and on the console"
+        python run_tests.py -stack <stack> --sm-set-combo-level 'console.*' DEUBG_9
+        python run_tests.py -stack <stack> -v 9
+
+### "I want to increase the amount of information stored to the main log files"
+        python run_tests.py -stack <stack> --sm-set-logger-level 'infra.*|test.*' DEUBG_9
+
+### "I want to capture a lot more info from a specific intermittent test failure"
+note: an upcoming story will add the ability to specify a specific test. At this time, the granularity is limited to
+a file or files.
+        python run_tests.py -stack <stack> --sm-set-file-level 'tests/rackhd11/test_rackhd11_api_catalogs.py'
+
+### "I'm developing new tests and just want to see everything while I'm doing that"
+        python run_tests.py -stack <stack> -test tests/rackhd11/test_rackhd11_api_catalogs.py:rackhd11_api_catalogs.test_api_11_catalog --sm-set-combo-level 'console.*' DEBUG_9
+        python run_tests.py -stack <stack> -test tests/rackhd11/test_rackhd11_api_catalogs.py:rackhd11_api_catalogs.test_api_11_catalog -v 9
+
+### "What does the help information about the '-v' option really mean?"
+There is only so much info that can be put into a --help line. The following
+shows a breakout of what the different '-v n' shortcuts mean. Note that currently, these are _also_
+tied to the older verbosity based print statements. These are being converted, but currently
+the output will be a mix of stdout/print data and logging messages. _The descriptions
+here are for the logging entries_. So, for example, '-v 0' is actually the default
+level of logging output as described in this section. '-v 1' is the option default and shows
+default level output via the unconverted verbosity based print statements. In terms of mapping
+to logging, it is the same as '-v 0'.
+* -v 0 : no special output.
+* -v 1 : default for unconverted verbosity based print statements. Same as -v 0 for logging.
+* -v 2 : turn console display of infra.run and test.run to the level DEBUG. This should be test and infra flow logic.
+* -v 4 : turn console display of test.data to the level DEBUG. This should add rest calls and status information.
+* -v 6 : turn console display of infra.data to the level DEBUG. This should add things like ipmi and ssh information.
+* -v 9 : turn console and log file display of all areas to the level of DEBUG_9. This basically turns on _everything_.
+
+Note that the levels are additive: -v 6 implies -v 4 and -v 2. Options not shown here "round down" to the nearest value. For example, -v 5 effectively means -v 4.
+
+Notice: if you are developing tests using '-v 9' (or any "-v n") and find yourself altering or removing log statements
+to tune the volume of logs produced, _please don't_. Instead take the time to read the rest of this file and learn
+more about how to segment the logging information and levels. The "-v" option is an extremely
+powerful tool for quickly getting access to all the log information, but it is primarily a
+test developer or feature developer running specific tests. Altering the logging content,
+detail, and volume to fit that single use case, breaks many of the other use cases.
+
+## Basic structure
+
+The infra-logging system is meant to make instrumenting, and then debugging FIT tests
+easier at both all points in the life-cycle of test development:
+- Gobs of information while writing the a test, either directly to console and/or within log files
+- Basic flow information, to the console when executing in a Jenkins type environment or by a non-test developer running the suite against their code during development.
+- More detailed debug info located in log files for that same Jenkins type environment.
+
+Combined with the stream-monitor plugin, the system will, when RAC-3849 is implemented,
+also "raise" the more detailed info from the log files to console output on test failure/errors.
+
+## Brief introduction to how python logging _works_
+These concepts are buried within the python logging documentation, but require some
+time to pull out in any meaningful way. This section is a brief overview of the
+core structures and terminology:
+
+* A "logger" is a named entity that is really the entry point for _doing_ the logging. Important properties:
+    * It has a name. The name can be split up with '.'s to create hierarchies.
+    * It is where one starts a log message from. For example a_logger.debug("message") or a_logger.info("message")
+    * It can have zero or more "handler"s attached to it (see below).
+    * It has a "level" threshold. If the level of the log-message is >= to the logger, it will process the message
+      by checking the message against each handler. It will also "climb" (progagate)
+      messages to less specific loggers. For example, if 'foo.bar' accepts the message, the system will then
+      check logger 'foo', and finally the 'root' logger or ''.
+* A "handler" is a named entity that is responsible for emitting the a message a logger matched. Properties:
+    * It also has a name, though it doesn't have any of the hierarchy abilities.
+    * More than one logger can be pointing to it. (or no loggers, but it will never do anything in that case!)
+    * It also has a level and if the message's level less, the handler won't process the message.
+    * It may also have 0 or more "filter"s (see below). Each filter is checked against the message and can
+      indicate if processing should continue or not in this handler. Filters can do other things, as described
+      below
+    * It can have a 'formatter' attribute that describes how the line is printed.
+    * It will also have handler-type specific information. For example:
+        * a "RotatingFileHandler" requires a name and may also include overrides to rotation settings.
+        * a "StreamHandler" will contain the stream-io information required to write to things like stdout.
+* A "filter" provides two bits of functionality:
+    * It can add or alter properties attached to the message being logged before the formatter is used. For example,
+      it could add a '.greenlet_name' or trim off the common part of '.filename'.
+    * It can do further checks to see if the handler should emit the message or not, returning False if it
+      should not, or True if it should continue looking through more filters. Filters that just alter/add
+      properties always return True.
+
+## A note on 'levels'
+The default syslog based loglevels are limited to 'CRITICAL', 'ERROR', 'WARNING, 'INFO', and 'DEBUG', and suffer
+the same problem all syslog derived system face of only having one level of, say, DEBUG.
+
+Luckily, the values assigned to the level names are DEBUG=10, INFO=20, and so on. The infra-logging system takes
+advantage of this, and adds entries for each primary level plus _0, _1, _2, through _9 where _5 is the same as the
+primary. I.E. DEBUG_5 is the same as plain DEBUG. So, a test writer can use the 'test.run' logger.debug_1(message)
+to indicate a message more verbose than logger.debug_0. Under default settings, this means that data flowing
+to the main log files include DEBUG_0 to DEBUG_5, leavning _6 to _9 for levels of debug/diagnostic information
+considered too verbose for including on every run. Note that because the logging is still syslog-like in
+its core, however, changing the threshhold level of say the root logger to 'DEBUG', will also mean it starts
+matching INFO_1, INFO_2 ... INFO_9.
+
+## How the infra-logging system uses this
+
+The infra-logging system defines four main loggers, a root logger, seven handlers, and one filter:
+
+* Loggers:
+    * The main loggers, 'infra.run', 'infra.data', 'test.run', and 'test.data'. Each of these:
+        * Has a level of 'DEBUG'.
+        * Points to its own log-file handler. This handler doesn't test for a level.
+        * Points to a second log-file handler that the other three main loggers also point to. Again, with no
+          level test, so if the logger matches, the line gets written to its specific file and to the combined file.
+    * A root logger. This logger ends up handling both propegation from the main loggers, and from any other
+      logger that gets defined elsewhere in the system. By default, it is set at 'INFO'. It has two handlers:
+        * 'console', which sends to stdout. 'console' also has a level of 'INFO'.
+        * 'console-capture', which writes to a file in the logging directory. This allows capture of the main
+          console from a run even if the stdout one was not piped to a file.
+
+The handlers were covered in place, and the filter is attached to every handler to add more fields.
+
+# Controlling logging:
+The following nose options are available to control and examine the loggers:
+
+
+    listing log settings:
+        --sm-list-logging   list logging settings
+        --sm-list-level=LIST_LOGGING_LEVEL
+                            detail level if --list-logging is used
+
+      setting log options:
+        note: both 'logger-name's and 'handler-name's can contain wild-card
+        characters to match multiple items.
+
+        --sm-set-logger-level=('logger-name', 'level-name-or-value')
+                            Set a logger's capture threshold. Loggers are
+                            evaluated before handlers.
+        --sm-set-handler-level=('handler-name[:logger-name]', 'level-name-or-value')
+                            Set a handler's capture threshold.
+        --sm-set-combo-level=('handler-name[:logger-name]', 'level-name-or-value')
+                            Set a handler's capture threshold AND all loggers
+                            feeding it.
+        --sm-set-file-level=('file-pattern', '[handler-name[:logger-name] [level-name-or-value]]')
+                            Same as --sm-set-combo-level, but restricts the change
+                            in output to only the files that match the file-
+                            pattern
+
+## The 'set' options:
+The following goes through each option and explains what it does:
+        --sm-set-logger-level=('logger-name', 'level-name-or-value')
+                            Set a logger's capture threshold. Loggers are
+                            evaluated before handlers.
+
+This will change the logger level. For example, '--sm-set-logger-level test.run DEBUG_5' will change the logger level
+from DEBUG(_0) to DEBUG_5. I.E. DEBUG_6 will still be dropped by the test.run logger. The way things are wired,
+this only impacts the level of messages flowing to test_run.log and combined_all_all.log. The messages would still be
+dropped by the root-logger, since it is at INFO.
+
+Note that the logger name can be wild-carded: 'test.*' or 'test*' to change both test.run and test.data, or '*.data' to raise up the volume of data dumps.
+
+    --sm-set-handler-level=('handler-name[:logger-name]', 'level-name-or-value')
+                        Set a handler's capture threshold.
+
+But what if you wanted to have more than just DEBUG flow to stdout? This option seems like it would work:
+'--sm-set-handler-level console DEBUG'. This will actually have less impact than you would think, since
+both the root logger AND the console handler have a level threshold of 'INFO'.
+The actual usefull application of this option would be to lower levels '--sm-set-handler-level console WARNING'.
+This would mean only warnings and above to the console, while still sending INFO and above to the
+console_capture file.
+
+Mostly, this is here for completeness, and for use 'behind the scenes' on the more usefull next option:
+
+    --sm-set-combo-level=('handler-name[:logger-name]', 'level-name-or-value')
+                        Set a handler's capture threshold AND all loggers
+                        feeding it.
+
+Doing a '--sm-set-combo-level console DEBUG' will go and change the handler level for 'console' AND all loggers
+feeding into it. Because 'console' is attached to the root logger, this ends up override ALL the
+loggers (that had been created at this point. That is a key limitation). Of course, this means that the console is
+being spammed with DEBUG output from everything. '--sm-set-combo-level console*:*.run DEBUG_5' will have the
+affect of of routing 'infra.run', and 'test.run' at DEBUG_5 to both the console and console_capture.
+
+Finally:
+    --sm-set-file-level=('file-pattern', '[handler-name[:logger-name] [level-name-or-value]]')
+                       Same as --sm-set-combo-level, but restricts the change
+                       in output to only the files that match the file-
+                       pattern
+
+This last option can be used to target increased (or decreased) output for a specific file or files. The handler and logger
+name parts are just like in the combo. The file pattern is a regex applied against the filename seen in the
+output records.
+
+## The 'list' options:
+Currently, only the flag-option '--sm-list-logging' has any effect, and just dumps some basic information
+about the loggers, handlers, and filters before existing.  '--sm-list-level=#' currently has no impact on the
+amount of detail provided for each item, but is the placeholder for that functionality.
+
+
+# How to use:
+This section will cover how to intstrument the test and test-infrastructure code and the general rules, etc.
+
+A very basic sketch is:
+        '''
+        Some file.py
+        '''
+        import flogging
+
+        logs = flogger.get_loggers()
+
+
+The "logs" instance here provides both default and advanced access to the main loggers. For example:
+        logs.debug("My test is doing this")
+will use the 'test.run' logger as its base to log from. The "logs" instance supports all the normal logger
+methods as well as the expanded ranges. For example: logs.info(), logs.info_1, logs.critical() and so on.
+
+It also contains the following:
+* .irl, which is the 'infra.run' logger instance.
+* .idl, which is the 'infra.data; logger instance.
+* .trl, which is _also_ the 'test.run' logger instance. Technically 'logs' delegates all access like .debug and such to .trl to handle.
+* .tdl, which is the 'test.data' logger instance.
+* .data_log, which is a synonym for the 'test.data' logger instance.
+
+These different loggers should be used as follows:
+* test.run via logs.trl (or just plain loggers) should explain what _your_ test is doing. It's path.
+* test.data via logs.tdl (or logs.data_log) should be data being moved around as _part_ of the test. This could be REST data and response for a service being tested. It should _not_ be REST calls that are not part of the service under test, if possible. Nor should it include the more infra-structure like data such as ssh traffic for remote commands that aren't _what_ is being tested.
+* infra.run via logs.irl is for logic flow of testing infrastructure code.
+* infra.data via logs.idl is for bulk data being moved around. The output from a pyexpect based ssh would be a perfect example of this.
+
+In general, use 'INFO' for core flow. 'starting test A' and so on. *most of these should be in infra.run*. Exceptions
+to that would be some form of progress information for longer running test-pieces. For example "Starting node 1 of 5"
+or such.
+
+Remember that .debug is captured to the logfiles, jenkins, and when RAC-3849 is done, .debug will be sent
+to console output on an error or failure.

--- a/test/stream-monitor/flogging/__init__.py
+++ b/test/stream-monitor/flogging/__init__.py
@@ -1,6 +1,4 @@
-from infra_logging import *
 from logger_sets import get_loggers
+from infra_logopts import LoggerArgParseHelper
 
-all = ['getLogger', 'getInfraRunLogger', 'getInfraDataLogger',
-       'getTestRunLogger', 'getTestDataLogger', 'get_loggers',
-       'logger_get_logging_dir', 'logger_config_api']
+all = [get_loggers, LoggerArgParseHelper]

--- a/test/stream-monitor/flogging/infra_logging.py
+++ b/test/stream-monitor/flogging/infra_logging.py
@@ -72,10 +72,19 @@ class _LevelLoggerClass(Logger):
         the base level for levelname plus or minus the value of the _n part
         of the attribute. An example is easier to understand:
         A Logger instance has a .debug() method, which uses the int value
-        of DEBUG to check/emit. DEBUG happens to be equal to the int 10.
-        debug_0 ends up mapping to the int value 15 (DEBUG + 5 - 0)
-        debug_5 ends up mapping to the int value 10  (DEBUG + 5 - 5)
-        debug_9 ends up mapping to the int value 6  (DEBUG + 5 - 9)
+        of DEBUG to check/emit. DEBUG happens to be equal to the int 10. The following
+        list shows the name and numeric value of each debug_n (or DEBUG_n)
+        name           int-value    'on'-by-default     note
+        debug_0        12           yes
+        debug_1        11           yes
+        debug_2        10           yes                 DEBUG synonym
+        debug_3         9           yes
+        debug_4         8           yes
+        debug_5         7           yes                 most detailed 'always on'
+        debug_6         6            no
+        debug_7         5            no
+        debug_8         4            no
+        debug_9         3            no
 
         Since the logging system treats higher int values as "more important"
         (e.g. CRITICAL is 50), this means debug_9 would be used to represent
@@ -95,7 +104,7 @@ class _LevelLoggerClass(Logger):
 
         base_name = attr_match.group("base").upper()
         val_adj = int(attr_match.group("post_num"))
-        actual_value = _levelNames[base_name] + (5 - val_adj)
+        actual_value = _levelNames[base_name] + (2 - val_adj)
 
         def wrapper(msg, *args, **kw):
             return self.log(actual_value, msg, *args, **kw)
@@ -190,9 +199,9 @@ class _LoggerSetup(object):
             for lvl_key, lvl_value in lvl_copy.items():
                 if isinstance(lvl_key, str) and lvl_key != 'NOTSET':
                     new_name = "{0}_{1}".format(lvl_key, adj)
-                    new_val = lvl_value + (5 - adj)
-                    # Note: we can't insert our overlap (DEBUG_5 == DEBUG)
-                    # here without changing what _appears_ in the log to be the _0
+                    new_val = lvl_value + (2 - adj)
+                    # Note: we can't insert our overlap (DEBUG_2 == DEBUG)
+                    # here without changing what _appears_ in the log to be the _2
                     # version. We let __getattr__ mapping handle this case.
                     if new_val != lvl_value:
                         addLevelName(new_val, new_name)
@@ -211,13 +220,13 @@ class _LoggerSetup(object):
             'handlers': {
                 'console': {
                     # catch all. May not need to exist?
-                    'level': 'INFO',
+                    'level': 'INFO_5',
                     'class': 'logging.StreamHandler',
                     'filters': ['ctx_add_filter'],
                     'formatter': 'simple'
                 },
                 'console-capture': {
-                    'level': 'INFO',
+                    'level': 'INFO_5',
                     'class': 'logging.handlers.RotatingFileHandler',
                     'filename': self.__console_capture_lgn,
                     'filters': ['ctx_add_filter'],
@@ -269,28 +278,28 @@ class _LoggerSetup(object):
                 '': {
                     'handlers': ['console', 'console-capture'],
                     'propagate': True,
-                    'level': 'INFO',
+                    'level': 'INFO_5',
                     'stream': 'ext://sys.stdout'
                 },
                 'infra.run': {
                     'handlers': ['infra-run', 'combined-all-all'],
                     'propagate': True,
-                    'level': 'DEBUG',
+                    'level': 'DEBUG_5',
                 },
                 'infra.data': {
                     'handlers': ['infra-data', 'combined-all-all'],
                     'propagate': True,
-                    'level': 'DEBUG',
+                    'level': 'DEBUG_5',
                 },
                 'test.run': {
                     'handlers': ['test-run', 'combined-all-all'],
                     'propagate': True,
-                    'level': 'DEBUG',
+                    'level': 'DEBUG_5',
                 },
                 'test.data': {
                     'handlers': ['test-data', 'combined-all-all'],
                     'propagate': True,
-                    'level': 'DEBUG',
+                    'level': 'DEBUG_5',
                 }
             },
             'formatters': {

--- a/test/stream-monitor/flogging/infra_logging.py
+++ b/test/stream-monitor/flogging/infra_logging.py
@@ -16,8 +16,8 @@ import gevent
 import os
 import errno
 import shutil
-
 import sys
+
 
 class _GeventInfoFilter(logging.Filter):
     _main_greenlet = gevent.getcurrent()
@@ -57,7 +57,11 @@ class _GeventInfoFilter(logging.Filter):
             record.location_info_string = ''
         else:    
             record.location_info_string = '{r.process} {r.processName} {r.pathname}:{r.funcName}@{r.lineno} {r.greenlet}'.format(r=record)
+
         return True
+
+    def __str__(self):
+        return 'infra-context-adding-filter'
 
 class _LevelLoggerClass(Logger):
     _log_call_matcher = re.compile(r'''^(?P<base>[a-zA-Z]\w*?)_(?P<post_num>\d)$''')
@@ -69,9 +73,9 @@ class _LevelLoggerClass(Logger):
         of the attribute. An example is easier to understand:
         A Logger instance has a .debug() method, which uses the int value
         of DEBUG to check/emit. DEBUG happens to be equal to the int 10.
-        debug_0 ends up mapping to the int value 10 (DEBUG - 0)
-        debug_5 ends up mapping to the int value 5  (DEBUG - 5)
-        debug_9 ends up mapping to the int value 1  (DEBUG - 9)
+        debug_0 ends up mapping to the int value 15 (DEBUG + 5 - 0)
+        debug_5 ends up mapping to the int value 10  (DEBUG + 5 - 5)
+        debug_9 ends up mapping to the int value 6  (DEBUG + 5 - 9)
 
         Since the logging system treats higher int values as "more important"
         (e.g. CRITICAL is 50), this means debug_9 would be used to represent
@@ -91,10 +95,10 @@ class _LevelLoggerClass(Logger):
 
         base_name = attr_match.group("base").upper()
         val_adj = int(attr_match.group("post_num"))
-        actual_value = _levelNames[base_name] - val_adj
+        actual_value = _levelNames[base_name] + (5 - val_adj)
 
         def wrapper(msg, *args, **kw):
-            return self._log(actual_value, msg, args, kw)
+            return self.log(actual_value, msg, *args, **kw)
 
         # We return a wrapper function, since we are being asked to resolve
         # the method, not call it. The above wrapper allows us to return
@@ -186,8 +190,8 @@ class _LoggerSetup(object):
             for lvl_key, lvl_value in lvl_copy.items():
                 if isinstance(lvl_key, str) and lvl_key != 'NOTSET':
                     new_name = "{0}_{1}".format(lvl_key, adj)
-                    new_val = lvl_value - adj
-                    # Note: we can't insert our overlap (DEBUG_0 == DEBUG)
+                    new_val = lvl_value + (5 - adj)
+                    # Note: we can't insert our overlap (DEBUG_5 == DEBUG)
                     # here without changing what _appears_ in the log to be the _0
                     # version. We let __getattr__ mapping handle this case.
                     if new_val != lvl_value:
@@ -222,7 +226,7 @@ class _LoggerSetup(object):
                 'infra-run': {
                     # the test infrastructure code (not the tests themselves)
                     # I.E., like logging about logging :)
-                    'level': 'DEBUG',
+                    'level': 'NOTSET',
                     'class': 'logging.handlers.RotatingFileHandler',
                     'filename': self.__infra_run_lgn,
                     'filters': ['ctx_add_filter'],
@@ -230,7 +234,7 @@ class _LoggerSetup(object):
                 },
                 'infra-data': {
                     # test infra data. for example, storing of expect stuff
-                    'level': 'DEBUG',
+                    'level': 'NOTSET',
                     'class': 'logging.handlers.RotatingFileHandler',
                     'filename': self.__infra_data_lgn,
                     'filters': ['ctx_add_filter'],
@@ -238,7 +242,7 @@ class _LoggerSetup(object):
                 },
                 'test-run': {
                     # test-run code. I.E., where tests can say "I'm doing X"
-                    'level': 'DEBUG',
+                    'level': 'NOTSET',
                     'class': 'logging.handlers.RotatingFileHandler',
                     'filename': self.__test_run_lgn,
                     'filters': ['ctx_add_filter'],
@@ -246,7 +250,7 @@ class _LoggerSetup(object):
                 },
                 'test-data': {
                     # raw data from actual tests. Like the infra-data
-                    'level': 'DEBUG',
+                    'level': 'NOTSET',
                     'class': 'logging.handlers.RotatingFileHandler',
                     'filename': self.__test_data_lgn,
                     'filters': ['ctx_add_filter'],
@@ -254,7 +258,7 @@ class _LoggerSetup(object):
                 },
                 'combined-all-all': {
                     # put the works into a single file
-                    'level': 'DEBUG',
+                    'level': 'NOTSET',
                     'class': 'logging.handlers.RotatingFileHandler',
                     'filename': self.__combined_all_all_lgn,
                     'filters': ['ctx_add_filter'],
@@ -307,6 +311,14 @@ class _LoggerSetup(object):
         logging.getLogger("urllib3").setLevel(logging.WARNING)
         logging.getLogger("requests").setLevel(logging.WARNING)
 
+    def reset_configuration(self):
+        """
+        Basically for use during plugin self-test, which runs multiple complete
+        test life-cycles for the plugins, but this watcher needs to survive
+        between them. The config of levels, etc, however, does NOT!
+        """
+        self.__do_config()
+
     def set_level(self, new_level):
         pass
 
@@ -324,7 +336,6 @@ def getLogger(name=None):
         rl = logging.getLogger()
     else:
         rl = logging.getLogger(name)
-    #rl = _GeventInfoAdapter(rl, {})
     return rl
 
 def _getLoggerBase(names, name):
@@ -344,8 +355,10 @@ def getTestRunLogger(name=None):
 def getTestDataLogger(name=None):
     return _getLoggerBase(['test', 'data'], name)
 
-
 _logger_setup_instance = _LoggerSetup()
+
+def logger_reset_configuration():
+    _logger_setup_instance.reset_configuration()
 
 def logger_config_api(verbosity):
     _logger_setup_instance.set_level(verbosity)

--- a/test/stream-monitor/flogging/infra_logopts.py
+++ b/test/stream-monitor/flogging/infra_logopts.py
@@ -185,13 +185,13 @@ class LoggerArgParseHelper(object):
             pass
         if levelno is None:
             # could not parse, so should be a name?
-            # Note: we need to handle that foo_5 == foo, BUT there won't be
-            #  a mapping inside logging for foo_5. (It would cause 'FOO' to always show up in
+            # Note: we need to handle that foo_2 == foo, BUT there won't be
+            #  a mapping inside logging for foo_2. (It would cause 'FOO' to always show up in
             #  the logs as 'FOO_5'. Still iffy on if it should or shoudn't, but that's why
-            #  we check and strip _5 here!)
+            #  we check and strip _2 here!)
             str_level = str(level)
-            if str_level.endswith('_5'):
-                str_level = str_level[:-2]   # hack of _5!
+            if str_level.endswith('_2'):
+                str_level = str_level[:-2]   # hack off _2!
 
             levelno = logging.getLevelName(str_level)
             if not isinstance(levelno, int):
@@ -224,7 +224,7 @@ class LoggerArgParseHelper(object):
 
     def __do_logger_settings(self, logger_level_list):
         """
-        Routine to look through the list of options like 'infra.run' 'DEBUG_5'.
+        Routine to look through the list of options like 'infra.run' 'DEBUG_2'.
         For each one, we search for loggers matching the name (wildcards are allowed) and
         for each of those, go in and set the level of the logger to the requested
         level. Remember loggers are independent of handlers. FIRST a candidate message

--- a/test/stream-monitor/flogging/infra_logopts.py
+++ b/test/stream-monitor/flogging/infra_logopts.py
@@ -1,0 +1,376 @@
+"""
+Copyright 2017, EMC, Inc.
+"""
+import logging
+import re
+import argparse
+import optparse
+import sys
+
+class _LoggingConfigFilter(logging.Filter):
+    """
+    Python logging Filter subclass that handles the following qualities:
+    * An override handler-threshold. Say from DEBUG_5 to override console-capture's normal INFO.
+    * which loggers connected to this handler should be tested against the override.
+      (I.E., you can set 'infra.run', and 'test.run' to DEBUG_5, and this filter will only
+       check infra.run and test.run loggers. Others will be checked against the 'unmatched_levelno'.
+    * An 'unmatched_levelno' to use when the logger is NOT in the list. (see note below)
+    * An optional file-pattern. Only checked within a matching logger.
+
+    The filter is applied on a 1:1 basis with a single handler.
+
+    Note that the unmatched_levelno is needed, because in order to get message records TO this
+    filter, the loggers that feed them need to have their threshold dropped low enough, BUT we
+    still want to apply their old handler threshold. This is how we do it.
+    """
+    def __init__(self, which_lgs, levelno, unmatched_levelno, name, file_pat=None):
+        super(_LoggingConfigFilter, self).__init__(name)
+        self.__which_loggers = which_lgs
+        self.__levelno = levelno
+        self.__unmatched_levelno = unmatched_levelno
+        if file_pat is None:
+            self.__file_matcher = re.compile('.*')  # match ANYTHING
+        else:
+            self.__file_matcher = re.compile(file_pat)
+
+    def filter(self, record):
+        if record.name in self.__which_loggers:
+            if record.levelno >= self.__levelno:
+                if self.__file_matcher.search(record.filename):
+                    return True
+            return False
+        if record.levelno >= self.__unmatched_levelno:
+            return True
+        return False
+
+    def __str__(self):
+        rs = 'level {0} threshold for {1} loggers, umatched={2}'.format(
+            self.__levelno, self.__which_loggers, self.__unmatched_levelno)
+        return rs
+
+class _ArgparseToOptparseWrapper(object):
+    def __init__(self, parser):
+        """
+        Wrapper for optparser based objects that map argparse style operations
+        to optparser ones. This is done to allow 'nose' (which still uses optparse!!!!) to
+        function.
+        """
+        self.__parser = parser
+
+    def add_argument_group(self, *args, **kwargs):
+        new_group = optparse.OptionGroup(self.__parser, *args, **kwargs)
+        new_wr_group = _ArgparseToOptparseWrapper(new_group)
+        self.__parser.add_option_group(new_group)
+        return new_wr_group
+
+    def add_argument(self, *args, **kwargs):
+        self.__parser.add_option(*args, **kwargs)
+
+    def error(self, message):
+        print >>sys.stderr, message
+        sys.exit(2)
+
+class LoggerArgParseHelper(object):
+    def __init__(self, parser):
+        """
+        This is a class that can be instantiated with a parser (either optparse OR argparse) that
+        adds options to control the infra-logging system.
+        """
+        if not isinstance(parser, argparse.ArgumentParser):
+            parser = _ArgparseToOptparseWrapper(parser)
+
+        self.__parser = parser
+        list_group = parser.add_argument_group('listing log settings')
+        list_group.add_argument(
+            '--sm-list-logging', dest='list_logging', action='store_true', default=False,
+            help='list logging settings')
+        list_group.add_argument(
+            '--sm-list-level', nargs=1, default=1, dest='list_logging_level',
+            help='detail level if --list-logging is used')
+        set_group = parser.add_argument_group(
+            'setting log options',
+            "note: both 'logger-name's and 'handler-name's can contain wild-card characters to match multiple items.")
+        set_group.add_argument(
+            '--sm-set-logger-level', nargs=2, default=[],
+            dest='set_logger_level_list', action='append',
+            metavar=('logger-name', 'level-name-or-value'),
+            help="Set a logger's capture threshold. Loggers are evaluated before handlers.")
+        set_group.add_argument(
+            '--sm-set-handler-level', nargs=2, default=[],
+            dest='set_handler_level_list', action='append',
+            metavar=('handler-name[:logger-name]', 'level-name-or-value'),
+            help="Set a handler's capture threshold.")
+
+        set_group.add_argument(
+            '--sm-set-combo-level', nargs=2, default=[],
+            dest='set_combo_level_list', action='append',
+            metavar=('handler-name[:logger-name]', 'level-name-or-value'),
+            help="Set a handler's capture threshold AND all loggers feeding it.")
+
+        set_group.add_argument(
+            '--sm-set-file-level', nargs=3, dest='set_file_level',
+            metavar=('file-pattern', '[handler-name[:logger-name] [level-name-or-value]]'),
+            help="Same as --sm-set-combo-level, but restricts the change in output to only the files that match the file-pattern")
+
+
+    def __display_filter(self, indent, filter, detail):
+        """
+        Print a bit of info on the given filter.
+        """
+        indent_txt = ' ' * indent
+        print >>sys.stderr, 'F{0}{1}: {2}'.format(indent_txt, filter.name, str(filter))
+
+    def __display_handler(self, indent, handler, detail):
+        """
+        Print out a bit of info on the given handler and then display its filters
+        """
+        indent_txt = ' ' * indent
+        if isinstance(handler, logging.StreamHandler):
+            extra_info = ', stream={0}'.format(handler.stream)
+        else:
+            extra_info = ''
+        print >>sys.stderr, 'H{0}{1}({2}): level={3}{4}'.format(
+            indent_txt, handler.get_name(), handler.__class__.__name__,
+            handler.level, extra_info)
+        for filter in handler.filters:
+            self.__display_filter(indent+1, filter, detail)
+
+    def __recurse_list(self, indent, logger, detail):
+        """
+        Print the passed in logger, its handlers, and then recurse on other
+        loggers under its space.
+        """
+        indent_txt = ' ' * indent
+        print >>sys.stderr, 'L{0}{1}: level={2}'.format(indent_txt, logger.name, logger.level)
+        for handler in logger.handlers:
+            self.__display_handler(indent+1, handler, detail)
+        for lg_name, lg_obj in logging.Logger.manager.loggerDict.items():
+            if isinstance(lg_obj, logging.PlaceHolder):
+                continue
+            if lg_obj.parent == logger:
+                self.__recurse_list(indent+3, lg_obj, detail)
+
+    def __do_list(self, detail):
+        """
+        Entry point for listing state of python logging stuff. Just grabs the root
+        and jumps into recursing off of it.
+        """
+        lg = logging.root
+        self.__recurse_list(0, lg, detail)
+
+    def __fail_level_parse(self, level_arg):
+        """
+        Common error routine for not-understanding a specified level
+        """
+        valid_nums = []
+        valid_names = []
+        for lv_key in logging._levelNames.keys():
+            if isinstance(lv_key, int):
+                valid_nums.append(lv_key)
+            else:
+                valid_names.append(lv_key)
+
+        self.__parser.error("Invalid level '{0}'. Valid numbers: {1}, names: {2}".format(
+                level_arg, valid_nums, valid_names))
+
+    def __parse_level(self, level):
+        """
+        Util method to turn any passed in level (int or string) into
+        its number AND name
+        """
+        levelno = None
+        try:
+            levelno = int(level)
+        except ValueError:
+            pass
+        if levelno is None:
+            # could not parse, so should be a name?
+            # Note: we need to handle that foo_5 == foo, BUT there won't be
+            #  a mapping inside logging for foo_5. (It would cause 'FOO' to always show up in
+            #  the logs as 'FOO_5'. Still iffy on if it should or shoudn't, but that's why
+            #  we check and strip _5 here!)
+            str_level = str(level)
+            if str_level.endswith('_5'):
+                str_level = str_level[:-2]   # hack of _5!
+
+            levelno = logging.getLevelName(str_level)
+            if not isinstance(levelno, int):
+                self.__fail_level_parse(level)
+
+        level_name = logging.getLevelName(levelno)
+        bad_name = 'Level {0}'.format(levelno)
+        if level_name == bad_name:
+            self.__fail_level_parse(level)
+        return levelno, level_name
+
+    def __find_loggers(self, search_lg_name):
+        """
+        Method to search loggers for a matching name. We allow regex, but also
+        do 'glob' style expansion of '*' to '.*' and stick a '$' on the end.
+        Note that re.match has to match from the start of the string, so no '^' is
+        needed.
+        """
+        regex_form = search_lg_name.replace('*', '.*') + '$'
+        matcher = re.compile(regex_form)
+        logger_list = []
+        for lg_name, lg_obj in self.__loggers_by_name.items():
+            if matcher.match(lg_name):
+                logger_list.append(lg_obj)
+
+        if len(logger_list) == 0:
+            self.__parser.error("Could not locate any loggers matching '{0}'".format(
+                    search_lg_name))
+        return logger_list
+
+    def __do_logger_settings(self, logger_level_list):
+        """
+        Routine to look through the list of options like 'infra.run' 'DEBUG_5'.
+        For each one, we search for loggers matching the name (wildcards are allowed) and
+        for each of those, go in and set the level of the logger to the requested
+        level. Remember loggers are independent of handlers. FIRST a candidate message
+        has to get past a logger before being considered by a handler or propagated up.
+        """
+        for lg_name, level in logger_level_list:
+            levelno, level_name = self.__parse_level(level)
+            target_loggers = self.__find_loggers(lg_name)
+            for target_logger in target_loggers:
+                target_logger.setLevel(levelno)
+
+    def __find_handlers(self, search_hd_name):
+        """
+        Locate handlers matching a specific name. It is basically a regex with an
+        extra 'glob' like mode added along with a '$' to match EOS. Note that regex's
+        'match()' will only match the start of a string.
+        """
+        regex_form = search_hd_name.replace('*', '.*') + '$'
+        matcher = re.compile(regex_form)
+        handler_list = []
+        for hd_name, hd_obj in self.__handlers_by_name.items():
+            if matcher.match(str(hd_name)):
+                handler_list.append(hd_obj)
+
+        if len(handler_list) == 0:
+            self.__parser.error(
+                "Could not locate any handlers matching '{0}'".format(
+                    search_hd_name))
+        return handler_list
+
+    def __update_handler(self, handler, for_loggers, levelno, file_pat=None):
+        """
+        Routine to update a single handler by adding a filter to it that is
+        includes the level, optional file-pattern, and a list of all the loggers
+        that feed into the handler. The filter will "take over" threshhold handling
+        of any handler we want to use the filter on. Otherwise, if the handler's level is
+        set higher than our per-logger override, the check won't reach our
+        filter. Of course, at the same time, we don't want the behavior to
+        change for handler + logger combinations we aren't trying to override!
+        Note: only one filter has to return a False to kill emitting a
+          record, so it doesn't hurt to "overwrite" the level multiple times.
+
+        The option "file_pat" param is used to limit output to only files matching that pattern.
+        """
+        for_names = []
+        for logger in for_loggers:
+            for_names.append(logger.name)
+
+        orig_level = handler.level
+        name = 'Filter({0}@{1})'.format(for_names, levelno)
+        filter = _LoggingConfigFilter(for_names, levelno, orig_level, name,
+                                      file_pat = file_pat)
+        handler.addFilter(filter)
+        handler.setLevel(logging.NOTSET)
+
+    def __do_a_handler(self, log_and_handler, level, file_pat=None, bump_loggers=False):
+        """
+        Handles changing levels on a handler or handlers.
+
+        The 'log_and_handler' is the name of the handler (possibly with wildcarding)
+        and optionally the list of loggers to restrict the change to. By default,
+        changing the handler level will "discover" all the loggers that point to it. In either
+        case, that list of loggers is passed into each __update_handler call so the logging
+        will be able to discern if it should act or not.
+
+        Finally, the "bump_loggers" option, which is used by the combo option,
+        will cause us to go back and drag the logger threshholds as well if set.
+        """
+        levelno, level_name = self.__parse_level(level)
+        if ':' in log_and_handler:
+            hd_name, lg_name = log_and_handler.split(':', 1)
+        else:
+            hd_name = log_and_handler
+            lg_name = '*'
+        target_handlers = self.__find_handlers(hd_name)
+        for_loggers = self.__find_loggers(lg_name)
+        for target_handler in target_handlers:
+            self.__update_handler(target_handler, for_loggers, levelno)
+        if bump_loggers:
+            for logger in for_loggers:
+                if logger.level > levelno:
+                    logger.setLevel(levelno)
+
+    def __do_handler_settings(self, handler_level_list, bump_loggers=False):
+        """
+        Entry point for walking handler and setting handler thresholds. It is also used
+        for "combo" settings via the "bump_loggers" param. This routine is just in
+        charge of walking the possible list of settings from the arg-parser though.
+        """
+        for log_and_handler, level in handler_level_list:
+            self.__do_a_handler(log_and_handler, level, bump_loggers=bump_loggers)
+
+    def __do_set_file_level(self, set_file_settings):
+        """
+        Cranks up the output for a regex/glob file-name. It can be targeted just like
+        a combo setting.
+        """
+        if len(set_file_settings) > 3:
+            self.__parser.error('Too many values for --set-file-level')
+        if len(set_file_settings) == 1:
+            set_file_settings.append('*')
+        if len(set_file_settings) == 2:
+            set_file_settings.append('DEBUG_9')
+        file_pat, log_and_handler, level = set_file_settings
+        self.__do_a_handler(log_and_handler, level, file_pat, True)
+
+    def __build_ref_lists(self):
+        """
+        Build up easy-to-use lists of loggers and handlers.
+        """
+        ll = {}
+        hl = {}
+        loggers = dict(logging.Logger.manager.loggerDict)
+        loggers[''] = logging.getLogger('')
+        loggers['root'] = logging.getLogger('')
+        for lg_name, lg_obj in loggers.items():
+            if not isinstance(lg_obj, logging.PlaceHolder):
+                ll[lg_name] = lg_obj
+                for handler in lg_obj.handlers:
+                    hl[handler.get_name()] = handler
+        self.__loggers_by_name = ll
+        self.__handlers_by_name = hl
+
+    def process_parsed(self, optargs):
+        """
+        This method needs to be called -after- the parser is run with the results dictionary.
+        It basically coordinates which filters to build up, with the bulk of the
+        work being done in sub-methods.
+        """
+        # Build up handy list of map of loggers and handlers
+        self.__build_ref_lists()
+        # If the user set any logger values, deal with them.
+        self.__do_logger_settings(optargs.set_logger_level_list)
+        # If the user set any handlers values, now deal with them.
+        self.__do_handler_settings(optargs.set_handler_level_list)
+        # Now the combos (auto-magic logger + handlers tweaks)
+        self.__do_handler_settings(optargs.set_combo_level_list, True)
+
+        # And finally the kind of "meta" option of just turning the volume up
+        # on a single file.
+        if optargs.set_file_level is not None:
+            self.__do_set_file_level(optargs.set_file_level)
+
+        # And last, does the user want to see the settings. We do this here, so if they
+        # opt for a list, they can see if AFTER the settings are made. We still
+        # exit, however.
+        if optargs.list_logging:
+            self.__do_list(optargs.list_logging_level)
+            sys.exit(0)

--- a/test/stream-monitor/flogging/logger_sets.py
+++ b/test/stream-monitor/flogging/logger_sets.py
@@ -1,11 +1,11 @@
 """
 Copyright 2017, EMC, Inc.
 """
-from .infra_logging import *
 
 # todo: document API (especially for common aka test-writer actor)
 class _LoggerSet(object):
     def __init__(self, name=None):
+        from .infra_logging import getInfraRunLogger, getInfraDataLogger, getTestRunLogger, getTestDataLogger
         self.irl = getInfraRunLogger(name=name)
         self.idl = getInfraDataLogger(name=name)
         self.trl = getTestRunLogger(name=name)

--- a/test/stream-monitor/sm_plugin/stream_monitor.py
+++ b/test/stream-monitor/sm_plugin/stream_monitor.py
@@ -8,7 +8,7 @@ from nose.plugins.xunit import Tee
 from nose import SkipTest
 from StringIO import StringIO
 from logging import ERROR, WARNING
-
+from flogging import LoggerArgParseHelper
 
 class StreamMonitorPlugin(Plugin):
     _singleton = None
@@ -53,6 +53,7 @@ class StreamMonitorPlugin(Plugin):
     def options(self, parser, env=os.environ):
         self.__take_step('options', parser=parser, env=env)
         self.__log = logging.getLogger('nose.plugins.streammonitor')
+        self.__flogger_opts_helper = LoggerArgParseHelper(parser)
         super(StreamMonitorPlugin, self).options(parser, env=env)
 
     def configure(self, options, conf):
@@ -73,6 +74,13 @@ class StreamMonitorPlugin(Plugin):
         # tood: check class "enabled_for_nose()"
         if len(self.__stream_plugins) == 0:
             self.__stream_plugins['logging'] = LoggingMarker()
+        else:
+            # This is basically for self-testing the plugin, since the
+            # logging monitor stays around between test-classes. If we don't do
+            # this, the prior logging settings "stick".
+            self.__stream_plugins['logging'].reset_configuration()
+
+        self.__flogger_opts_helper.process_parsed(self.conf.options)
 
         for pg in self.__stream_plugins.values():
             pg.handle_begin()

--- a/test/stream-monitor/stream_sources/log_type.py
+++ b/test/stream-monitor/stream_sources/log_type.py
@@ -11,8 +11,10 @@ class LoggingMarker(StreamMonitorABC):
 
     def __init__(self):
         # import HERE to prevent taking over logfiles for things
-        # like 'nosetests --help'.
-        import flogging
+        # like 'nosetests --help'. Note that a generic "import flogging" won't trigger this.
+        # We need to explicity pull the infra_logging module.
+        import flogging.infra_logging
+        self.__config_reset_method = flogging.infra_logging.logger_reset_configuration
         self.__print_to = None
         # Uncomment next line to view steps to console live
         # self.__print_to = sys.stderr
@@ -23,6 +25,16 @@ class LoggingMarker(StreamMonitorABC):
     @classmethod
     def enabled_for_nose(self):
         return True
+
+    def reset_configuration(self):
+        """
+        Basically for use during plugin self-test, which runs multiple complete
+        test life-cycles for the plugins, but this watcher needs to survive
+        between them. The config of levels, etc, however, does NOT!
+
+        Note: __config_reset_method is pulled from the flogging module in __init__.
+        """
+        self.__config_reset_method()
 
     def handle_begin(self):
         self.__loggers = self.__find_loggers()

--- a/test/stream-monitor/test/log_stream_helper.py
+++ b/test/stream-monitor/test/log_stream_helper.py
@@ -1,0 +1,198 @@
+"""
+Copyright 2017, EMC, Inc.
+"""
+import os
+import re
+import logging
+
+class _TempLogfileObserver(object):
+    """
+    We don't HAVE the stupid stream monitors yet, so this hack allows
+    us to do basic content testing on the log files infra-logging generated.
+
+    This class gets the logging dir from flogging, figures out where we "are" in
+    the file at the moment, and is then able to do simple regex checking in the
+    data from that point forward (kinda like an "tail -f x.log | fgrep <patterns>")
+
+    Cludgely handles both real files and stringio ones.
+    """
+    def __init__(self, lg_name, stringio_override=None):
+        if stringio_override is None:
+            # defer import till here in order to avoid messing up infra-logging
+            # during test loads
+            from flogging.infra_logging import logger_get_logging_dir
+            self.__full_name = os.path.join(logger_get_logging_dir(), lg_name)
+            self.__current_length = os.stat(self.__full_name).st_size
+        else:
+            self.__full_name = lg_name
+            self.__current_length = stringio_override.len
+        self.__stringio_override = stringio_override
+
+    def __get_tail_chunk(self):
+        log_data = ''
+        if self.__stringio_override is None:
+            with open(self.__full_name, 'r') as log_file:
+                log_file.seek(self.__current_length)
+                log_data = log_file.read()
+        else:
+            log_file = self.__stringio_override
+            log_file.seek(self.__current_length)
+            log_data = log_file.read()
+        return log_data
+
+    def check_for_line(self, test, line_re, exp_count):
+        fdata = self.__get_tail_chunk()
+        matches = 0
+        re_matcher = re.compile(line_re)
+        for line in fdata.split('\n'):
+            if re_matcher.search(line):
+                matches += 1
+
+        test.assertTrue(
+            matches == exp_count,
+            'Saw {0} rather than expected {1} of "{2}" in {3}, raw=[[[{4}]]]'.format(
+                matches, exp_count, line_re, self.__full_name, fdata))
+
+    def iter_on_re(self, iter_re):
+        fdata = self.__get_tail_chunk()
+        return re.finditer(iter_re, fdata, re.VERBOSE | re.MULTILINE)
+
+
+class TempLogfileChecker(object):
+    """
+    Crude logfile checker that holds the "business logic" to check for backtraces and
+    capture stdout or stderr contents (or lack thereof!)
+    """
+    def __init__(self, file_name, stringio_override = None):
+        self.__lf_observer = _TempLogfileObserver(file_name, stringio_override)
+        self.__file_name = file_name
+
+    def __check_line(self, test, line_re, exp_count):
+        self.__lf_observer.check_for_line(test, line_re, exp_count)
+
+    def check_backtrace(self, test, ltype, suitepath, test_class, test_file, test_method, exp_count):
+        full_file = os.path.join(suitepath, test_file)
+        tb_line = '{0}\s+traceback: Traceback \(most recent call last\):'.format(ltype)
+        self.__check_line(test, tb_line, exp_count)
+        file_line = 'File "{0}", line \d+, in {1}'.format(full_file, test_method)
+        self.__check_line(test, file_line, exp_count)
+
+    def check_capture(self, test, cap_type, cap_level, test_class, test_method, exp_count):
+        """
+        param test: test-case (to do test.assertEqual on)
+        param cap_type: 'stdout' or 'stderr'
+        param cap_level: 'ERROR' or 'WARNING'
+        param test_class: test class name
+        param test_method: method name in test class
+        param exp_count: expected sightings in file
+        """
+        eline = '{0}\s+{1}:'.format(cap_level, cap_type)
+        self.__check_line(test, eline, exp_count)
+        # Need to check for expected match-data and NOT match data.
+        self.__check_match_data(test, cap_type, test_class, test_method, exp_count)
+
+    def __check_match_data(self, test, which_out, test_class, test_method, exp_count):
+        md_prefix = '{0}-MATCH-DATA: {1}'.format(which_out.upper(), test_class)
+        # Make sure setUp shows up in the one we want.
+        # todo: stream-monitor when we get to it should be able to grab all stdout:
+        #  for example.
+        setup_re = '{0}: {1} setUp'.format(which_out, md_prefix)
+        self.__check_line(test, setup_re, exp_count)
+        method_re = '{0} {1}'.format(md_prefix, test_method)
+        self.__check_line(test, method_re, exp_count)
+        # should see NONE of these:
+        no_see_re = '{0}-MUST-NOT-SEE:'.format(which_out.upper())
+        self.__check_line(test, no_see_re, 0)
+
+    def check_level_output(self, test, start_at_levelno, lg_name):
+        """
+        Routine to look into our file for the last test duration and see if we saw (or didn't see)
+        the right log records. We are looking for (in a normal logger output line)
+        * The right progression of string levels IN the message part of the line
+        * The right progression of string levels in the level part of the line. (same as prior ^^^)
+        * The right level number that matches the string level.
+        * The expected logger name in the message part of the line.
+
+        The "progression" means starting at the start_at_levelno value and going to CRITICAL (the
+        max level the logging system will in theory produce. kind of). Or, if the start_at_levelno
+        is None, we expect to NOT see anything!
+        """
+        line_re = r'''^\d\d\d\d-\d\d-\d\d\s     # '2017-01-12 '
+                      \d\d:\d\d:\d\d,\d\d\d\s   # '10:10:46,106 '
+                      (?P<level>\S+)\s+         # 'WARNING_9 ' or 'INFO   '
+                      MATCH-START\s             # 'MATCH-START '
+                      (?P<logger_name>\S+)\s    # 'infra.run '
+                      (?P<levelno>\d+)\(        # '28('
+                      (?P<level_name>\S+?)\)\s  # 'WARNING_2) '
+                      MATCH-END\s+              # 'MATCH-END    '
+                      .*?$                      # rest-of-line
+                      '''
+        if start_at_levelno is None:
+            test_levelno = 1  # lowest legal value
+            info_base = 'not-matches-expected, lg_name={0}'.format(lg_name)
+            exp_count = 0
+        else:
+            test_levelno = start_at_levelno
+            info_base = 'start_at_levelno={0}, lg_name={1}'.format(start_at_levelno, lg_name)
+            # "CRITICAL" is our max log-value injected in makeSuite in test_logopts.pyh
+            exp_count = logging.getLevelName('CRITICAL') - test_levelno
+
+        count = 0
+        for match in self.__lf_observer.iter_on_re(line_re):
+            count += 1
+            test_level_name = levelno_to_name(test_levelno)
+            pass_info = '({0}, test_level_name={1}, test_levelno={2})'.format(
+                info_base, test_level_name, test_levelno)
+            found_log_level_name = match.group("level")
+            found_msg_logger_name = match.group("logger_name")
+            found_msg_levelno = int(match.group("levelno"))
+            found_msg_level_name = match.group("level_name")
+            test.assertEqual(test_levelno, found_msg_levelno,
+                             'expected levelno {0} != found levelno {1}'.format(
+                                 test_levelno, found_msg_levelno))
+            test.assertEqual(test_level_name, found_msg_level_name,
+                             'expected msg levelname {0} != found {1}'.format(
+                                 test_level_name, found_msg_level_name))
+            test.assertEqual(test_level_name, found_log_level_name,
+                             'expected logger levelname {0} != found {1}'.format(
+                                 test_level_name, found_log_level_name))
+            test.assertEqual(lg_name, found_msg_logger_name,
+                             'expected logger name {0} != found {1}'.format(
+                                 lg_name, found_msg_logger_name))
+            test_levelno += 1
+        test.assertEqual(count, exp_count,
+                         'Expected {0} matches, but only saw {1}'.format(exp_count, count))
+
+
+def levelno_to_name(levelno):
+    """
+    This test infra does not have access to the plugins expanded
+    logger names. So, find the base number and then add an _<remaimder>
+    for non-predefined levels.
+    """
+    # this will turn 21 into 20, 20 into 20, 15 into 10 and so on.
+    adjusted_tens =    (4 + levelno) / 10
+    adjusted_base =    (adjusted_tens * 10)
+    name = logging.getLevelName(adjusted_base)
+    remainder = (4 + levelno) % 10
+    # and reverse because remainder is currently reversed vs range.
+    remainder = 9 - remainder
+    if remainder != 5:
+        name = '{0}_{1}'.format(name, remainder)
+    return name
+
+
+def levelname_to_number(level_name):
+    """
+    This test infra does not have access to the plugins expanded
+    logger names. This function will take a name and figure out the raw
+    number value.
+    """
+    if '_' in level_name:
+        base_name, num_str = level_name.split('_', 1)
+        base_value = logging.getLevelName(base_name)
+        offset_val = int(num_str)
+        ret_val = base_value + (5 - offset_val)
+    else:
+        ret_val = logging.getLevelName(level_name)
+    return ret_val

--- a/test/stream-monitor/test/plugin_test_helper.py
+++ b/test/stream-monitor/test/plugin_test_helper.py
@@ -8,8 +8,10 @@ class _BaseStreamMonitorPluginTester(PluginTester, unittest.TestCase):
     activate = '--with-stream-monitor'
     _smp = StreamMonitorPlugin()
     _smp._self_test_print_step_enable()
-    _expect_nose_success = True
     plugins = [_smp]
+
+class _BaseStreamMonitorPluginTesterVerify(_BaseStreamMonitorPluginTester):
+    _expect_nose_success = True
     def runTest(self):
         # This is called once for each class derived from it. We don't really
         # have access to much other than success/failure and the raw string output
@@ -92,6 +94,9 @@ class _BaseStreamMonitorPluginTester(PluginTester, unittest.TestCase):
 
 
 def resolve_helper_class():
+    return _BaseStreamMonitorPluginTesterVerify
+
+def resolve_no_verify_helper_class():
     return _BaseStreamMonitorPluginTester
 
 def resolve_suitepath(*args):

--- a/test/stream-monitor/test/test_infra_logging.py
+++ b/test/stream-monitor/test/test_infra_logging.py
@@ -4,7 +4,7 @@ Copyright 2016, EMC, Inc.
 This file contains (very very crude, at the moment!) self
 tests of the logging infrastructure.
 """
-import flogging
+from flogging.infra_logging import logger_get_logging_dir
 import os
 from unittest import TestCase
 
@@ -14,7 +14,7 @@ class TestInfraLogging(TestCase):
         pass
 
     def setUp(self):
-        self.__lg_full_path = flogging.logger_get_logging_dir()
+        self.__lg_full_path = logger_get_logging_dir()
         self.__lg_container_path = os.path.dirname(self.__lg_full_path)
         self.__lg_sym_path = os.path.join(self.__lg_container_path, 'run_last.d')
 

--- a/test/stream-monitor/test/test_log_stream.py
+++ b/test/stream-monitor/test/test_log_stream.py
@@ -2,90 +2,8 @@ import plugin_test_helper
 import os
 import re
 import sys
+from log_stream_helper import TempLogfileChecker
 
-class _TempLogfileObserver(object):
-    """
-    We don't HAVE the stupid stream monitors yet, so this hack allows
-    us to do basic content testing on the log files infra-logging generated.
-
-    This class gets the logging dir from flogging, figures out where we "are" in
-    the file at the moment, and is then able to do simple regex checking in the
-    data from that point forward (kinda like an "tail -f x.log | fgrep <patterns>")
-    """
-    def __init__(self, lg_name):
-        # defer import till here in order to avoid messing up infra-logging
-        # during test loads
-        from flogging import logger_get_logging_dir
-        self.__full_name = os.path.join(logger_get_logging_dir(), lg_name)
-        self.__current_length = os.stat(self.__full_name).st_size
-
-    def __get_tail_chunk(self):
-        log_data = ''
-        with open(self.__full_name, 'r') as log_file:
-            log_file.seek(self.__current_length)
-            log_data = log_file.read()
-        return log_data
-
-    def check_for_line(self, test, line_re, exp_count):
-        fdata = self.__get_tail_chunk()
-        matches = 0
-        re_matcher = re.compile(line_re)
-        for line in fdata.split('\n'):
-            if re_matcher.search(line):
-                matches += 1
-
-        test.assertTrue(
-            matches == exp_count, 
-            'Saw {0} rather than expected {1} of "{2}" in {3}, raw=[[[{4}]]]'.format(
-                matches, exp_count, line_re, self.__full_name, fdata))
-        
-
-class _TempLogfileChecker(object):
-    """
-    Crude logfile checker that holds the "business logic" to check for backtraces and
-    capture stdout or stderr contents (or lack thereof!)
-    """
-    def __init__(self, file_name):
-        self.__lf_observer = _TempLogfileObserver(file_name)
-
-    def __check_line(self, test, line_re, exp_count):
-        self.__lf_observer.check_for_line(test, line_re, exp_count)
-                
-    def check_backtrace(self, test, ltype, suitepath, test_class, test_file, test_method, exp_count):
-        full_file = os.path.join(suitepath, test_file)
-        tb_line = '{0}\straceback: Traceback \(most recent call last\):'.format(ltype)
-        self.__check_line(test, tb_line, exp_count)
-        file_line = 'File "{0}", line \d+, in {1}'.format(full_file, test_method)
-        self.__check_line(test, file_line, exp_count)
-
-    def check_capture(self, test, cap_type, cap_level, test_class, test_method, exp_count):
-        """
-        param test: test-case (to do test.assertEqual on)
-        param cap_type: 'stdout' or 'stderr'
-        param cap_level: 'ERROR' or 'WARNING'
-        param test_class: test class name
-        param test_method: method name in test class
-        param exp_count: expected sightings in file
-        
-        """
-        eline = '{0}\s{1}:'.format(cap_level, cap_type)
-        self.__check_line(test, eline, exp_count)
-        # Need to check for expected match-data and NOT match data.
-        self.__check_match_data(test, cap_type, test_class, test_method, exp_count)
-
-    def __check_match_data(self, test, which_out, test_class, test_method, exp_count):
-        md_prefix = '{0}-MATCH-DATA: {1}'.format(which_out.upper(), test_class)
-        # Make sure setUp shows up in the one we want.
-        # todo: stream-monitor when we get to it should be able to grab all stdout:
-        #  for example.
-        setup_re = '{0}: {1} setUp'.format(which_out, md_prefix)
-        self.__check_line(test, setup_re, exp_count)
-        method_re = '{0} {1}'.format(md_prefix, test_method)
-        self.__check_line(test, method_re, exp_count)
-        # should see NONE of these:
-        no_see_re = '{0}-MUST-NOT-SEE:'.format(which_out.upper())
-        self.__check_line(test, no_see_re, 0)
-        
 
 class TestSMPLoggingSingleOk(plugin_test_helper.resolve_helper_class()):
     suitepath = plugin_test_helper.resolve_suitepath('stream-source', 'logging', 'one_pass')
@@ -123,7 +41,7 @@ class _BacktraceBase(plugin_test_helper.resolve_helper_class()):
     _expect_nose_success = False
 
     def setUp(self):
-        self.__logfile_checker = _TempLogfileChecker(self._backtrace_finder_file)
+        self.__logfile_checker = TempLogfileChecker(self._backtrace_finder_file)
         super(_BacktraceBase, self).setUp()
         
     def verify(self):
@@ -163,7 +81,7 @@ class TestSMPLoggingBacktrace_console_capture_error(_BacktraceBase):
 class _CaptureBase(plugin_test_helper.resolve_helper_class()):
     _capture_method = None
     def setUp(self):
-        self.__logfile_checker = _TempLogfileChecker(self._capture_finder_file)
+        self.__logfile_checker = TempLogfileChecker(self._capture_finder_file)
         super(_CaptureBase, self).setUp()
         
     def verify(self):

--- a/test/stream-monitor/test/test_logopts.py
+++ b/test/stream-monitor/test/test_logopts.py
@@ -1,0 +1,224 @@
+"""
+Copyright 2017, EMC, Inc.
+"""
+import plugin_test_helper
+import os
+import re
+import sys
+from log_stream_helper import TempLogfileChecker, levelname_to_number
+import unittest
+import logging
+from StringIO import StringIO
+
+
+class _Expector(object):
+    def __init__(self, use_logger, at_level, all_all_at='NOTSET', concap_at='INFO', real_at='INFO'):
+        """
+        Simple class to automate some of the compare setups.
+        """
+        at_levelno = levelname_to_number(at_level)
+        self.at_level = at_level
+        self.logger_name = use_logger
+        self.expect_for_infra_run = None
+        self.expect_for_infra_data = None
+        self.expect_for_test_run = None
+        self.expect_for_test_data = None
+        self.expect_for_console_capture = None
+        self.expect_for_all_all = None
+        self.expect_for_real = None
+        figure_all_all = True
+        figure_concap = True
+        figure_real = True
+        if use_logger == 'infra.run':
+            self.expect_for_infra_run = at_level
+        elif use_logger == 'infra.data':
+            self.expect_for_infra_data = at_level
+        elif use_logger == 'test.run':
+            self.expect_for_test_run = at_level
+        elif use_logger == 'test.data':
+            self.expect_for_test_data = at_level
+        else:
+            figure_all_all = False
+            figure_concap = False
+            figure_real = False
+
+        if figure_all_all:
+            self.expect_for_all_all = all_all_at
+
+        if figure_concap:
+            self.expect_for_console_capture = concap_at
+
+        if figure_real:
+            self.expect_for_real = real_at
+
+
+class _OutputScannerBase(plugin_test_helper.resolve_no_verify_helper_class()):
+    """
+    Plugin tester instance used for each real test block.
+    """
+    def setUp(self, *args, **kwargs):
+        """
+        This is called before all the test in the block, but in the context of the
+        plugin-under-test. We do the following:
+        * replace stderr with a StringIO stream.
+        * start a dict of log-file to our cheesy log-file-checkers on the stderr streamio.
+        * add to the dict of log-files with a cheesy log-file-checkers for each physical log file.
+        * init our super (to finish any wiring IT has to do)
+        """
+        checker_dict = {}
+        self.__save_stderr = sys.stderr
+        self.__stream_stderr = StringIO()
+        sys.stderr = self.__stream_stderr
+        checker_dict['stderr'] = TempLogfileChecker('stderr', self.__stream_stderr)
+
+        lg_names = ['all_all.log', 'console_capture.log', 'infra_data.log',
+                    'infra_run.log', 'test_data.log', 'test_run.log']
+        for lg_name in lg_names:
+            checker_dict[lg_name] = TempLogfileChecker(lg_name)
+        self.__lgfile_watchers = checker_dict
+        super(_OutputScannerBase, self).setUp(*args, **kwargs)
+
+    def tearDown(self, *args, **kwargs):
+        """
+        The mirror of setUp. We restore stderr and then do our one magic trick:
+        We clear out the call sequence of the stream-monitor plugin. WE don't use it, but
+        can't turn it off and if we don't clear it, OUR calls will end up in the
+        next test's sequence!
+        """
+        sys.stderr = self.__save_stderr
+        self._smp._self_test_sequence_seen()
+        super(_OutputScannerBase, self).tearDown(*args, **kwargs)
+
+    def __common_test_expected(self, expect_level, emit_level, logger_name, log_file):
+        if expect_level is not None:
+            exp_levelno = logging.getLevelName(expect_level)
+            emit_levelno = logging.getLevelName(emit_level)
+            expect_level = max(exp_levelno, emit_levelno)
+        self.__lgfile_watchers[log_file].check_level_output(
+                self, expect_level, logger_name)
+
+    def test_infra_run_expected(self):
+        self.__common_test_expected(
+            self._expector.expect_for_infra_run, self._expector.at_level,
+            self._expector.logger_name, 'infra_run.log')
+
+    def test_infra_data_expected(self):
+        self.__common_test_expected(
+            self._expector.expect_for_infra_data, self._expector.at_level,
+            self._expector.logger_name, 'infra_data.log')
+
+    def test_test_run_expected(self):
+        self.__common_test_expected(
+            self._expector.expect_for_test_run, self._expector.at_level,
+            self._expector.logger_name, 'test_run.log')
+
+    def test_test_data_expected(self):
+        self.__common_test_expected(
+            self._expector.expect_for_test_data, self._expector.at_level,
+            self._expector.logger_name, 'test_data.log')
+
+    def test_all_all_expected(self):
+        self.__common_test_expected(
+            self._expector.expect_for_all_all, self._expector.at_level,
+            self._expector.logger_name, 'all_all.log')
+
+    def test_console_capture_expected(self):
+        self.__common_test_expected(
+            self._expector.expect_for_console_capture, self._expector.at_level,
+            self._expector.logger_name, 'console_capture.log')
+
+    def test_real_console(self):
+        self.__common_test_expected(
+            self._expector.expect_for_real, self._expector.at_level,
+            self._expector.logger_name, 'stderr')
+
+    def makeSuite(self):
+        """
+        This is a required method for plugin-testing that return a suite of tests
+        for this class. Said suite must implement "runTest" (see comment there).
+        We also 'publish' this class's expector, so the runTest method can see it.
+        """
+        expector = self._expector
+        class TC(unittest.TestCase):
+            def runTest(self):
+                """
+                This method spams the logger from the expector from its base level
+                up to CRITICAL with a message that is fairly easy to regex match in
+                the routines from the methods in test_log_stream.py.
+                """
+                import logging
+                lg_name = expector.logger_name
+                lg = logging.getLogger(lg_name)
+                start_level = logging.getLevelName('DEBUG_9')
+                end_level = logging.getLevelName('CRITICAL')
+                for lvl in xrange(start_level, end_level):
+                    lg.log(lvl, 'MATCH-START %s %d(%s) MATCH-END',
+                           lg_name, lvl, logging.getLevelName(lvl))
+
+        return [TC()]
+
+
+"""
+The following classes are all derived from _OutputScannerBase. They each
+set a different batch of command line args to nosetest, and define an
+"expector" to tell the inherited methods in _OutputScannerBase what to do and look for.
+"""
+
+class OutputScannerBaseInfraRun(_OutputScannerBase):
+    args=[]
+    _expector = _Expector('infra.run', 'DEBUG')
+
+
+class LevelsForAnOutputInfraRun(_OutputScannerBase):
+    args=['--sm-set-logger-level', 'infra.run', 'DEBUG_7']
+    _expector = _Expector('infra.run', 'DEBUG_7')
+
+
+class LevelsForAnOutputInfraData(_OutputScannerBase):
+    args=['--sm-set-logger-level', 'infra.data', 'DEBUG_9']
+    _expector = _Expector('infra.data', 'DEBUG_9')
+
+
+class LevelsForAnOutputTestRun(_OutputScannerBase):
+    args=['--sm-set-logger-level', 'test.run', 'WARNING']
+    _expector = _Expector('test.run', 'WARNING')
+
+
+class LevelsForAnOutputTestData(_OutputScannerBase):
+    args=['--sm-set-logger-level', 'test.data', 'INFO_9']
+    _expector = _Expector('test.data', 'INFO_9')
+
+
+class HandlerRemapForALogger(_OutputScannerBase):
+    """
+    Note: this is paired with _OutputScannerBaseInfraRun, since that "proves" that
+    by default, no debug is making it into log-capture. THIS lets the debugs out.
+    """
+    args=['--sm-set-logger-level', 'infra.run', 'DEBUG_7',
+          '--sm-set-handler-level', 'console-capture', 'DEBUG']
+    _expector = _Expector('infra.run', 'DEBUG_7', concap_at='DEBUG')
+
+
+class ComboRemapForALoggerSingleHandler(_OutputScannerBase):
+    """
+    This options sets the level of a given handler AND any logger feeding it.
+    This will test a fairly basic footprint of that. Note that this argument
+    is basically the equiv of the combo of logger and handler levels set in
+    HandlerRemapForALogger.
+    """
+    args=['--sm-set-combo-level', 'console-capture', 'DEBUG_6']
+    _expector = _Expector('infra.run', 'DEBUG_6', concap_at='DEBUG_6')
+
+class ComboRemapForALoggerGlobHandlers(_OutputScannerBase):
+    """
+    Same as ComboRemapForALoggerSingleHandler, but we grab both console and
+    console-capture handlers via wildcard.
+    """
+    args=['--sm-set-combo-level', 'console*', 'DEBUG_8']
+    _expector = _Expector('infra.run', 'DEBUG_8', concap_at='DEBUG_8', real_at='DEBUG_8')
+
+
+class SetFileLevelTestAtD7(_OutputScannerBase):
+    args=['--sm-set-file-level', 'test_logopts.py', '*', 'DEBUG_7']
+    _expector = _Expector('infra.run', 'DEBUG_7', concap_at='DEBUG_7', real_at='DEBUG_7')
+    # note: todo/missing test -> also inject into a 2nd logger and only see data from IT at info

--- a/test/stream-monitor/test/test_logopts.py
+++ b/test/stream-monitor/test/test_logopts.py
@@ -12,7 +12,7 @@ from StringIO import StringIO
 
 
 class _Expector(object):
-    def __init__(self, use_logger, at_level, all_all_at='NOTSET', concap_at='INFO', real_at='INFO'):
+    def __init__(self, use_logger, at_level, all_all_at='NOTSET', concap_at='INFO_5', real_at='INFO_5'):
         """
         Simple class to automate some of the compare setups.
         """
@@ -150,7 +150,7 @@ class _OutputScannerBase(plugin_test_helper.resolve_no_verify_helper_class()):
                 lg_name = expector.logger_name
                 lg = logging.getLogger(lg_name)
                 start_level = logging.getLevelName('DEBUG_9')
-                end_level = logging.getLevelName('CRITICAL')
+                end_level = logging.getLevelName('CRITICAL_0')
                 for lvl in xrange(start_level, end_level):
                     lg.log(lvl, 'MATCH-START %s %d(%s) MATCH-END',
                            lg_name, lvl, logging.getLevelName(lvl))
@@ -166,7 +166,7 @@ set a different batch of command line args to nosetest, and define an
 
 class OutputScannerBaseInfraRun(_OutputScannerBase):
     args=[]
-    _expector = _Expector('infra.run', 'DEBUG')
+    _expector = _Expector('infra.run', 'DEBUG_5')
 
 
 class LevelsForAnOutputInfraRun(_OutputScannerBase):
@@ -180,8 +180,8 @@ class LevelsForAnOutputInfraData(_OutputScannerBase):
 
 
 class LevelsForAnOutputTestRun(_OutputScannerBase):
-    args=['--sm-set-logger-level', 'test.run', 'WARNING']
-    _expector = _Expector('test.run', 'WARNING')
+    args=['--sm-set-logger-level', 'test.run', 'WARNING_5']
+    _expector = _Expector('test.run', 'WARNING_5')
 
 
 class LevelsForAnOutputTestData(_OutputScannerBase):
@@ -195,8 +195,8 @@ class HandlerRemapForALogger(_OutputScannerBase):
     by default, no debug is making it into log-capture. THIS lets the debugs out.
     """
     args=['--sm-set-logger-level', 'infra.run', 'DEBUG_7',
-          '--sm-set-handler-level', 'console-capture', 'DEBUG']
-    _expector = _Expector('infra.run', 'DEBUG_7', concap_at='DEBUG')
+          '--sm-set-handler-level', 'console-capture', 'DEBUG_5']
+    _expector = _Expector('infra.run', 'DEBUG_7', concap_at='DEBUG_5')
 
 
 class ComboRemapForALoggerSingleHandler(_OutputScannerBase):


### PR DESCRIPTION
This adds control of the levels to the new logging infra. This is a first step, and
is focused mainly on the controls via the nose-plugin options, but with some wiring
for (temporary) to run_test.py's -v specturm. (rac-3984 will dig into that further).

Alas, this is a fairly big change-set. The bulk of what was added can be summed up with
the following --help chunk:

  listing log settings:
    --sm-list-logging   list logging settings
    --sm-list-level=LIST_LOGGING_LEVEL
                        detail level if --list-logging is used

  setting log options:
    note: both 'logger-name's and 'handler-name's can contain wild-card
    characters to match multiple items.

    --sm-set-logger-level=('logger-name', 'level-name-or-value')
                        Set a logger's capture threshold. Loggers are
                        evaluated before handlers.
    --sm-set-handler-level=('handler-name[:logger-name]', 'level-name-or-value')
                        Set a handler's capture threshold.
    --sm-set-combo-level=('handler-name[:logger-name]', 'level-name-or-value')
                        Set a handler's capture threshold AND all loggers
                        feeding it.
    --sm-crank-file=('file-pattern', '[handler-name[:logger-name] [level-name-or-value]]')
                        changes the logging level for handler(s) on the given
                        loggers to a new value for matching files

Everything else is to support that and/or test it. I am updating the README.td file, in parallel with
starting the review, and the README will have an overview of the loggers and how loggers + handlers work. Actually, I'll problably start with the overview in this PR!

Overview of whats going on in order to make sense of the changes :) :
In a very brief sense, when you use the "main" logger from the first example conversion (logs = flogging.get_loggers()), you
are writing to the 'test.run' logger when you do a 'logs.debug()' or 'logs.info()' call. The sequence is a like this:

There are four infra-logging loggers: infra.run, infra.data, test.run, test.dat (and technically the root one, but it itself ins't used directly for log-calls)
So, by default, there are six files: 'test_run.log', 'test_data.log', 'infra_run.log', 'infra_data.log', 'combined_all_all.log', and 'console_capture.log', placed in the directory 'log_output/run_<datetime-stamp>.d'. 'log_output/run_last.d' is linked to the most recent of these.
test_run, test_data, infra_run, and infra_data all contain DEBUG level and above output for THEIR loggers.
combined_all_all contains DEBUG level and above from all of those.
console_capture contains only INFO level and above from the four infra-loggers (and INFO and above from any other logger outside of main infra-logging ones)

So, back to the --help stuff:
    --sm-set-logger-level=('logger-name', 'level-name-or-value')
                        Set a logger's capture threshold. Loggers are
                        evaluated before handlers.
This will change the logger level. For example, '--sm-set-logger-level test.run DEBUG_5' will change the logger level from DEBUG(_0) to DEBUG_5. I.E. DEBUG_6 will still be dropped by the test.run logger.
The way things are wired, this only impacts the level of messages flowing to test_run.log and combined_all_all.log. The messages would still be dropped by the root-logger, since it is at INFO.

Note that the logger name can be wild-carded: 'test.*' or 'test*' to change both test.run and test.data, or '*.data' to crank up the volume of data dumps.

    --sm-set-handler-level=('handler-name[:logger-name]', 'level-name-or-value')
                        Set a handler's capture threshold.

But if you wanted to have more than just DEBUG flow to stdout? '--sm-set-handler-level console DEBUG'. This will actually have less impact than you would think, since
both the root logger AND the console handler have a level threshold of 'INFO'.
The actual usefull application of this option would be to lower levels '--sm-set-handler-level console WARNING'. This would me only warnings and above to the console, while still sending INFO and above to the console_capture file.

Mostly, this is here for completeness, and for use 'behind the scenes' on the more usefull next option:

    --sm-set-combo-level=('handler-name[:logger-name]', 'level-name-or-value')
                        Set a handler's capture threshold AND all loggers
                        feeding it.

Doing a '--sm-set-combo-level console DEBUG' will go and change the handler level for 'console' AND all loggers feeding into it. Because 'console' is attached to the
root logger, this ends up override ALL the loggers (that had been created at this point. That is a key limitation).
Of course, this means that the console is being spammed with DEBUG output from everything. '--sm-set-combo-level console*:*.run DEBUG_5' will have the affect of:

    --sm-crank-file=('file-pattern', '[handler-name[:logger-name] [level-name-or-value]]')
                        changes the logging level for handler(s) on the given
                        loggers to a new value for matching files

This last option can be used to "crank up" the output for a specific file or files. The handler and logger name parts are just like in the combo.
The file pattern is a regex applied against the filename seen in the output records.

The changes made to do this:
* adapted run_test.py to be able to pass arguments it didn't use to nosetests (and get help back).
* changed the comment for the -v option in run_test.py and setup argument mappings to implement them.
* changed the wrapper in _LevelLoggerClass, which was wrongly using _log rather than log (_log didn't propagate!)
* changed levels in the dict-config from DEBUG to NOTSET infra handlers
* added a 'reset_config' method in flogging/infra_logging.py to squash configs between tests run in the plugin tester
* added a 'flogging/infra_logopts.py':
** contains a parser-helper class that other entry-points can call to add the infra-logging-opts options to it and then later call to process the args. This also includes the implementation for the list and set options.
** since nose is still on the old optargs, add a converter class to convert setup via argparse to the more limited optargs.
** the _LoggingConfigFilter class defined here implements the handler+logger filtering described above.
* wired the parser-helper setup and processing into the stream_monitor plugin.
* moved most of the file observer logic into its own file, log_stream_Helper.py
* added logic to same to deal with testing for level based logs.
* added a test_log_opts.py inside stream-monitor/test to self-test options.
* rewired imports a little to be more precise about when the "real" flogging gets imported/instantiated.

@RackHD/corecommitters @johren @hohene @gpaulos @larry-dean @jimturnquist @keedya @panpan0000 @changev @anhou
