### PR TITLE
add script:  install from src script (used for vagrant box rackhd-dev)

### DIFF
--- a/example/install_from_src.sh
+++ b/example/install_from_src.sh
@@ -19,7 +19,8 @@ BRANCH=${2:-master} # can be a tag like 1.0.0
 
 
 
-RACKHD_DEP_REPOS=("on-core" "on-tasks" "di.js" )
+#RACKHD_DEP_REPOS=("on-core" "on-tasks" "di.js" )
+RACKHD_DEP_REPOS=("on-core" "on-tasks" }
 RACKHD_MAIN_REPOS=("on-http" "on-taskgraph" "on-dhcp-proxy" "on-tftp" "on-syslog" )
 RACKHD_NODE_REPOS=("${RACKHD_DEP_REPOS[@]}" "${RACKHD_MAIN_REPOS[@]}")
 RACKHD_OTHER_REPOS=( "on-wss" "on-tools" "on-imagebuilder" "RackHD")
@@ -49,7 +50,7 @@ for r in ${RACKHD_NODE_REPOS[@]}; do
 done
 
 echo "[Info] Make common static directory & generate Docs"
-HTTP_STATIC_FOLDER=on-http/static/http
+HTTP_STATIC_FOLDER=on-http/static/http/common
 TFTP_STATIC_FOLDER=on-tftp/static/tftp
 mkdir -p $HTTP_STATIC_FOLDER
 mkdir -p $TFTP_STATIC_FOLDER
@@ -64,16 +65,16 @@ popd
 
 echo "[Info] Download Static Images"
 HTTP_BASE_URL=https://bintray.com/artifact/download/rackhd/binary/builds/
-TFTP_BASE_URL=https://bintray.com/artifact/download/rackhd/binary/builds/
+TFTP_BASE_URL=https://bintray.com/artifact/download/rackhd/binary/ipxe/
 SYSL_BASE_URL=https://bintray.com/artifact/download/rackhd/binary/syslinux/
 HTTP_STATIC_FILES=( discovery.overlay.cpio.gz base.trusty.3.16.0-25-generic.squashfs.img initrd.img-3.16.0-25-generic vmlinuz-3.16.0-25-generic )
 TFTP_STATIC_FILES=( monorail.ipxe monorail-undionly.kpxe monorail-efi32-snponly.efi monorail-efi64-snponly.efi monorail.intel.ipxe )
 #SYSL_STATIC_FILES=( undionly.kkpxe )
 for f in ${HTTP_STATIC_FILES[@]}; do
-    wget ${HTTP_BASE_URL}/${f}  ${HTTP_STATIC_FOLDER}/${f}
+    wget ${HTTP_BASE_URL}/${f} -O  ${HTTP_STATIC_FOLDER}/${f}
 done
 for f in ${TFTP_STATIC_FILES[@]}; do
-    wget ${TFTP_BASE_URL}/${f}  ${TFTP_STATIC_FOLDER}/${f}
+    wget ${TFTP_BASE_URL}/${f} -O ${TFTP_STATIC_FOLDER}/${f}
 done
 #### undionly.kkpxe is no longer used ###
 #for f in ${SYSL_STATIC_FILES[@]}; do

--- a/example/install_src.sh
+++ b/example/install_src.sh
@@ -19,9 +19,9 @@ BRANCH=${2:-master} # can be a tag like 1.0.0
 
 
 
-RACKHD_CORE_REPOS=("on-core" "on-tasks" "di.js" )
-RACKHD_DEP_REPOS=("on-http" "on-taskgraph" "on-dhcp-proxy" "on-tftp" "on-syslog" )
-RACKHD_NODE_REPOS=("${RACKHD_CORE_REPOS[@]}" "${RACKHD_DEP_REPOS[@]}")
+RACKHD_DEP_REPOS=("on-core" "on-tasks" "di.js" )
+RACKHD_MAIN_REPOS=("on-http" "on-taskgraph" "on-dhcp-proxy" "on-tftp" "on-syslog" )
+RACKHD_NODE_REPOS=("${RACKHD_DEP_REPOS[@]}" "${RACKHD_MAIN_REPOS[@]}")
 RACKHD_OTHER_REPOS=( "on-wss" "on-tools" "on-imagebuilder" "RackHD")
 REPOS=( "${RACKHD_NODE_REPOS[@]}"  "${RACKHD_OTHER_REPOS[@]}" )
 
