### PR TITLE
Commit RAC-3711-change-ora-references

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -60,33 +60,32 @@ All FIT tests can be run from the wrapper 'run_tests.py':
     Command Help
 
     optional arguments:
-      -h, --help          show this help message and exit
-      -test TEST          test to execute, default: tests/
-      -config CONFIG      config file location, default: config
-      -group GROUP        test group to execute: 'smoke', 'regression',
-                          'extended', default: 'all'
-      -stack STACK        stack label (test bed), overrides -ora
-      -ora ORA            OnRack/RackHD appliance IP address or hostname, default:
-                          localhost
-      -version VERSION    OnRack package install version, example:onrack-
-                          release-0.3.0, default: onrack-devel
-      -template TEMPLATE  path or URL link to OVA template or OnRack OVA
-      -xunit              generates xUnit XML report files
-      -numvms NUMVMS      number of virtual machines for deployment on specified
-                          stack
-      -list               generates test list only
-      -sku SKU            node SKU name, example: Quanta-T41, default=all
-      -obmmac OBMMAC      node OBM MAC address, example:00:1e:67:b1:d5:64
-      -nodeid NODEID      node identifier string of a discovered node, example:
-                          56ddcf9a8eff16614e79ec74
-      -http               forces the tests to utilize the http API protocol
-      -https              forces the tests to utilize the https API protocol
-      -port PORT          API port number override, default from
-                          install_config.json
-      -v V                Verbosity level of console output, default=1, Built Ins:
-                          0: No debug, 2: User script output, 4: rest calls and
-                          status info, 6: other common calls (ipmi, ssh), 9: all
-                          the rest
+  -h, --help            show this help message and exit
+  -test TEST            test to execute, default: tests/
+  -config CONFIG        config file location, default: config
+  -group GROUP          test group to execute: 'smoke', 'regression',
+                        'extended', default: 'all'
+  -stack STACK          stack label (test bed), overrides -rackhd_host
+  -rackhd_host RACKHD_HOST
+                        RackHD appliance IP address or hostname, default:
+                        localhost
+  -template TEMPLATE    path or URL link to OVA template or RackHD OVA
+  -xunit                generates xUnit XML report files
+  -numvms NUMVMS        number of virtual machines for deployment on specified
+                        stack
+  -list                 generates test list only
+  -sku SKU              node SKU name, example: Quanta-T41, default=all
+  -obmmac OBMMAC        node OBM MAC address, example:00:1e:67:b1:d5:64
+  -nodeid NODEID        node identifier string of a discovered node, example:
+                        56ddcf9a8eff16614e79ec74
+  -http                 forces the tests to utilize the http API protocol
+  -https                forces the tests to utilize the https API protocol
+  -port PORT            API port number override, default from
+                        install_config.json
+  -v V                  Verbosity level of console output, default=1, Built
+                        Ins: 0: No debug, 2: User script output, 4: rest calls
+                        and status info, 6: other common calls (ipmi, ssh), 9:
+                        all the rest
 
 When run_tests.py executes, a generated configuration will be created in the
 config/generated directory.  The name will appear in the run_test.py output.

--- a/test/README.md
+++ b/test/README.md
@@ -61,29 +61,29 @@ All FIT tests can be run from the wrapper 'run_tests.py':
         Command Help
 
         optional arguments:
