### PR TITLE
Updates to RackHD/test to cleanup module pathing.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,3 +6,5 @@ include = .
 exclude = .venv
 
 ignore =
+    # F401 imported but unused
+    F401

--- a/test/common/fit_common.py
+++ b/test/common/fit_common.py
@@ -24,9 +24,8 @@ import inspect
 
 import nose
 import argparse
+import fit_path
 from mkcfg import mkcfg
-
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test")
 
 VERBOSITY = 1
 TEST_PATH = None
@@ -1131,7 +1130,8 @@ def run_nose(nosepath=None):
         env = {
             'FIT_CONFIG': mkcfg().get_path(),
             'HOME':  os.environ['HOME'],
-            'PATH':  os.environ['PATH']
+            'PATH':  os.environ['PATH'],
+            'PYTHONPATH': ':'.join(sys.path)
         }
         argv = ['nosetests']
         argv.extend(noseopts)

--- a/test/common/test_api_utils.py
+++ b/test/common/test_api_utils.py
@@ -11,7 +11,7 @@
 
 import sys
 import subprocess
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/common")
+import fit_path
 import fit_common
 
 import unicodedata

--- a/test/deploy/os_ova_install.py
+++ b/test/deploy/os_ova_install.py
@@ -16,8 +16,7 @@ usage:
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 import pdu_lib
 

--- a/test/deploy/rackhd_package_install.py
+++ b/test/deploy/rackhd_package_install.py
@@ -21,8 +21,7 @@ usage:
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # set proxy if required

--- a/test/deploy/rackhd_source_install.py
+++ b/test/deploy/rackhd_source_install.py
@@ -23,8 +23,7 @@ usage:
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # set proxy if required

--- a/test/deploy/rackhd_stack_init.py
+++ b/test/deploy/rackhd_stack_init.py
@@ -22,8 +22,7 @@ import subprocess
 import json
 import time
 import unittest
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 import pdu_lib
 

--- a/test/deploy/run_rackhd_installer.py
+++ b/test/deploy/run_rackhd_installer.py
@@ -10,8 +10,7 @@ This wrapper script installs RackHD into the selected stack and runs the stack i
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 class rackhd_installer(fit_common.unittest.TestCase):

--- a/test/deploy/run_rackhd_smoke_test.py
+++ b/test/deploy/run_rackhd_smoke_test.py
@@ -10,8 +10,7 @@ This wrapper script installs RackHD and runs Smoke Test.
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 class rackhd_smoke_test(fit_common.unittest.TestCase):

--- a/test/fit_path/__init__.py
+++ b/test/fit_path/__init__.py
@@ -1,0 +1,4 @@
+import sys
+import subprocess
+sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test")
+sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")

--- a/test/fit_path/setup.py
+++ b/test/fit_path/setup.py
@@ -1,0 +1,19 @@
+try:
+    import ez_setup
+    ez_setup.use_setuptools()
+except ImportError:
+    pass
+
+from setuptools import setup
+
+setup(
+    name='fit test pathing',
+    version='0.1',
+    author='James Turnquist',
+    author_email = 'james.turnquist@dell.com',
+    description = 'setup pathing for RackHD/test',
+    license = 'Apache 2.0',
+    packages = [],
+    entry_points = { }
+    )
+

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -23,6 +23,7 @@ urllib3==1.19.1
 # WARNING: do not just replace this file with "pip freeze > requirements.txt".
 # You need to keep the following line as is! (freeze will turn it into
 # a https/git reference)
+-e fit_path
 -e stream-monitor
 
 # WARNING: there is an ubuntu bug that causes a bad package to get listed when doing a freeze.

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -11,7 +11,7 @@ George Paulos
 import sys
 import subprocess
 
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # validate command line args

--- a/test/templates/fit_test_template.py
+++ b/test/templates/fit_test_template.py
@@ -10,8 +10,7 @@ import os
 import sys
 import subprocess
 
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Select test group here using @attr, these can be any labels to run groups of tests selectively

--- a/test/templates/run_wrapper_template.py
+++ b/test/templates/run_wrapper_template.py
@@ -9,8 +9,7 @@ FIT test wrapper script template
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 class wrapper_template(fit_common.unittest.TestCase):

--- a/test/tests/api-cit/v2_0/nodes_tests_fit.py
+++ b/test/tests/api-cit/v2_0/nodes_tests_fit.py
@@ -7,8 +7,7 @@ import sys
 import subprocess
 import json
 
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test")
+import fit_path
 
 import unittest
 from common import fit_common

--- a/test/tests/bootstrap/test_redfish10_os_bootstrap_base.py
+++ b/test/tests/bootstrap/test_redfish10_os_bootstrap_base.py
@@ -47,8 +47,7 @@ import sys
 import subprocess
 import random
 
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # This node catalog section will be replaced with fit_common.node_select() when it is checked in

--- a/test/tests/compute/test_rackhd11_computenode_pollers.py
+++ b/test/tests/compute/test_rackhd11_computenode_pollers.py
@@ -10,8 +10,7 @@ This test checks pollers under API 1.1
 import sys
 import subprocess
 
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 import test_api_utils
 

