### PR TITLE
Rac 4080 parallel OS bootstrap test

### DIFF
--- a/test/tests/bootstrap/test_redfish10_os_bootstrap_parallel.py
+++ b/test/tests/bootstrap/test_redfish10_os_bootstrap_parallel.py
@@ -112,9 +112,9 @@ if "regression" in sys.argv or "-a" not in sys.argv:
         {"os":"CentOS", "version":"6.5", "path":"/CentOS/6.5"},
         {"os":"CentOS+KVM", "version":"6.5", "path":"/CentOS/6.5"},
         {"os":"CentOS", "version":"7", "path":"/CentOS/7.0"},
-        {"os":"RHEL+KVM", "version":"7", "path":"/CentOS/7.0"},
+        {"os":"RHEL+KVM", "version":"7", "path":"/RHEL/7.0"},
         {"os":"RHEL", "version":"7", "path":"/RHEL/7.0"},
-        {"os":"CentOS+KVM", "version":"7", "path":"/RHEL/7.0"}
+        {"os":"CentOS+KVM", "version":"7", "path":"/CentOS/7.0"}
     ]
     nodeindex = 0
     for item in oslist:

--- a/test/tests/bootstrap/test_redfish10_os_bootstrap_parallel.py
+++ b/test/tests/bootstrap/test_redfish10_os_bootstrap_parallel.py
@@ -1,0 +1,184 @@
+# Copyright 2017, EMC, Inc.
+
+'''
+This script tests base case of the RackHD Redfish BootImage API and OS bootstrap workflows
+The test will select a single eligible node to run all currently supported bootstrap workflows
+
+Bootstrap tests require special RackHD configuration and mirror repositories for the OS images
+OS images are loaded via RackHD "httpProxies" settings in config.json.
+
+Example:
+      "httpProxies": [
+          {
+              "localPath": "/ESXi/5.5",
+              "remotePath": "/",
+              "server": "http://os-mirror-server/esxi/5.5/esxi"
+          },
+          {
+              "localPath": "/ESXi/6.0",
+              "remotePath": "/",
+              "server": "http://os-mirror-server/6.0/esxi6"
+          },
+          {
+              "localPath": "/CentOS/6.5",
+              "remotePath": "/",
+              "server": "http://os-mirror-server/centos/6.5/os/x86_64"
+          },
+          {
+              "localPath": "/CentOS/7.0",
+              "remotePath": "/",
+              "server": "http://os-mirror-server/centos/7/os/x86_64"
+          },
+          {
+              "localPath": "/RHEL/7.0",
+              "remotePath": "/",
+              "server": "http://os-mirror-server/rhel/7.0/os/x86_64"
+          }
+      ],
+
+For each OS type, the "localpath" string must conform to the schema above.
+The "server' URL points to the location of the OS executables in an image repository.
+
+'''
+
+import os
+import sys
+import subprocess
+import random
+
+# set path to common libraries
+sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
+import fit_common
+
+# This node catalog section will be replaced with fit_common.node_select() when it is checked in
+NODECATALOG = fit_common.node_select()
+
+# download RackHD config from host
+rackhdconfig = fit_common.rackhdapi('/api/2.0/config')['json']
+httpProxies = rackhdconfig['httpProxies']
+rackhdhost = "http://" + str(rackhdconfig['apiServerAddress']) + ":" + str(rackhdconfig['apiServerPort'])
+
+# dict containing bootstrap workflow IDs and states
+status = {}
+
+# this routine polls a task ID for completion
+def wait_for_task_complete(taskid, retries=60):
+    for dummy in range(0, retries):
+        result = fit_common.rackhdapi(taskid)
+        if result['status'] != 200:
+            return False
+        if result['json']['TaskState'] == 'Running' or result['json']['TaskState'] == 'Pending':
+            if fit_common.VERBOSITY >= 2:
+                print "OS Install workflow state: {}".format(result['json']['TaskState'])
+            fit_common.time.sleep(30)
+        elif result['json']['TaskState'] == 'Completed':
+            if fit_common.VERBOSITY >= 2:
+                print "OS Install workflow state: {}".format(result['json']['TaskState'])
+            return True
+        else:
+            break
+    print "Task failed with the following state: " + result['json']['TaskState']
+    return False
+
+# helper routine for selecting OS image path by matching proxy path
+def proxySelect(tag):
+    for entry in httpProxies:
+        if tag in entry['localPath']:
+            return entry['localPath']
+    return ''
+
+# run individual bootstrap with parameters
+def run_bootstrap_instance(node, osname, version, path):
+    #delete active workflows for specified node
+    fit_common.cancel_active_workflows(node)
+    payload_data = {
+                    "osName": osname,
+                    "version": version,
+                    "repo": rackhdhost + path,
+                    "rootPassword": "1234567",
+                    "hostname": "rackhdnode",
+                    "dnsServers": [rackhdconfig['apiServerAddress']],
+                    "users": [{
+                                "name": "rackhd",
+                                "password": "R@ckHD1!",
+                                "uid": 1010,
+                            }]
+                   }
+    result = fit_common.rackhdapi('/redfish/v1/Systems/'
+                                        + node
+                                        + '/Actions/RackHD.BootImage',
+                                        action='post', payload=payload_data)
+    if result['status'] == 202:
+        status[node] = {"os":osname, "version":version, "id":result['json']['@odata.id']}
+    else:
+        status[node] = {"os":osname, "version":version, 'id':"/redfish/v1/taskservice/tasks/failed"}
+
+# run all bootstraps on available nodes
+def launch_bootstraps():
+    oslist = [
+        {"os":"ESXi", "version":"5.5", "path":"/ESXi/5.5"},
+        {"os":"ESXi", "version":"6.0", "path":"/ESXi/6.0"},
+        {"os":"CentOS", "version":"6.5", "path":"/CentOS/6.5"},
+        {"os":"CentOS+KVM", "version":"6.5", "path":"/CentOS/6.5"},
+        {"os":"CentOS", "version":"7", "path":"/CentOS/7.0"},
+        {"os":"RHEL+KVM", "version":"7", "path":"/CentOS/7.0"},
+        {"os":"RHEL", "version":"7", "path":"/RHEL/7.0"},
+        {"os":"CentOS+KVM", "version":"7", "path":"/RHEL/7.0"}
+    ]
+    nodeindex = 0
+    for item in oslist:
+        # if OS proxy entry exists, run bootstrap against selected node
+        if proxySelect(item['path']) and nodeindex < len(NODECATALOG):
+            run_bootstrap_instance(NODECATALOG[nodeindex],item['os'],item['version'],item['path'])
+            nodeindex += 1
+
+# return the task ID associated with the running bootstrap workflow
+def node_taskid(osname, version):
+    for entry in status:
+        if status[entry]['os'] == osname and status[entry]['version'] == version:
+            return status[entry]['id']
+    return ""
+
+launch_bootstraps()
+print "\n"
+print fit_common.json.dumps(status)
+
+# ------------------------ Tests -------------------------------------
+from nose.plugins.attrib import attr
+@attr(all=True, regression=True)
+class os_bootstrap_base(fit_common.unittest.TestCase):
+
+    @fit_common.unittest.skipUnless(node_taskid("ESXi", "5.5") != '', "Skipping ESXi5.5")
+    def test_bootstrap_esxi55(self):
+        self.assertTrue(wait_for_task_complete(node_taskid("ESXi", "5.5")), "ESXi5.5 failed.")
+
+    @fit_common.unittest.skipUnless(node_taskid("ESXi", "6.0")  != '', "Skipping ESXi6.0")
+    def test_bootstrap_esxi60(self):
+        self.assertTrue(wait_for_task_complete(node_taskid("ESXi", "6.0")), "ESXi6.0 failed.")
+
+    @fit_common.unittest.skipUnless(node_taskid("CentOS", "6.5")  != '', "Skipping Centos 6.5")
+    def test_bootstrap_centos65(self):
+        self.assertTrue(wait_for_task_complete(node_taskid("CentOS", "6.5")), "Centos 6.5 failed.")
+
+    @fit_common.unittest.skipUnless(node_taskid("CentOS+KVM", "6.5") != '', "Skipping Centos 6.5 KVM")
+    def test_bootstrap_centos65_kvm(self):
+        self.assertTrue(wait_for_task_complete(node_taskid("CentOS+KVM", "6.5")), "Centos 6.5 KVM failed.")
+
+    @fit_common.unittest.skipUnless(node_taskid("CentOS", "7") != '', "Skipping Centos 7.0")
+    def test_bootstrap_centos70(self):
+        self.assertTrue(wait_for_task_complete(node_taskid("CentOS", "7")), "Centos 7.0 failed.")
+
+    @fit_common.unittest.skipUnless(node_taskid("CentOS+KVM", "7") != '', "Skipping Centos 7.0 KVM")
+    def test_bootstrap_centos70_kvm(self):
+        self.assertTrue(wait_for_task_complete(node_taskid("CentOS+KVM", "7")), "Centos 7.0 KVM failed.")
+
+    @fit_common.unittest.skipUnless(node_taskid("RHEL", "7") != '', "Skipping Redhat 7.0")
+    def test_bootstrap_rhel70(self):
+        self.assertTrue(wait_for_task_complete(node_taskid("RHEL", "7")), "RHEL 7.0 failed.")
+
+    @fit_common.unittest.skipUnless(node_taskid("RHEL+KVM", "7") != '', "Skipping Redhat 7.0 KVM")
+    def test_bootstrap_rhel70_kvm(self):
+        self.assertTrue(wait_for_task_complete(node_taskid("RHEL+KVM", "7")), "RHEL 7.0 KVM failed.")
+
+if __name__ == '__main__':
+    fit_common.unittest.main()