-         -h, --help            show this help message and exit
-          -test TEST            test to execute, default: tests/
-          -config CONFIG        config file location, default: config
-          -group GROUP          test group to execute: 'smoke', 'regression',
-                                'extended', default: 'all'
-          -stack STACK          stack label (test bed), overrides -rackhd_host
-          -rackhd_host RACKHD_HOST
-                                RackHD appliance IP address or hostname, default:
-                                localhost
-          -template TEMPLATE    path or URL link to OVA template or RackHD OVA
-          -xunit                generates xUnit XML report files
-          -numvms NUMVMS        number of virtual machines for deployment on specified
-                                stack
-          -list                 generates test list only
-          -sku SKU              node SKU name, example: Quanta-T41, default=all
-          -obmmac OBMMAC        node OBM MAC address, example:00:1e:67:b1:d5:64
-          -nodeid NODEID        node identifier string of a discovered node, example:
-                                56ddcf9a8eff16614e79ec74
-          -http                 forces the tests to utilize the http API protocol
-          -https                forces the tests to utilize the https API protocol
-          -port PORT            API port number override, default from
-                                install_config.json
-
+          -h, --help          show this help message and exit
+          -test TEST          test to execute, default: tests/
+          -config CONFIG      config file location, default: config
+          -group GROUP        test group to execute: 'smoke', 'regression',
+                              'extended', default: 'all'
+          -stack STACK        stack label (test bed), overrides -ora
+          -ora ORA            OnRack/RackHD appliance IP address or hostname, default:
+                              localhost
+          -version VERSION    OnRack package install version, example:onrack-
+                              release-0.3.0, default: onrack-devel
+          -template TEMPLATE  path or URL link to OVA template or OnRack OVA
+          -xunit              generates xUnit XML report files
+          -numvms NUMVMS      number of virtual machines for deployment on specified
+                              stack
+          -list               generates test list only
+          -sku SKU            node SKU name, example: Quanta-T41, default=all
+          -obmmac OBMMAC      node OBM MAC address, example:00:1e:67:b1:d5:64
+          -nodeid NODEID      node identifier string of a discovered node, example:
+                              56ddcf9a8eff16614e79ec74
+          -http               forces the tests to utilize the http API protocol
+          -https              forces the tests to utilize the https API protocol
+          -port PORT          API port number override, default from
+                              install_config.json
           -v V                Verbosity level of console and log output (see -nose-
                               help for more options), Built Ins: 0: Minimal logging,
                               1: Display ERROR and CRITICAL to console and to files,

--- a/test/README.md
+++ b/test/README.md
@@ -39,9 +39,9 @@ The FIT test framework is under RackHD/test
 ## Configuration
 
 Default configuration file values can be found in the following files:
-    'config/rackhd_default.json'
-    'config/credentials_default.json'
-    'config/install_default.json'
+* 'config/rackhd_default.json'
+* 'config/credentials_default.json'
+* 'config/install_default.json'
 
 Stack definitions are set from the 'config/stack_config.json' file.
 An alternate configuration directory can be selected using the -config argument.
@@ -51,65 +51,64 @@ More details in config/README.md.
 
 All FIT tests can be run from the wrapper 'run_tests.py':
 
-    usage: run_tests.py [-h] [-test TEST] [-config CONFIG] [-group GROUP]
-                        [-stack STACK] [-ora ORA] [-version VERSION]
-                        [-template TEMPLATE] [-xunit] [-numvms NUMVMS] [-list]
-                        [-sku SKU] [-obmmac OBMMAC | -nodeid NODEID]
-                        [-http | -https] [-port PORT] [-v V]
+### --help output
+        usage: run_tests.py [-h] [-test TEST] [-config CONFIG] [-group GROUP]
+                            [-stack STACK] [-ora ORA] [-version VERSION]
+                            [-template TEMPLATE] [-xunit] [-numvms NUMVMS] [-list]
+                            [-sku SKU] [-obmmac OBMMAC | -nodeid NODEID]
+                            [-http | -https] [-port PORT] [-v V] [-nose-help]
 
-    Command Help
+        Command Help
 
