### PR TITLE
Update deploy/rackhd_stack_init.py

### DIFF
--- a/test/deploy/rackhd_stack_init.py
+++ b/test/deploy/rackhd_stack_init.py
@@ -42,7 +42,7 @@ class rackhd_stack_init(unittest.TestCase):
         rc = fit_common.remote_shell("curl -ks -X POST -H 'Content-Type:application/json' https://localhost:" \
                                      + str(fit_common.fitports()['https']) + "/api/2.0/users -d @auth.json")
         if rc['exitcode'] != 0:
-            print "ALERT: Auth admin user not set! Please manually set the admin user account if https access is desired."
+            print "ALERT: Auth admin user not set! Please manually set the admin user account if authenticated access is desired."
 
     def test02_preload_sku_packs(self):
         print "**** Processing SKU Packs"


### PR DESCRIPTION
Several updates to deploy/rackhd_stack_init.py:

lines 34-47: resequenced 'set_auth_user' to run first. This will support the secure deployment case where http is not enabled. If 'set_auth_user' is not run first, sku packs would fail in this case.

line 107: passes assert if a 409 return code is received where the default sku is already set. This allows user to run stack init multiple times without error.

lines 229-259: fixed code in the management server setup. Still have this skipped because enabling results in a test failure in test_redfish10_api_chassis.py:redfish10_api_chassis.test_02_redfish_v1_chassis_id_links. Investigating whether failure is a test bug or product bug.

@hohene @jimturnquist @johren @larry-dean