@@ -82,10 +82,10 @@ done
 
 
 echo "[Info] Move the on-core/on-tasks into each dependent repo's node_modueles..."
-for r in ${RACKHD_DEP_REPOS[@]}; do
+for r in ${RACKHD_MAIN_REPOS[@]}; do
     pushd ${r}/node_modules/
     #remove the on-core/on-tasks, and replace by a link to local folder
-    for dep in ${RACKHD_CORE_REPOS[@]}; do
+    for dep in ${RACKHD_DEP_REPOS[@]}; do
        rm ${dep} -rf
        ln -s ../../${dep}     ${dep}
     done

--- a/example/install_src.sh
+++ b/example/install_src.sh
@@ -19,12 +19,12 @@ BRANCH=${2:-master} # can be a tag like 1.0.0
 
 
 
-NODE_CORE_REPOS=("on-core" "on-tasks" "di.js" )
-NODE_OTHER_REPOS=("on-http" "on-taskgraph" "on-dhcp-proxy" "on-tftp" "on-syslog" )
-NODE_REPOS=("${NODE_CORE_REPOS[@]}" "${NODE_OTHER_REPOS[@]}")
-OTHER_REPOS=( "on-wss" "on-tools" "on-imagebuilder" "RackHD")
-REPOS=( "${NODE_REPOS[@]}"  "${OTHER_REPOS[@]}" )
-#GITHUB="https://eos2git.cec.lab.emc.com/RackHD" # https://github.com/RackHD
+RACKHD_CORE_REPOS=("on-core" "on-tasks" "di.js" )
+RACKHD_DEP_REPOS=("on-http" "on-taskgraph" "on-dhcp-proxy" "on-tftp" "on-syslog" )
+RACKHD_NODE_REPOS=("${RACKHD_CORE_REPOS[@]}" "${RACKHD_DEP_REPOS[@]}")
+RACKHD_OTHER_REPOS=( "on-wss" "on-tools" "on-imagebuilder" "RackHD")
+REPOS=( "${RACKHD_NODE_REPOS[@]}"  "${RACKHD_OTHER_REPOS[@]}" )
+
 GITHUB="https://github.com/RackHD"
 
 
@@ -42,9 +42,9 @@ for r in ${REPOS[@]}; do
     popd
 done
 
-for r in ${NODE_REPOS[@]}; do
+for r in ${RACKHD_NODE_REPOS[@]}; do
     pushd ${r}
-    npm install --production
+    npm install
     popd
 done
 
@@ -68,23 +68,24 @@ TFTP_BASE_URL=https://bintray.com/artifact/download/rackhd/binary/builds/
 SYSL_BASE_URL=https://bintray.com/artifact/download/rackhd/binary/syslinux/
 HTTP_STATIC_FILES=( discovery.overlay.cpio.gz base.trusty.3.16.0-25-generic.squashfs.img initrd.img-3.16.0-25-generic vmlinuz-3.16.0-25-generic )
 TFTP_STATIC_FILES=( monorail.ipxe monorail-undionly.kpxe monorail-efi32-snponly.efi monorail-efi64-snponly.efi monorail.intel.ipxe )
-SYSL_STATIC_FILES=( undionly.kkpxe )
+#SYSL_STATIC_FILES=( undionly.kkpxe )
 for f in ${HTTP_STATIC_FILES[@]}; do
     wget ${HTTP_BASE_URL}/${f}  ${HTTP_STATIC_FOLDER}/${f}
 done
 for f in ${TFTP_STATIC_FILES[@]}; do
     wget ${TFTP_BASE_URL}/${f}  ${TFTP_STATIC_FOLDER}/${f}
 done
-for f in ${SYSL_STATIC_FILES[@]}; do
-    wget ${SYSL_BASE_URL}/${f}  ${SYSL_STATIC_FOLDER}/${f}
-done
+#### undionly.kkpxe is no longer used ###
+#for f in ${SYSL_STATIC_FILES[@]}; do
+#    wget ${SYSL_BASE_URL}/${f}  ${SYSL_STATIC_FOLDER}/${f}
+#done
 
 
 echo "[Info] Move the on-core/on-tasks into each dependent repo's node_modueles..."
