### PR TITLE
Remove SNMP settings from node

### DIFF
--- a/test/tests/api/v2_0/nodes_tests.py
+++ b/test/tests/api/v2_0/nodes_tests.py
@@ -35,31 +35,19 @@ class NodesTests(object):
                 'identifiers': ["FF:FF:FF:01"],
                 'autoDiscover': 'false',
                 'name': 'test_switch_node',
-                'type': 'switch',
-                'snmpSettings': {
-                    'host': '1.1.1.1',
-                    'community': 'rackhd'
-                }
+                'type': 'switch'
             },
             {
                 'identifiers': ["FF:FF:FF:02"],
                 'autoDiscover': 'false',
                 'name': 'test_mgmt_node',
-                'type': 'mgmt',
-                'snmpSettings': {
-                    'host': '1.1.1.1',
-                    'community': 'rackhd'
-                }
+                'type': 'mgmt'
             },
             {
                 'identifiers': ["FF:FF:FF:03"],
                 'autoDiscover': 'false',
                 'name': 'test_pdu_node',
-                'type': 'pdu',
-                'snmpSettings': {
-                    'host': '1.1.1.2',
-                    'community': 'rackhd'
-                }
+                'type': 'pdu'
             },
             {
                 'identifiers': ["FF:FF:FF:04"],

--- a/test/tests/rackhd20/test_rackhd20_api_nodes.py
+++ b/test/tests/rackhd20/test_rackhd20_api_nodes.py
@@ -132,7 +132,7 @@ class rackhd20_api_nodes(fit_common.unittest.TestCase):
     def test_api_20_nodes_ID_ssh(self):
         # iterate through nodes
         for nodeid in NODECATALOG:
-            payload = {"host": nodeid, "user": "user", "password": "1234567"}
+            payload = {"service": "ssh-ibm-service", "config": {"host": "1.1.1.1", "user": "user", "password": "1234567"}}
             api_data = fit_common.rackhdapi("/api/2.0/nodes/" + nodeid + "/ssh", action="post", payload=payload)
             self.assertEqual(api_data['status'], 201, 'Incorrect HTTP return code, expected 201, got:' + str(api_data['status']))
             api_data = fit_common.rackhdapi("/api/2.0/nodes/" + nodeid + "/ssh")


### PR DESCRIPTION
In support of:
RackHD/on-tasks#394
RackHD/on-core#252
RackHD/on-http#570