--- a/test/tests/bootstrap/test_redfish10_os_bootstrap_parallel.py
+++ b/test/tests/bootstrap/test_redfish10_os_bootstrap_parallel.py
@@ -1,10 +1,15 @@
-# Copyright 2017, EMC, Inc.
-
 '''
-This script tests base case of the RackHD Redfish BootImage API and OS bootstrap workflows
-The test will select a single eligible node to run all currently supported bootstrap workflows
+Copyright 2017, EMC, Inc.
 
-Bootstrap tests require special RackHD configuration and mirror repositories for the OS images
+Author(s):
+George Paulos
+
+This script tests base case of the RackHD Redfish BootImage API and OS bootstrap workflows.
+This routine runs OS bootstrap jobs simultaneously on multiple nodes.
+For 8 tests to run, 8 nodes are required in the stack. If there are less than that, tests will be skipped.
+This test takes 15-20 minutes to run.
+
+OS bootstrap tests require special RackHD configuration and mirror repositories for the OS images.
 OS images are loaded via RackHD "httpProxies" settings in config.json.
 
 Example:
@@ -36,7 +41,7 @@ Example:
           }
       ],
 
-For each OS type, the "localpath" string must conform to the schema above.
+For each OS type, the "localpath" string must conform to the convention above.
 The "server' URL points to the location of the OS executables in an image repository.
 
 '''
