### PR TITLE
Fix proxy settings in config/install_default.json

### DIFF
--- a/test/config/install_default.json
+++ b/test/config/install_default.json
@@ -24,8 +24,8 @@
         "https://github.com/RackHD/on-skupack"
         ],
       "proxy": {
-        "host": "web.hwimo.lab.emc.com",
-        "port": "3128"
+        "host": "",
+        "port": ""
       }
   }
 }


### PR DESCRIPTION
MN proxy settings inadvertently got included into the default public FIT config. This is causing the deployment scripts to fail outside of MN lab. Please review and merge quickly.

@johren @jimturnquist @hohene 