### PR TITLE
rac-4044 upstream updates appear to have broken FIT's run_tests.py

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -14,6 +14,8 @@ on_http_redfish_1_0>=1.0.0
 pexpect==3.3
 proboscis==1.2.6.0
 requests==2.9.0
+# there are problems with the 34.0.x setuptools and nosedeps. Pin for now.
+setuptools==33.1.1
 # urllib3 1.20 breaks CIT test, specify version as a temp solution
 urllib3==1.19.1
 


### PR DESCRIPTION

The following showed during recent (like 1/23/17ish) new checkouts of FIT where the mkenv was run on a ubuntu 16 box:

    *** Using config file: dellemc-test/config-mn/generated/fit-config-20170124-151936
    /emc/ohrenj/work/RackHD/test/.venv/fit/local/lib/python2.7/site-packages/nose/plugins/manager.py:395: RuntimeWarning: Unable to load plugin nosedep = nosedep:NoseDep: No module named extern.six RuntimeWarning)
    Usage: nosetests options

Problem tracked to version 34.0.x of setuptools. Other folk are hitting similar issues. Until this stabalizes, pin the setuptools version to 33.1.1 (last version before 34.0.0 came out). @larry-dean: we may want to let zithrax know, since he will probably have others hitting this!

Testing:
* before/after : python run_tests.py -stack vagrant -list worked on mac and u14
* before, same failed on u16
* after, same worked on u16

@RackHD/corecommitters @johren  @hohene  @gpaulos @larry-dean @jimturnquist @keedya @panpan0000 @changev @anhou