@@ -44,13 +49,12 @@ The "server' URL points to the location of the OS executables in an image reposi
 import os
 import sys
 import subprocess
-import random
 
 # set path to common libraries
 sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
-# This node catalog section will be replaced with fit_common.node_select() when it is checked in
+# This gets the list of nodes
 NODECATALOG = fit_common.node_select()
 
 # download RackHD config from host
@@ -140,8 +144,6 @@ def node_taskid(osname, version):
     return ""
 
 launch_bootstraps()
-print "\n"
-print fit_common.json.dumps(status)
 
 # ------------------------ Tests -------------------------------------
 from nose.plugins.attrib import attr

--- a/test/tests/bootstrap/test_redfish10_os_bootstrap_parallel.py
+++ b/test/tests/bootstrap/test_redfish10_os_bootstrap_parallel.py
@@ -112,7 +112,8 @@ OSLIST = [
 # Match up tests to node IDs to feed skip decorators
 index = 0 # node index
 for item in OSLIST:
-    NODE_STATUS[NODECATALOG[index]] = {"os":item['os'], "version":item['version'], "id":"Pending"}
+    if proxy_select(item['path']) and index < len(NODECATALOG):
+        NODE_STATUS[NODECATALOG[index]] = {"os":item['os'], "version":item['version'], "id":"Pending"}
     index += 1
 
 # ------------------------ Tests -------------------------------------

--- a/test/tests/bootstrap/test_redfish10_os_bootstrap_parallel.py
+++ b/test/tests/bootstrap/test_redfish10_os_bootstrap_parallel.py
@@ -73,7 +73,7 @@ def wait_for_task_complete(taskid, retries=60):
     for dummy in range(0, retries):
         result = fit_common.rackhdapi(taskid)
         if result['status'] != 200:
-            log.tdl.error(" " + result['text'])
+            log.error(" " + result['text'])
             return False
         if result['json']['TaskState'] == 'Running' or result['json']['TaskState'] == 'Pending':
             if fit_common.VERBOSITY >= 2:
@@ -82,12 +82,12 @@ def wait_for_task_complete(taskid, retries=60):
         elif result['json']['TaskState'] == 'Completed':
             if fit_common.VERBOSITY >= 2:
                 print "OS Install workflow state: {}".format(result['json']['TaskState'])
-            log.tdl.info_5(" " + result['text'])
+            log.info_5(" " + result['text'])
             return True
         else:
-            log.tdl.error(" " + result['text'])
+            log.error(" " + result['text'])
             return False
-    log.tdl.error(" Workflow Timeout: " + result['text'])
+    log.error(" Workflow Timeout: " + result['text'])
     return False
 
 # helper routine for selecting OS image path by matching proxy path
@@ -127,12 +127,12 @@ def run_bootstrap_instance(node, osname, version, path):
                                         action='post', payload=payload_data)
     if result['status'] == 202:
         status[node] = {"os":osname, "version":version, "id":result['json']['@odata.id']}