-for r in ${NODE_OTHER_REPOS[@]}; do
+for r in ${RACKHD_DEP_REPOS[@]}; do
     pushd ${r}/node_modules/
     #remove the on-core/on-tasks, and replace by a link to local folder
-    for dep in ${NODE_CORE_REPOS[@]}; do
+    for dep in ${RACKHD_CORE_REPOS[@]}; do
        rm ${dep} -rf
        ln -s ../../${dep}     ${dep}
     done

--- a/example/install_src.sh
+++ b/example/install_src.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+PWD=$(pwd)
+MYDIR=${1:-$PWD}
+if [ ! -d $MYDIR ]; then
+    echo "[Error] working directory=$MYDIR doesn't exist"
+    exit -1
+fi
+
+pushd $MYDIR
+
+WORKDIR=$(pwd)  # Absolute Path
+
+
+set -e
+set -x
+
+BRANCH=${2:-master} # can be a tag like 1.0.0
+
+
+
+NODE_CORE_REPOS=("on-core" "on-tasks" "di.js" )
+NODE_OTHER_REPOS=("on-http" "on-taskgraph" "on-dhcp-proxy" "on-tftp" "on-syslog" )
+NODE_REPOS=("${NODE_CORE_REPOS[@]}" "${NODE_OTHER_REPOS[@]}")
+OTHER_REPOS=( "on-wss" "on-tools" "on-imagebuilder" "RackHD")
+REPOS=( "${NODE_REPOS[@]}"  "${OTHER_REPOS[@]}" )
+#GITHUB="https://eos2git.cec.lab.emc.com/RackHD" # https://github.com/RackHD
+GITHUB="https://github.com/RackHD"
+
+
+echo "[Info] Clone RackHD repos, and checkout to  branch ${BRANCH}"
+
+
+for r in ${REPOS[@]}; do
+    rm ${r} -rf
+    git clone ${GITHUB}/${r}.git
+    pushd ${r}
+    git fetch --all --prune --tags
+    if [ -z $BRANCH ]; then
+        git checkout ${BRANCH}
+    fi
+    popd
+done
+
+for r in ${NODE_REPOS[@]}; do
+    pushd ${r}
+    npm install --production
+    popd
+done
+
+echo "[Info] Make common static directory & generate Docs"
+HTTP_STATIC_FOLDER=on-http/static/http
+TFTP_STATIC_FOLDER=on-tftp/static/tftp
+mkdir -p $HTTP_STATIC_FOLDER
+mkdir -p $TFTP_STATIC_FOLDER
+mkdir -p on-http/static/http/common
+pushd on-http
+npm install apidoc
+npm run apidoc
+npm run taskdoc
+popd
+
+
+
+echo "[Info] Download Static Images"
+HTTP_BASE_URL=https://bintray.com/artifact/download/rackhd/binary/builds/
+TFTP_BASE_URL=https://bintray.com/artifact/download/rackhd/binary/builds/
+SYSL_BASE_URL=https://bintray.com/artifact/download/rackhd/binary/syslinux/
+HTTP_STATIC_FILES=( discovery.overlay.cpio.gz base.trusty.3.16.0-25-generic.squashfs.img initrd.img-3.16.0-25-generic vmlinuz-3.16.0-25-generic )
+TFTP_STATIC_FILES=( monorail.ipxe monorail-undionly.kpxe monorail-efi32-snponly.efi monorail-efi64-snponly.efi monorail.intel.ipxe )
+SYSL_STATIC_FILES=( undionly.kkpxe )
+for f in ${HTTP_STATIC_FILES[@]}; do
+    wget ${HTTP_BASE_URL}/${f}  ${HTTP_STATIC_FOLDER}/${f}
+done
+for f in ${TFTP_STATIC_FILES[@]}; do
+    wget ${TFTP_BASE_URL}/${f}  ${TFTP_STATIC_FOLDER}/${f}
+done
+for f in ${SYSL_STATIC_FILES[@]}; do
+    wget ${SYSL_BASE_URL}/${f}  ${SYSL_STATIC_FOLDER}/${f}
+done
+
+
+echo "[Info] Move the on-core/on-tasks into each dependent repo's node_modueles..."
+for r in ${NODE_OTHER_REPOS[@]}; do
+    pushd ${r}/node_modules/
+    #remove the on-core/on-tasks, and replace by a link to local folder
+    for dep in ${NODE_CORE_REPOS[@]}; do
+       rm ${dep} -rf
+       ln -s ../../${dep}     ${dep}
+    done
+    popd
+done
+
+echo "[Info] npm install pm2...."
+
+sudo npm install -g pm2
+
+echo  "
+apps:
+  - script: index.js
+    name: on-taskgraph
+    cwd: ${WORKDIR}/on-taskgraph
+  - script: index.js
+    name: on-http
+    cwd: ${WORKDIR}/on-http
+  - script: index.js
+    name: on-dhcp
+    cwd: ${WORKDIR}/on-dhcp-proxy
+  - script: index.js
+    name: on-syslog
+    cwd: ${WORKDIR}/on-syslog
+  - script: index.js
+    name: on-tftp
+    cwd: ${WORKDIR}/on-tftp
+" > rackhd-pm2-config.yml
+
+echo "[Info] Starts RackHD with pm2"
+
+echo "[Done!] Please start RackHD with command line -->  sudo pm2 start rackhd-pm2-config.yml "
+
+popd
+
+
+


