### PR TITLE
Update deploy/os_ova_install.py multiple VMs routine

### DIFF
--- a/test/deploy/os_ova_install.py
+++ b/test/deploy/os_ova_install.py
@@ -46,9 +46,10 @@ class os_ova_install(fit_common.unittest.TestCase):
         if numvms == 1:
             ovamac = fit_common.fitcfg()['ovamac']
         else:
-            stacknum = '{0:02}'.format(int(fit_common.fitargs()['stack']))
+            # compose appropriate MAC address using lab convention
             vmnum = '{0:02}'.format(int(vm))
-            ovamac = fitcommon.fitcfg()['test-config']['ova']['oui'] + ":00:" + stacknum + ":" + vmnum
+            macsplit = fit_common.fitcfg()['ovamac'].split(":")
+            ovamac = macsplit[0] + ":" + macsplit[1] + ":" + macsplit[2] + ":" + macsplit[3] + ":" + macsplit[4] + ":"  + vmnum
         # Install MAC address by editing OVA .vmx file, then startup VM
         esxi_command = "export fullpath=`find vmfs -name ora-stack-" + fit_common.fitargs()['stack'] + "-" + str(vm) + "*.vmx`;" \
                        "for file in $fullpath;" \

--- a/test/deploy/os_ova_install.py
+++ b/test/deploy/os_ova_install.py
@@ -111,10 +111,6 @@ class os_ova_install(fit_common.unittest.TestCase):
         # check for number of virtual machine
         self.assertTrue(numvms < 100, "Number of vms should not be greater than 99")
 
-        # check stack ID as number to generate MAC address for multiple OVA
-        if numvms > 1:
-            self.assertTrue(fit_common.fitargs()['stack'].isdigit(), "Stack ID must be a number if numvms is greater than 1")
-
         # Shutdown previous ORA
         if fit_common.subprocess.call('ping -c 1 ' + fit_common.fitargs()['ora'], shell=True) == 0:
             fit_common.remote_shell('shutdown -h now')


### PR DESCRIPTION
Fixed OVA installer for new FIT configuration system.
Multiple VM deployments now seed off of the 'ovamac' key in the stack config.

@hohene @jimturnquist @johren @larry-dean