### PR TITLE
RAC-3870 capture test progress

### DIFF
--- a/test/common/fit_common.py
+++ b/test/common/fit_common.py
@@ -364,7 +364,7 @@ def mkargs(in_args=None):
         vargs = ['--sm-set-combo-level', '*', 'ERROR_5']
     else:
         # 0 and 1 currently try to squish ALL logging output.
-        vargs = ['--sm-set-combo-level', '*', 'CRITICAL_0']
+        vargs = ['--sm-set-combo-level', '*', 'CRITICAL_0', '--sm-no-logify-console']
 
     other_args.extend(vargs)
 

--- a/test/stream-monitor/flogging/README.md
+++ b/test/stream-monitor/flogging/README.md
@@ -152,6 +152,9 @@ The following nose options are available to control and examine the loggers:
         note: both 'logger-name's and 'handler-name's can contain wild-card
         characters to match multiple items.
 
+        --sm-no-logify-console
+                            set to not capture raw stderr traffic to console as
+                            logging messages.
         --sm-set-logger-level=('logger-name', 'level-name-or-value')
                             Set a logger's capture threshold. Loggers are
                             evaluated before handlers.
@@ -163,7 +166,7 @@ The following nose options are available to control and examine the loggers:
         --sm-set-file-level=('file-pattern', '[handler-name[:logger-name] [level-name-or-value]]')
                             Same as --sm-set-combo-level, but restricts the change
                             in output to only the files that match the file-
-                            pattern
+                            pattern.
 
 ## The 'set' options:
 The following goes through each option and explains what it does:

--- a/test/stream-monitor/flogging/infra_logopts.py
+++ b/test/stream-monitor/flogging/infra_logopts.py
@@ -91,6 +91,10 @@ class LoggerArgParseHelper(object):
             'setting log options',
             "note: both 'logger-name's and 'handler-name's can contain wild-card characters to match multiple items.")
         set_group.add_argument(
+            '--sm-no-logify-console', dest='sm_no_logify_console',
+            action='store_true', default=False,
+            help='set to not capture raw stderr traffic to console as logging messages.')
+        set_group.add_argument(
             '--sm-set-logger-level', nargs=2, default=[],
             dest='set_logger_level_list', action='append',
             metavar=('logger-name', 'level-name-or-value'),
@@ -110,7 +114,7 @@ class LoggerArgParseHelper(object):
         set_group.add_argument(
             '--sm-set-file-level', nargs=3, dest='set_file_level',
             metavar=('file-pattern', '[handler-name[:logger-name] [level-name-or-value]]'),
-            help="Same as --sm-set-combo-level, but restricts the change in output to only the files that match the file-pattern")
+            help="Same as --sm-set-combo-level, but restricts the change in output to only the files that match the file-pattern.")
 
 
     def __display_filter(self, indent, filter, detail):

--- a/test/stream-monitor/flogging/logger_sets.py
+++ b/test/stream-monitor/flogging/logger_sets.py
@@ -22,7 +22,7 @@ class _LoggerSet(object):
         if hasattr(self.trl, key):
             return getattr(self.trl, key)
 
-        m = "'{0}' object has no attribute '{1}'".format(self.__name__, key)
+        m = "'{0}' object has no attribute '{1}'".format(self.__class__.__name__, key)
         raise AttributeError(m)
 
 

--- a/test/stream-monitor/test/log_stream_helper.py
+++ b/test/stream-monitor/test/log_stream_helper.py
@@ -74,7 +74,7 @@ class TempLogfileChecker(object):
         full_file = os.path.join(suitepath, test_file)
         tb_line = '{0}\s+traceback: Traceback \(most recent call last\):'.format(ltype)
         self.__check_line(test, tb_line, exp_count)
-        file_line = 'File "{0}", line \d+, in {1}'.format(full_file, test_method)
+        file_line = '^\s+File "{0}", line \d+, in {1}'.format(full_file, test_method)
         self.__check_line(test, file_line, exp_count)
 
     def check_capture(self, test, cap_type, cap_level, test_class, test_method, exp_count):


### PR DESCRIPTION
This change makes it so progress information from nose is entered as log lines.

Changes included:
* fix to problem in logger_set.py discovered during coding
* added logic to sm-plugin turn the base nose stream to log entries:
** allow the option to be enabled/disabled with a flag (to allow -v 0, basically!)
** generate a fake stream-like object to pretend to be stderr but instead pass data on to a logger
** tie one of those in when the plugin is test.begin'ed for the first time (if flagged to do so)
* fixed the regex for detecting tracebacks. It was picking up the pilfered stderr stream and seeing that one, which would throw off the count.

Ends up looking something like this under "normal" use:
{code}
2017-02-03 15:55:46,568 INFO    test_tr (test.tests.test_me.test_flogging) ... ok
2017-02-03 15:55:46,568 INFO    -1.04 - ENDING TEST: test_tr (test.tests.test_me.test_flogging)
2017-02-03 15:55:46,569 INFO
2017-02-03 15:55:46,569 INFO    ----------------------------------------------------------------------
2017-02-03 15:55:46,570 INFO    Ran 4 tests in 0.056s
2017-02-03 15:55:46,570 INFO
2017-02-03 15:55:46,570 INFO    OK
{code}
and like this with -v0

{code}
python run_tests.py -stack vagrant -test tests/test_me.py -v0
*** Created config file: config/generated/fit-config-20170203-160002
*** Using config file: config/generated/fit-config-20170203-160002
2017-02-03 16:00:02,650 INFO    removing previous logging dir /Users/stanls1/ws/rac-3870-capture-test-progress/test/log_output/run_2017-02-03_14:12:59.d 45582 MainProcess stream-monitor/flogging/infra_logging.py:__init__@128 gl-main
2017-02-03 16:00:02,650 INFO    this runs logging dir /Users/stanls1/ws/rac-3870-capture-test-progress/test/log_output/run_2017-02-03_16:00:02.d 45582 MainProcess stream-monitor/flogging/infra_logging.py:__init__@128 gl-main
*** Reloading config file: config/generated/fit-config-20170203-160002
test_id (test.tests.test_me.test_flogging) ... ok
test_ir (test.tests.test_me.test_flogging) ... ok
test_td (test.tests.test_me.test_flogging) ... ok
test_tr (test.tests.test_me.test_flogging) ... ok

----------------------------------------------------------------------
Ran 4 tests in 0.014s

OK
{code}

@RackHD/corecommitters @johren @hohene @gpaulos @larry-dean @jimturnquist @keedya @panpan0000 @changev @anhou