### PR DESCRIPTION
** Detail Doc **
https://rackhd.atlassian.net/wiki/display/RAC1/Develop+RackHD+with+pre-build+Vagrant

the rackhd-dev box is here: https://atlas.hashicorp.com/rackhd/boxes/rackhd-dev

**Background**

the new vagrant box(>=1.0.0) are pre-installed debian packages, instead of src code in ~/src any more.
there's a user case:  developer use "vagrant box" as the dev env (running RackHD & InfraSIM). and they will copy their code in the box , then start RackHD inside vagrant for their new code.
so it's suggested we could have another vagrant box , to fulfill above user case.

**Implementation**

1. we provide a rackhd-dev vagrant box in ATLAS, which pre-install all necessary packages for RackHD development (Jenkins : http://rackhdci.lss.emc.com/job/BuildRelease/job/Build/job/vagrant-post-test/). but no RackHD source code pre-download there.

2. with this script , 
people follow steps:
  2.1 - download this script
```wget https://raw.githubusercontent.com/RackHD/RackHD/InstallSRC/example/install_src.sh```
  2.2 - create ~/src folder, because the build-in ```rackhd-pm2-config.yml``` in vagrant's home directory points the source code in ```~/src```
```mkdir ~/src```
  2.3 - run the script, to download RackHD src code, and npm install them. and download static files as well.
``` ./install_src.sh  ~/src  ```
    if you want to use branch code, like release/1.0.0 branch. run as below:
``` ./install_src.sh  ~/src   release/1.0.0```
  2.4 start RackHD
```sudo pm2 start  rackhd-pm2-config.yml```
    if you download code in some other directory instead of ```~/src```, don't forget to modify the ``` rackhd-pm2-config.yml``` file

   2.5 RackHD runs , PM2 will dump info like below
```
---------------------------------------------------------------------------------------------
| App name     | id | mode | pid  | status | restart | uptime | cpu  | mem       | watching |
----------------------------------------------------------------------------------------------
| on-dhcp      | 2  | fork | 4584 | online | 0       | 1s     | 66%  | 44.2 MB   | disabled |
| on-http      | 1  | fork | 4572 | online | 0       | 1s     | 67%  | 47.9 MB   | disabled |
| on-syslog    | 3  | fork | 4591 | online | 0       | 1s     | 87%  | 52.4 MB   | disabled |
| on-taskgraph | 0  | fork | 4566 | online | 0       | 1s     | 310% | 48.3 MB   | disabled |
| on-tftp      | 4  | fork | 4617 | online | 0       | 1s     | 31%  | 27.9 MB   | disabled |
--------------------|------|------|--------|------------------|------|----------------------|

```




Jenkins: depends on https://github.com/RackHD/on-http/pull/514 