-    optional arguments:
-  -h, --help            show this help message and exit
-  -test TEST            test to execute, default: tests/
-  -config CONFIG        config file location, default: config
-  -group GROUP          test group to execute: 'smoke', 'regression',
-                        'extended', default: 'all'
-  -stack STACK          stack label (test bed), overrides -rackhd_host
-  -rackhd_host RACKHD_HOST
-                        RackHD appliance IP address or hostname, default:
-                        localhost
-  -template TEMPLATE    path or URL link to OVA template or RackHD OVA
-  -xunit                generates xUnit XML report files
-  -numvms NUMVMS        number of virtual machines for deployment on specified
-                        stack
-  -list                 generates test list only
-  -sku SKU              node SKU name, example: Quanta-T41, default=all
-  -obmmac OBMMAC        node OBM MAC address, example:00:1e:67:b1:d5:64
-  -nodeid NODEID        node identifier string of a discovered node, example:
-                        56ddcf9a8eff16614e79ec74
-  -http                 forces the tests to utilize the http API protocol
-  -https                forces the tests to utilize the https API protocol
-  -port PORT            API port number override, default from
-                        install_config.json
-  -v V                  Verbosity level of console output, default=1, Built
-                        Ins: 0: No debug, 2: User script output, 4: rest calls
-                        and status info, 6: other common calls (ipmi, ssh), 9:
-                        all the rest
+        optional arguments:
+         -h, --help            show this help message and exit
+          -test TEST            test to execute, default: tests/
+          -config CONFIG        config file location, default: config
+          -group GROUP          test group to execute: 'smoke', 'regression',
+                                'extended', default: 'all'
+          -stack STACK          stack label (test bed), overrides -rackhd_host
+          -rackhd_host RACKHD_HOST
+                                RackHD appliance IP address or hostname, default:
+                                localhost
+          -template TEMPLATE    path or URL link to OVA template or RackHD OVA
+          -xunit                generates xUnit XML report files
+          -numvms NUMVMS        number of virtual machines for deployment on specified
+                                stack
+          -list                 generates test list only
+          -sku SKU              node SKU name, example: Quanta-T41, default=all
+          -obmmac OBMMAC        node OBM MAC address, example:00:1e:67:b1:d5:64
+          -nodeid NODEID        node identifier string of a discovered node, example:
+                                56ddcf9a8eff16614e79ec74
+          -http                 forces the tests to utilize the http API protocol
+          -https                forces the tests to utilize the https API protocol
+          -port PORT            API port number override, default from
+                                install_config.json
 
-When run_tests.py executes, a generated configuration will be created in the
-config/generated directory.  The name will appear in the run_test.py output.
+          -v V                Verbosity level of console and log output (see -nose-
+                              help for more options), Built Ins: 0: Minimal logging,
+                              1: Display ERROR and CRITICAL to console and to files,
+                              3: Display INFO to console and to files, 4: (default)
+                              Display INFO to console, and DEBUG to files, 5: Display
+                              infra.run and test.run DEBUG to both, 6: Add display of
+                              test.data (rest calls and status) DEBUG to both, 7: Add
+                              display of infra.data (ipmi, ssh) DEBUG to both, 9:
+                              Display infra.* and test.* at DEBUG_9 (max output)
+          -nose-help          display help from underlying nosetests command,
+                              including additional log options
 
-A previously generated configuration can be used again for a run_tests.py
-invocation by setting the environment variable FIT_CONFIG.
 
-This example will run the RackHD installer onto stack 1 via the wrapper script:
+### Example that will run the RackHD installer onto stack 1 via the wrapper script:
 
     python run_tests.py -stack 1 -test deploy/run_rackhd_installer.py
-    *** Created config file: config/generated/fit-config-20170118-160319
-    *** Using config file: config/generated/fit-config-20170118-160319
 
-The -stack or -ora argument can be omitted when running on the server or appliance. The test defaults to localhost:8080 for API calls.
-
-To run this exact test configuration again, the following could be done:
-    export FIT_CONFIG=config/generated/fit-config-20170118-160319
-    python run_tests.py
-
-This example will run the smoke test from the appliance node or the default Vagrant test bed:
+### Example will run the smoke test from the appliance node or the default Vagrant test bed:
 
     python run_tests.py -test tests -group smoke
 
+The -stack or -ora argument can be omitted when running on the server or appliance. The test defaults to localhost:8080 for API calls.
 
+
+### Example using nosetests
 Alternatively tests can be run directly from nose. Runtime parameters such as ORA address must be set in the environment.
 
 The following example will run all the entire test harness from a third party machine to ORA at 192.168.1.1:
@@ -118,7 +117,7 @@ The following example will run all the entire test harness from a third party ma
     nosetests -s tests
 
 
-## Running individual tests
+### Running individual tests
 
 Individual test scripts or tests may be executed using the following 'Nose' addressing scheme:
 
@@ -129,6 +128,24 @@ For example, to run the test 'test_rackhd11_api_catalogs' in script 'tests/rackh
 
     python run_tests.py -stack 11 -test tests/rackhd11/test_rackhd11_api_catalogs.py:rackhd11_api_catalogs.test_api_11_catalogs
 
