### PR TITLE
fix urllib3 version in cit to fix api 1.1 post_nodes as a temp solution

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -14,6 +14,8 @@ on_http_redfish_1_0>=1.0.0
 pexpect==3.3
 proboscis==1.2.6.0
 requests==2.9.0
+# urllib3 1.20 breaks CIT test, specify version as a temp solution
+urllib3==1.19.1
 
 # WARNING: do not just replace this file with "pip freeze > requirements.txt".
 # You need to keep the following line as is! (freeze will turn it into


### PR DESCRIPTION
In Jenkins, "POST:/nodes/" of api 1.1 in CIT always fails with the error message "connection abort" in these two days.
It is found that urllib3 used by on_http_1.1 python client releases a new version yesterday (see https://pypi.python.org/pypi/urllib3). Fix the version used for cit to the older one solves the problem.
It can be a temp solution until we verify the newer version of urllib3 works for our system.