--- a/test/tests/compute/test_rackhd20_computenode_pollers.py
+++ b/test/tests/compute/test_rackhd20_computenode_pollers.py
@@ -10,8 +10,7 @@ This test checks pollers under API 1.1
 import sys
 import subprocess
 
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 import test_api_utils
 

--- a/test/tests/query/test_rackhd11_query.py
+++ b/test/tests/query/test_rackhd11_query.py
@@ -10,8 +10,7 @@ import os
 import sys
 import subprocess
 
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 from nose.plugins.attrib import attr

--- a/test/tests/query/test_rackhd20_query.py
+++ b/test/tests/query/test_rackhd20_query.py
@@ -10,8 +10,7 @@ import os
 import sys
 import subprocess
 
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 from nose.plugins.attrib import attr

--- a/test/tests/rackhd11/test_rackhd11_api_catalogs.py
+++ b/test/tests/rackhd11/test_rackhd11_api_catalogs.py
@@ -9,7 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 import flogging
 

--- a/test/tests/rackhd11/test_rackhd11_api_config.py
+++ b/test/tests/rackhd11/test_rackhd11_api_config.py
@@ -9,8 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd11/test_rackhd11_api_files.py
+++ b/test/tests/rackhd11/test_rackhd11_api_files.py
@@ -9,8 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd11/test_rackhd11_api_lookups.py
+++ b/test/tests/rackhd11/test_rackhd11_api_lookups.py
@@ -9,8 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd11/test_rackhd11_api_misc.py
+++ b/test/tests/rackhd11/test_rackhd11_api_misc.py
@@ -9,8 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd11/test_rackhd11_api_nodes.py
+++ b/test/tests/rackhd11/test_rackhd11_api_nodes.py
@@ -9,8 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 

--- a/test/tests/rackhd11/test_rackhd11_api_obms.py
+++ b/test/tests/rackhd11/test_rackhd11_api_obms.py
@@ -9,8 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd11/test_rackhd11_api_pollers.py
+++ b/test/tests/rackhd11/test_rackhd11_api_pollers.py
@@ -9,8 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 

--- a/test/tests/rackhd11/test_rackhd11_api_profiles.py
+++ b/test/tests/rackhd11/test_rackhd11_api_profiles.py
@@ -9,8 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd11/test_rackhd11_api_schemas.py
+++ b/test/tests/rackhd11/test_rackhd11_api_schemas.py
@@ -9,8 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd11/test_rackhd11_api_skus.py
+++ b/test/tests/rackhd11/test_rackhd11_api_skus.py
@@ -9,8 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd11/test_rackhd11_api_tags.py
+++ b/test/tests/rackhd11/test_rackhd11_api_tags.py
@@ -9,8 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Local methods

--- a/test/tests/rackhd11/test_rackhd11_api_templates.py
+++ b/test/tests/rackhd11/test_rackhd11_api_templates.py
@@ -9,7 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd11/test_rackhd11_api_workflows.py
+++ b/test/tests/rackhd11/test_rackhd11_api_workflows.py
@@ -9,8 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 

--- a/test/tests/rackhd20/test_rackhd20_api_catalogs.py
+++ b/test/tests/rackhd20/test_rackhd20_api_catalogs.py
@@ -9,7 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 

--- a/test/tests/rackhd20/test_rackhd20_api_config.py
+++ b/test/tests/rackhd20/test_rackhd20_api_config.py
@@ -9,8 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd20/test_rackhd20_api_dhcp.py
+++ b/test/tests/rackhd20/test_rackhd20_api_dhcp.py
@@ -9,8 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Local methods

--- a/test/tests/rackhd20/test_rackhd20_api_files.py
+++ b/test/tests/rackhd20/test_rackhd20_api_files.py
@@ -9,8 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd20/test_rackhd20_api_lookups.py
+++ b/test/tests/rackhd20/test_rackhd20_api_lookups.py
@@ -9,8 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd20/test_rackhd20_api_misc.py
+++ b/test/tests/rackhd20/test_rackhd20_api_misc.py
@@ -9,8 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd20/test_rackhd20_api_nodes.py
+++ b/test/tests/rackhd20/test_rackhd20_api_nodes.py
@@ -9,8 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 

--- a/test/tests/rackhd20/test_rackhd20_api_obms.py
+++ b/test/tests/rackhd20/test_rackhd20_api_obms.py
@@ -9,8 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 

--- a/test/tests/rackhd20/test_rackhd20_api_pollers.py
+++ b/test/tests/rackhd20/test_rackhd20_api_pollers.py
@@ -9,8 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 

--- a/test/tests/rackhd20/test_rackhd20_api_profiles.py
+++ b/test/tests/rackhd20/test_rackhd20_api_profiles.py
@@ -9,8 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd20/test_rackhd20_api_schemas.py
+++ b/test/tests/rackhd20/test_rackhd20_api_schemas.py
@@ -9,8 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd20/test_rackhd20_api_skus.py
+++ b/test/tests/rackhd20/test_rackhd20_api_skus.py
@@ -9,8 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd20/test_rackhd20_api_tags.py
+++ b/test/tests/rackhd20/test_rackhd20_api_tags.py
@@ -9,8 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Local methods

