### PR TITLE
RAC-4005  Pylint cleanup in RackHD/test

### DIFF
--- a/test/common/api_utils.py
+++ b/test/common/api_utils.py
@@ -170,7 +170,7 @@ def api_validate_node_pollers(client, node_id_list, all_pollers=False):
         node_poller_rsp = client.last_response
         node_poller_list = loads(node_poller_rsp.data)
         if node_poller_rsp.status != 200:
-            print '**** Unable to retrieve node: {} pollers via API. status ({})\n'.format(node.get('id'),
+            print '**** Unable to retrieve node: {} pollers via API. status ({})\n'.format(node_ld,
                                                                                            node_poller_rsp.status)
             # unable to get poller for this node, so return a False
             return False
@@ -222,7 +222,7 @@ def api_validate_node_pollers(client, node_id_list, all_pollers=False):
                 break
 
     return good_pollers
-    
+
 def validate_obm_settings(client, identifier):
     """
     The OBM objectis are obtained for the requested node. They are then searched to 
@@ -253,7 +253,7 @@ def validate_obm_settings(client, identifier):
         if get_by_string(obm_entry, 'config.properties.community'):
             return True
     return False
-    
+
 def get_by_string(source_dict, search_string, default_if_not_found=None):
     '''
     Search a dictionary using keys provided by the search string.
@@ -275,4 +275,4 @@ def get_by_string(source_dict, search_string, default_if_not_found=None):
         except StopIteration:
             return default_if_not_found
     return dict_obj
-        
+

--- a/test/common/fit_common.py
+++ b/test/common/fit_common.py
@@ -607,7 +607,7 @@ def restful(url_command, rest_action='get', rest_payload=[], rest_timeout=None, 
                                          verify=sslverify
                                          )
     except requests.exceptions.Timeout:
-        return {'json':'', 'text':'',
+        return {'json':{}, 'text':'',
                 'status':0,
                 'headers':'',
                 'timeout':True}

--- a/test/common/test_api_utils.py
+++ b/test/common/test_api_utils.py
@@ -362,14 +362,14 @@ def run_ipmi_command_to_node(node_id, str_ipmi_cmd):
     :return: running result on success.
              Different return codes otherwise.
     '''
-
+    str_ip = get_compute_bmc_ip(node_id)
     if (str_ip == 2 or str_ip == 1) or str_ip == '0.0.0.0' :
         if fit_common.VERBOSITY >= 2:
             print "Unable to find the bmc ip at given node id"
         return 1
 
     dict_cred = get_compute_node_username(node_id)
-    if (dict_cred == 2 or dict_cred == 1) or dict_cred == 3:
+    if dict_cred == 1 or dict_cred == 2 or dict_cred == 3:
         if fit_common.VERBOSITY >= 2:
             print "No username or password found at given node id"
         return 1
@@ -404,7 +404,7 @@ def get_supported_pollers(node_id):
 
     if mondata['status'] not in [200,201,202,204]:
         if fit_common.VERBOSITY >= 2:
-            print "Status: {},  Failed to get data for poller id: {}".format(mondata['status'], str(poller_id))
+            print "Status: {},  Failed to get poller data for node: {}".format(mondata['status'], node_id)
     else:
         pollers = mondata['json']
         poller_dict = dict()

--- a/test/mkcheck.sh
+++ b/test/mkcheck.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Run code checks (pylint for example)
+#
+# Command forms:
+#   mkcheck.sh
+#       Runs checker and writes to stdout
+#
+#   mkcheck.sh <pkg_version> <pkg_format>
+#       Runs checker and writes to file named
+#           onserve_<pkg_version>_pylint.<pkg_format>
+#
+#       <pkg_format> can be 'html', 'text'.  See pylint
+#           for more.
+#
+
+if [ $# -eq 0 ]; then
+    format="text"
+    pylint_output_file="/dev/stdout"
+    copyright_output_file="/dev/stdout"
+elif [ $# -eq 1 ]; then
+    format="text"
+    pylint_output_file="/dev/stdout"
+    copyright_output_file="/dev/stdout"
+elif [ $# -eq 2 ]; then
+    PKG_VERSION=$1
+    format=$2
+    pylint_output_file="onserve_${PKG_VERSION}_pylint.${format}"
+    copyright_output_file="onserve_${PKG_VERSION}_copyright.${format}"
+else
+    echo "bad command form"
+    echo "mkcheck.sh [<pkg_version> <pkg_format>]"
+    exit 1
+fi
+
+final_status=0
+
+scandirs=`find * -prune -type d`
+
+errors_only="-E"
+
+pylint ${errors_only} --rcfile=pylintrc --output-format=${format} ${scandirs} > ${pylint_output_file}
+status=$?
+
+if [ ${status} -ne 0 ]; then
+    echo "Pylint errors:"
+    if [ "${pylint_output_file}" != "/dev/stdout" ]; then
+        cat ${pylint_output_file}
+    fi
+    echo ""
+    echo "Python checker failed.  Clean up code and retry"
+    final_status=$status
+else
+    echo "Python checker succeeded"
+fi
+
+# No copyright checking yet
+#./checkCopyright.sh > ${copyright_output_file}
+#status=$?
+#if [ ${status} -ne 0 ]; then
+#    if [ "${copyright_output_file}" != "/dev/stdout" ]; then
+#        cat ${copyright_output_file}
+#    fi
+#    echo "Copyright checker failed.  Add copyrights and retry"
+#    final_status=$status
+#else
+#    echo "Copyright checker succeeded"
+#fi
+
+exit ${final_status}

--- a/test/modules/amqp.py
+++ b/test/modules/amqp.py
@@ -54,7 +54,7 @@ class AMQPWorker(ConsumerMixin):
             self.__max_error -= 1
         else:
             LOG.error('max connection errors exceeded.')
-            stop()
+            self.stop()
 
     def start(self):
         LOG.info('Starting AMQP worker {0}'.format(self.__queue))

--- a/test/tests/api/v1_1/workflows_tests.py
+++ b/test/tests/api/v1_1/workflows_tests.py
@@ -164,7 +164,7 @@ class WorkflowsTests(object):
                 status = self.__client.last_response.status
                 LOG.warning('Workflow status for Node {0} (status={1},retries={2})' \
                     .format(node, status, retries))
-                sleep(1)
+                time.sleep(1)
                 retries -= 1
                 Nodes().nodes_identifier_workflows_active_get(node)
             assert_equal(HTTP_NO_CONTENT, status, \


### PR DESCRIPTION
- added mkcheck.sh script to perform pylint checking (and
  anything else we may eventually want to check).  This
  can be used by Jenkins as a code quality gate.
- Only actual errors are checked for ("pylint -E").  Cleaning
  up warnings is for another day.
- Updated a handful of errors that existed presently in RackHD/test