-        log.tdl.info_5(" TaskID: " + result['text'])
-        log.tdl.info_5(" Payload: " + fit_common.json.dumps(payload_data))
+        log.info_5(" TaskID: " + result['text'])
+        log.info_5(" Payload: " + fit_common.json.dumps(payload_data))
     else:
         status[node] = {"os":osname, "version":version, 'id':"/redfish/v1/taskservice/tasks/failed"}
-        log.tdl.error(" TaskID: " + result['text'])
-        log.tdl.error(" Payload: " + fit_common.json.dumps(payload_data))
+        log.error(" TaskID: " + result['text'])
+        log.error(" Payload: " + fit_common.json.dumps(payload_data))
 
 # run all bootstraps on available nodes
 def launch_bootstraps():

--- a/test/tests/bootstrap/test_redfish10_os_bootstrap_parallel.py
+++ b/test/tests/bootstrap/test_redfish10_os_bootstrap_parallel.py
@@ -49,6 +49,7 @@ The "server' URL points to the location of the OS executables in an image reposi
 import os
 import sys
 import subprocess
+from nose.plugins.attrib import attr
 
 # set path to common libraries
 sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
@@ -88,10 +89,10 @@ def wait_for_task_complete(taskid, retries=60):
     log.error(" Workflow Timeout: " + result['text'])
     return False
 
-# helper routine for selecting OS image path by matching proxy path
+# helper routine for selecting OS image path by matching proxy 'localPath'
 def proxy_select(tag):
     for entry in rackhdconfig['httpProxies']:
-        if tag in entry['localPath']:
+        if tag == entry['localPath']:
             return entry['localPath']
     return ''
 
@@ -153,7 +154,7 @@ if "regression" in sys.argv or "-a" not in sys.argv:
 
 
 # ------------------------ Tests -------------------------------------
-from nose.plugins.attrib import attr
+
 @attr(all=True, regression=True)
 
 


### PR DESCRIPTION
This resubmit of the new test script that runs Redfish 1.0 OS bootstrap tests in parallel. This dramatically reduces test time from several hours down to 15-20 minutes, making this test suitable for regression suite.

This test allocates available nodes to test cases then runs all of them. 8 nodes are required to run all of the existing test cases. If there are less than 8 nodes, tests will be skipped. Note that Redfish API currently only supports ESXi, CentOS, and RHEL. Tests for other OSs will be added when Redfish API is updated.

Most of the work in this script is done in the classSetUp routine. The test methods are just polling loops to wait for completion of the associated workflow and assert on fail.

@hohene @jimturnquist @larry-dean @stuart-stanley @johren