+### Example of rerunning a test based on a previous run's configuration:
+
+When run_tests.py executes, a generated configuration will be created in the
+config/generated directory.  The name will appear in the run_test.py output.
+
+A previously generated configuration can be used again for a run_tests.py
+invocation by setting the environment variable FIT_CONFIG.
+
+This shows the config being generated:
+
+     python run_tests.py -stack 1 -test deploy/run_rackhd_installer.py
+     *** Created config file: config/generated/fit-config-20170118-160319
+     *** Using config file: config/generated/fit-config-20170118-160319
+
+This shows re-using the generated config:
+
+     export FIT_CONFIG=config/generated/fit-config-20170118-160319
+     python run_tests.py
 
 ## Running FIT tests on Vagrant RackHD
 
@@ -166,6 +183,12 @@ Use the following commands to initialize the server and run a Smoke Test:
 Note that any previously installed RackHD Vagrant boxes will prevent a new instance from running.
 Please remove any old RackHD VMs prior to executing this routine.
 
+## Hints and background for logging/debuging tests
+
+Please read 'stream_monitor/flogging/README.md' for information on the logging system.
+That file also contains a set of common "if you want this to happen, type this" at the top of the file and how
+the existing '-v' shortcut option maps to the loggers.
+
 ## Test conventions
 
 - Tests should be written using Python 'unittest' classes and methods.
@@ -188,7 +211,7 @@ The setUp and tearDown methods are useful ways to setup and clean out test-speci
     virtualenv .venv
     source .venv/bin/activate
     sudo pip install -r requirements.txt
-    
+
 ## Running the tests
 
 Run Vagrant environment
@@ -223,13 +246,13 @@ Run regression tests
 
     python run.py --config=/home/user/config.ini
 
