### PR TITLE
Updated Vagrantfile to conform to new FIT system

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -26,12 +26,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         target.vm.network "forwarded_port", guest: 9090, host: 9090
         target.vm.network "forwarded_port", guest: 443, host: 443
         target.vm.provision "shell", inline: <<-SHELL
-            git clone https://github.com/RackHD/RackHD 
+            git clone https://github.com/RackHD/RackHD fit_tests
             sudo apt-get -y update
             sudo apt-get -y install python-pip
             sudo apt-get -y install virtualenv
             sudo apt-get -y install libghc-hsopenssl-dev
-            cd RackHD/test
+            cd fit_tests/test
             ./mkenv.sh vagrant
             source myenv_vagrant
             python run_tests.py -test deploy/rackhd_source_install.py -v 9 -stack vagrant;echo

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -26,15 +26,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         target.vm.network "forwarded_port", guest: 9090, host: 9090
         target.vm.network "forwarded_port", guest: 443, host: 443
         target.vm.provision "shell", inline: <<-SHELL
-            git clone https://github.com/RackHD/RackHD fit_tests
+            git clone https://github.com/RackHD/RackHD 
             sudo apt-get -y update
             sudo apt-get -y install python-pip
             sudo apt-get -y install virtualenv
-            cd fit_tests/test
+            sudo apt-get -y install libghc-hsopenssl-dev
+            cd RackHD/test
             ./mkenv.sh vagrant
             source myenv_vagrant
-            python run_tests.py -test deploy/rackhd_source_install.py -v 9
-            python run_tests.py -test deploy/rackhd_stack_init.py:rackhd_stack_init.test01_preload_sku_packs -stack vagrant -v 9
+            python run_tests.py -test deploy/rackhd_source_install.py -v 9 -stack vagrant;echo
+            python run_tests.py -test util/load_sku_packs.py -v 9 -stack vagrant;echo
         SHELL
     end
 
@@ -66,8 +67,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         target.ssh.password = "vagrant"
         target.vm.network "private_network", ip: "172.31.128.1", virtualbox__intnet: "closednet"
         target.ssh.forward_agent = true
+        target.vm.network "forwarded_port", guest: 8080, host: 8080
+        target.vm.network "forwarded_port", guest: 9080, host: 9080
+        target.vm.network "forwarded_port", guest: 9090, host: 9090
+        target.vm.network "forwarded_port", guest: 443, host: 443
         target.vm.provision "shell", inline: <<-SHELL
-            git clone https://github.com/RackHD/RackHD fit_tests
+            git clone https://github.com/RackHD/RackHD
         SHELL
     end
 


### PR DESCRIPTION
Recent changes to FIT broke the Vagrant installer.

These changes fix Vagrantfile script.

NOTES:
lines 37-38: the echo at the end of the line makes sure that each line returns a zero exitcode. Vagrant stops when a non-zero exit code is detected.
line 33: added package required for Python modules

@hohene @jimturnquist @johren @larry-dean

