### PR TITLE
Update deploy/rackhd_source_install.py for new FIT configuration

### DIFF
--- a/test/deploy/rackhd_source_install.py
+++ b/test/deploy/rackhd_source_install.py
@@ -214,7 +214,7 @@ class rackhd_source_install(fit_common.unittest.TestCase):
 
     def test06_startup(self):
         print "**** Start services."
-        self.assertEqual(fit_common.remote_shell("chmod 777 startup.sh;/etc/init.d/isc-dhcp-server restart")['exitcode'], 0, "dhcp startup failure.")
+        self.assertEqual(fit_common.remote_shell("/etc/init.d/isc-dhcp-server restart")['exitcode'], 0, "dhcp startup failure.")
         self.assertEqual(fit_common.remote_shell("cd ~/;pm2 start rackhd-pm2-config.yml > /dev/null 2>&1")['exitcode'], 0, "RackHD startup failure.")
         print "**** Check installation."
         fit_common.time.sleep(10)

--- a/test/deploy/rackhd_source_install.py
+++ b/test/deploy/rackhd_source_install.py
@@ -110,7 +110,7 @@ class rackhd_source_install(fit_common.unittest.TestCase):
         self.assertEqual(fit_common.remote_shell(PROXYVARS +
                                                  "cd ~/rackhd/packer/ansible/;"
                                                  "ansible-playbook -i 'local,' -c local rackhd_local.yml",
-                                                 timeout=2000,
+                                                 timeout=3000,
                                                  )['exitcode'], 0, "RackHD Install failure.")
 
     def test04_install_network_config(self):


### PR DESCRIPTION
Fixed source installer for new FIT configuration system.

NOTES:
 lines 20-21: removed reference to deprecated -ora arguments
line 127 - increased ansible installer timeout for Vagrant deployments which often time out
 line 133: revision to accommodate docker deployments
 lines 89-100: removed explicit repo list, instead harvest repo list from config in line 97
 lines 208-266: using generated 'config.json' from FIT config.

@hohene @jimturnquist @johren @larry-dean