-    
+
 ## HTTP proxy configuration:
 
 For OS installer related tests, optional HTTP proxies for accessing remote OS image repositories can be defined, see the [RackHD Configuration howto](http://rackhd.readthedocs.io/en/latest/rackhd/configuration.html?highlight=httpProxies#rackhd-configuration)
 
 ## Specifying test groups
-    
+
     To display the entire test plan and available test groups run:
 
     python run.py --show-plan
@@ -245,7 +268,7 @@ For OS installer related tests, optional HTTP proxies for accessing remote OS im
     Run only Redfish 1.0 compliant API related tests:
     python run.py --group=api-redfish-1.0
 
-## To reset the default target BMC user/password 
+## To reset the default target BMC user/password
 
     NOTE: only prompts for user/password when .passwd file is missing
 
@@ -254,45 +277,78 @@ For OS installer related tests, optional HTTP proxies for accessing remote OS im
     python run.py
     <enter BMC username and password>
 
+
+
 ## Running footprint benchmark test
 
+
+
 Footprint benchmark collects system data when running poller, node discovery and bootstrap.
+
 Details can be found in WIKI page:
+
 [proposal-footprint-benchmarks](https://github.com/RackHD/RackHD/wiki/proposal-footprint-benchmarks)
+
 The benchmark data collection process can also start/stop independently without binding to any test case,
 thus users can get the footprint info about any operations they carry out during this period of time.
 
 ###Precondition
 
+
+
 The machine running RackHD can use apt-get to install packages, which means it must have accessible sources.list
 
 In RackHD, compute nodes have been discovered, and pollers are running
 
+
+
 No external AMQP queue with the name "graph.finished" is listening RackHD
 
+
+
 Make sure the AMQP port in RackHD machine can be accessed by the test machine.
+
 If you are not using Vagrant, you can tunnel the port by the following command in RackHD
+
+
 
     sudo socat -d -d TCP4-LISTEN:55672,reuseaddr,fork TCP4:localhost:5672
 
+
+
 ###Settings
 
+
+
 Aside from Optional settings in the section above,
+
 following parameters are also required at the first time user issuing the test,
+
 and stored in .passwd
+
+
 
     localhost username and password: username and password that can run "apt-get install"
     in the machine running the test
 
+
 ###Running the tests
+
+
 
 Run poller|discovery|bootstrap tests
 
+
     python benchmark.py --group=poller|discovery|bootstrap
+
 
 Run all benchmark tests
 
+
+
     python benchmark.py
+
+
 
 Start|Stop benchmark data collection
 
@@ -304,14 +360,26 @@ Get the directory of the latest log data
 
 ###Getting result
 
+
+
 Footprint report is in ~/benchmark/(timestamp)/(case)/report.
+
+
 
 Report in html format can display its full function by
 
+
+
     chrome.exe --user-data-dir="C:/Chrome dev session" --allow-file-access-from-files
+
+
 
 to open the browser and drag the summary.html to it.
 
+
+
 Data summary and graph is shown by process and footprint matrix.
+
+
 
 Data in different time and cases can be selected to compare with the current one.

--- a/test/common/fit_common.py
+++ b/test/common/fit_common.py
@@ -186,10 +186,10 @@ def apply_stack_config():
     stack = fitargs()['stack']
     if stack is not None:
         mkcfg().add_from_file('stack_config.json', stack)
-        if 'ora' in fitcfg():
-            fitargs()['ora'] = fitcfg()['ora']
+        if 'rackhd_host' in fitcfg():
+            fitargs()['rackhd_host'] = fitcfg()['rackhd_host']
         else:
-            fitargs()['ora'] = 'localhost'
+            fitargs()['rackhd_host'] = 'localhost'
         if 'bmc' in fitcfg():
             fitargs()['bmc'] = fitcfg()['bmc']
         if 'hyper' in fitcfg():
@@ -220,7 +220,7 @@ def add_globals():
         if API_PORT == "None":
             API_PORT = fitports()['https']
 
-    if fitargs()["ora"] == "localhost":
+    if fitargs()['rackhd_host'] == "localhost":
         if API_PROTOCOL == "None":
             API_PROTOCOL = 'http'
         if API_PORT == "None":
@@ -275,13 +275,13 @@ def mkargs(in_args=None):
     arg_parser.add_argument("-group", default="all",
                             help="test group to execute: 'smoke', 'regression', 'extended', default: 'all'")
     arg_parser.add_argument("-stack", default="vagrant",
-                            help="stack label (test bed), overrides -ora")
-    arg_parser.add_argument("-ora", default="localhost",
-                            help="OnRack/RackHD appliance IP address or hostname, default: localhost")
-    arg_parser.add_argument("-version", default="onrack-devel",
-                            help="OnRack package install version, example:onrack-release-0.3.0, default: onrack-devel")
+                            help="stack label (test bed), overrides -rackhd_host")
+    arg_parser.add_argument("-rackhd_host", default="localhost",
+                            help="RackHD appliance IP address or hostname, default: localhost")
+    arg_parser.add_argument("-version", default="None",
+                            help="RackHD install version, not yet implemented")
     arg_parser.add_argument("-template", default="None",
-                            help="path or URL link to OVA template or OnRack OVA")
+                            help="path or URL link to OVA template or RackHD OVA")
     arg_parser.add_argument("-xunit", default="False", action="store_true",
                             help="generates xUnit XML report files")
     arg_parser.add_argument("-numvms", default=1, type=int,
@@ -332,7 +332,7 @@ def countdown(sleep_time, sleep_interval=1):
 def remote_shell(shell_cmd, expect_receive="", expect_send="", timeout=300,
                  address=None, user=None, password=None):
     '''
-    Run ssh based shell command on a remote machine at fitargs()["ora"]
+    Run ssh based shell command on a remote machine at fitargs()['rackhd_host']
 
     :param shell_cmd: string based command
     :param expect_receive:
@@ -341,14 +341,14 @@ def remote_shell(shell_cmd, expect_receive="", expect_send="", timeout=300,
     :param address: IP or hostname of remote host
     :param user: username of remote host
     :param password: password of remote host
-    :return: dict = {'stdout': str:ouput, 'exitcode': return code}
+    :return: dict = {'stdout': str:output, 'exitcode': return code}
     '''
     if not address:
-        address = fitargs()['ora']
+        address = fitargs()['rackhd_host']
     if not user:
-        user = fitcreds()['ora'][0]['username']
+        user = fitcreds()['rackhd_host'][0]['username']
     if not password:
-        password = fitcreds()['ora'][0]['password']
+        password = fitcreds()['rackhd_host'][0]['password']
 
     logfile_redirect = None
     if VERBOSITY >= 4:
@@ -360,7 +360,7 @@ def remote_shell(shell_cmd, expect_receive="", expect_send="", timeout=300,
         logfile_redirect = sys.stdout
 
     # if localhost just run the command local
-    if fitargs()['ora'] == 'localhost':
+    if fitargs()['rackhd_host'] == 'localhost':
         (command_output, exitstatus) = \
             pexpect.run("sudo bash -c \"" + shell_cmd + "\"",
                         withexitstatus=1,
@@ -393,11 +393,13 @@ def remote_shell(shell_cmd, expect_receive="", expect_send="", timeout=300,
 
     return {'stdout':command_output, 'exitcode':exitstatus}
 
-
 def scp_file_to_ora(src_file_name):
+    # backward compatibility for deprecated method name
+    return scp_file_to_host(src_file_name)
+
+def scp_file_to_host(src_file_name):
     '''
-    scp the given file over to the ORA and place it in onrack's
-    home directory.
+    scp the given file over to the rackhd_host and place it in home directory.
 
     :param src_file_name: name of file to copy over. May include path
     :type src_file_name: basestring
@@ -407,24 +409,24 @@ def scp_file_to_ora(src_file_name):
     logfile_redirect = file('/dev/null', 'w')
     just_fname = os.path.basename(src_file_name)
     # if localhost just copy to home dir
-    if fitargs()['ora'] == 'localhost':
+    if fitargs()['rackhd_host'] == 'localhost':
         remote_shell('cp ' + src_file_name + ' ~/' + src_file_name)
         return src_file_name
 
-    scp_target = fitcreds()['ora'][0]['username'] + '@{0}:'.format(fitargs()["ora"])
+    scp_target = fitcreds()['rackhd_host'][0]['username'] + '@{0}:'.format(fitargs()['rackhd_host'])
     cmd = 'scp -o StrictHostKeyChecking=no {0} {1}'.format(src_file_name, scp_target)
     if VERBOSITY >= 4:
-        print "scp_file_to_ora: '{0}'".format(cmd)
+        print "scp_file_to_host: '{0}'".format(cmd)
 
     if VERBOSITY >= 9:
         logfile_redirect = sys.stdout
 
     (command_output, ecode) = pexpect.run(
         cmd, withexitstatus=1,
-        events={'(?i)assword: ':fitcreds()['ora'][0]['password'] + '\n'},
+        events={'(?i)assword: ':fitcreds()['rackhd_host'][0]['password'] + '\n'},
         logfile=logfile_redirect)
     if VERBOSITY >= 4:
-        print "scp_file_to_ora: Exit Code = {0}".format(ecode)
+        print "scp_file_to_host: Exit Code = {0}".format(ecode)
 
     assert ecode == 0, \
         'failed "{0}" because {1}. Output={2}'.format(cmd, ecode, command_output)
@@ -437,17 +439,17 @@ def get_auth_token():
     api_login = {"username": fitcreds()["api"][0]["admin_user"], "password": fitcreds()["api"][0]["admin_pass"]}
     redfish_login = {"UserName": fitcreds()["api"][0]["admin_user"], "Password": fitcreds()["api"][0]["admin_pass"]}
     try:
-        restful("https://" + fitargs()['ora'] + ":" + str(API_PORT) +
+        restful("https://" + fitargs()['rackhd_host'] + ":" + str(API_PORT) +
                        "/login", rest_action="post", rest_payload=api_login, rest_timeout=2)
     except:
         AUTH_TOKEN = "Unavailable"
         return False
     else:
-        api_data = restful("https://" + fitargs()['ora'] + ":" + str(API_PORT) +
+        api_data = restful("https://" + fitargs()['rackhd_host'] + ":" + str(API_PORT) +
                            "/login", rest_action="post", rest_payload=api_login, rest_timeout=2)
         if api_data['status'] == 200:
             AUTH_TOKEN = str(api_data['json']['token'])
-            redfish_data = restful("https://" + fitargs()['ora'] + ":" + str(API_PORT) +
+            redfish_data = restful("https://" + fitargs()['rackhd_host'] + ":" + str(API_PORT) +
                                    "/redfish/v1/SessionService/Sessions",
                                    rest_action="post", rest_payload=redfish_login, rest_timeout=2)
             if 'x-auth-token' in redfish_data['headers']:
@@ -484,7 +486,7 @@ def rackhdapi(url_cmd, action='get', payload=[], timeout=None, headers={}):
     if API_PROTOCOL == "None":
         if API_PORT == "None":
             API_PORT = str(fitports()['http'])
-        if restful("http://" + fitargs()['ora'] + ":" + str(API_PORT) + "/", rest_timeout=2)['status'] == 0:
+        if restful("http://" + fitargs()['rackhd_host'] + ":" + str(API_PORT) + "/", rest_timeout=2)['status'] == 0:
             API_PROTOCOL = 'https'
             API_PORT = str(fitports()['https'])
         else:
@@ -495,7 +497,7 @@ def rackhdapi(url_cmd, action='get', payload=[], timeout=None, headers={}):
     if AUTH_TOKEN == "None":
         get_auth_token()
 
-    return restful(API_PROTOCOL + "://" + fitargs()['ora'] + ":" + str(API_PORT) + url_cmd,
+    return restful(API_PROTOCOL + "://" + fitargs()['rackhd_host'] + ":" + str(API_PORT) + url_cmd,
                        rest_action=action, rest_payload=payload, rest_timeout=timeout, rest_headers=headers)
 
 def restful(url_command, rest_action='get', rest_payload=[], rest_timeout=None, sslverify=False, rest_headers={}):

--- a/test/common/fit_common.py
+++ b/test/common/fit_common.py
@@ -278,8 +278,6 @@ def mkargs(in_args=None):
                             help="stack label (test bed), overrides -rackhd_host")
     arg_parser.add_argument("-rackhd_host", default="localhost",
                             help="RackHD appliance IP address or hostname, default: localhost")
-    arg_parser.add_argument("-version", default="None",
-                            help="RackHD install version, not yet implemented")
     arg_parser.add_argument("-template", default="None",
                             help="path or URL link to OVA template or RackHD OVA")
     arg_parser.add_argument("-xunit", default="False", action="store_true",

--- a/test/config/credentials_default.json
+++ b/test/config/credentials_default.json
@@ -18,7 +18,7 @@
         "password": "password"
       }
     ],
-    "ora": [
+    "rackhd_host": [
       {
         "username": "vagrant",
         "password": "vagrant"

--- a/test/config/stack_config.json
+++ b/test/config/stack_config.json
@@ -4,17 +4,17 @@
     "control": "control switch admin address",
     "data": "data switch admin address",
     "hyper": "hypervisor admin address",
-    "ora": "appliance OVA admin address",
-    "ovamac": "appliance OVA MAC address",
+    "rackhd_host": "appliance admin address",
+    "ovamac": "appliance OVA MAC address for ESXi deployments",
     "pdu": "PDU admin address",
     "type": "deployment type: esxi, docker, linux, or vagrant"
   },
   "vagrant":{
-    "ora": "localhost",
+    "rackhd_host": "localhost",
     "type": "vagrant"
   },
   "vagrant_remote": {
-    "ora": "127.0.0.1",
+    "rackhd_host": "127.0.0.1",
     "type": "vagrant"
   }
 }

--- a/test/deploy/os_ova_install.py
+++ b/test/deploy/os_ova_install.py
@@ -112,7 +112,7 @@ class os_ova_install(fit_common.unittest.TestCase):
         self.assertTrue(numvms < 100, "Number of vms should not be greater than 99")
 
         # Shutdown previous ORA
-        if fit_common.subprocess.call('ping -c 1 ' + fit_common.fitargs()['ora'], shell=True) == 0:
+        if fit_common.subprocess.call('ping -c 1 ' + fit_common.fitargs()['rackhd_host'], shell=True) == 0:
             fit_common.remote_shell('shutdown -h now')
             fit_common.time.sleep(5)
 


### PR DESCRIPTION
This PR just renames 'ora' to 'rackhd_host' in reference to the appliance hostname or IP address for RAC-3711.

Tested on deployments and smoke test.

Please merge https://eos2git.cec.lab.emc.com/OnRack/dellemc-test/pull/7 after this PR.

@johren @hohene @jimturnquist @larry-dean 