--- a/test/tests/rackhd20/test_rackhd20_api_templates.py
+++ b/test/tests/rackhd20/test_rackhd20_api_templates.py
@@ -9,7 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd20/test_rackhd20_api_users.py
+++ b/test/tests/rackhd20/test_rackhd20_api_users.py
@@ -9,8 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd20/test_rackhd20_api_views.py
+++ b/test/tests/rackhd20/test_rackhd20_api_views.py
@@ -9,8 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd20/test_rackhd20_api_workflows.py
+++ b/test/tests/rackhd20/test_rackhd20_api_workflows.py
@@ -9,8 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 

--- a/test/tests/redfish10/test_redfish10_api_accountservice.py
+++ b/test/tests/redfish10/test_redfish10_api_accountservice.py
@@ -9,7 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/redfish10/test_redfish10_api_chassis.py
+++ b/test/tests/redfish10/test_redfish10_api_chassis.py
@@ -9,7 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 import json
 

--- a/test/tests/redfish10/test_redfish10_api_eventservice.py
+++ b/test/tests/redfish10/test_redfish10_api_eventservice.py
@@ -9,7 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/redfish10/test_redfish10_api_managers.py
+++ b/test/tests/redfish10/test_redfish10_api_managers.py
@@ -9,7 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/redfish10/test_redfish10_api_registries.py
+++ b/test/tests/redfish10/test_redfish10_api_registries.py
@@ -9,7 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/redfish10/test_redfish10_api_schemas.py
+++ b/test/tests/redfish10/test_redfish10_api_schemas.py
@@ -9,7 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/redfish10/test_redfish10_api_sessionservice.py
+++ b/test/tests/redfish10/test_redfish10_api_sessionservice.py
@@ -9,7 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/redfish10/test_redfish10_api_systems.py
+++ b/test/tests/redfish10/test_redfish10_api_systems.py
@@ -9,7 +9,7 @@ George Paulos
 import os
 import sys
 import subprocess
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 

--- a/test/tests/redfish10/test_redfish10_api_taskservice.py
+++ b/test/tests/redfish10/test_redfish10_api_taskservice.py
@@ -9,7 +9,7 @@ import os
 import sys
 import subprocess
 import json
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 

--- a/test/tests/redfish10/test_redfish10_system_reset_base.py
+++ b/test/tests/redfish10/test_redfish10_system_reset_base.py
@@ -12,7 +12,7 @@ import time
 import string
 import json
 
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 import test_api_utils
 

--- a/test/tests/switch/test_rackhd11_switch_pollers.py
+++ b/test/tests/switch/test_rackhd11_switch_pollers.py
@@ -10,8 +10,7 @@ import sys
 import subprocess
 import pprint
 
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 import test_api_utils
 

--- a/test/tests/switch/test_rackhd11_switch_telemetry.py
+++ b/test/tests/switch/test_rackhd11_switch_telemetry.py
@@ -11,8 +11,7 @@ import subprocess
 import json
 import time
 
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 

--- a/test/tests/switch/test_rackhd20_switch_pollers.py
+++ b/test/tests/switch/test_rackhd20_switch_pollers.py
@@ -10,8 +10,7 @@ import sys
 import subprocess
 import pprint
 
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 import test_api_utils
 

--- a/test/tests/switch/test_rackhd20_switch_telemetry.py
+++ b/test/tests/switch/test_rackhd20_switch_telemetry.py
@@ -11,8 +11,7 @@ import subprocess
 import json
 import time
 
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 

--- a/test/util/display_SYSINFO_settings.py
+++ b/test/util/display_SYSINFO_settings.py
@@ -9,8 +9,7 @@ import os
 import sys
 import subprocess
 
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 import test_api_utils
 

--- a/test/util/display_node_FIRMWARE_versions.py
+++ b/test/util/display_node_FIRMWARE_versions.py
@@ -11,8 +11,7 @@ import subprocess
 import json
 import pprint
 
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 import test_api_utils
 

--- a/test/util/display_rackhd_nodes.py
+++ b/test/util/display_rackhd_nodes.py
@@ -13,10 +13,8 @@ import sys
 import subprocess
 import json
 import pprint
+import fit_path
 from nosedep import depends
-
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 import test_api_utils
 

--- a/test/util/load_sku_packs.py
+++ b/test/util/load_sku_packs.py
@@ -10,8 +10,7 @@ import os
 import sys
 import subprocess
 
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 from nose.plugins.attrib import attr

--- a/test/util/node_list.py
+++ b/test/util/node_list.py
@@ -11,8 +11,7 @@ import os
 import sys
 import subprocess
 import argparse
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_path
 import fit_common
 
 


### PR DESCRIPTION
Standardized how RackHD/test finds test and test/common.  This
eliminates the need for inlined 'git-rev-parse' style statements
throughout the code.  Doing the following in an individual test
will set up the module pathing:

import fit_path