### PR TITLE
Add an exclusion for flake8 E402

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,3 +6,5 @@ include = .
 exclude = .venv
 
 ignore =
+    # E402 module level import not at top of file
+    E402


### PR DESCRIPTION
import statements are not always at the top of files within
RackHD/test.  This problem will be solved at some time in the
future.  For now, the python module pathing to test and test/common
needs to appear before statement like 'import fit_common'

@hohene 