### PR TITLE
Updates to RackHD/test to cleanup module pathing.

### DIFF
--- a/test/common/fit_common.py
+++ b/test/common/fit_common.py
@@ -9,6 +9,7 @@ This is the main common function library for OnRack/RackHD FIT tests.
 '''
 
 # Standard imports
+import fit_path  # NOQA: unused import
 import os
 import sys
 import json
@@ -26,8 +27,6 @@ import inspect
 import nose
 import argparse
 from mkcfg import mkcfg
-
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test")
 
 VERBOSITY = 1
 TEST_PATH = None
@@ -239,7 +238,7 @@ def add_globals():
             API_PORT = '8080'
 
     # add globals section to base configuration
-    TEST_PATH = subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/"
+    TEST_PATH = fit_path.fit_path_root + '/'
     CONFIG_PATH = TEST_PATH + fitargs()['config'] + "/"
     mkcfg().add_from_dict({
         'globals': {
@@ -1157,7 +1156,8 @@ def run_nose(nosepath=None):
         env = {
             'FIT_CONFIG': mkcfg().get_path(),
             'HOME': os.environ['HOME'],
-            'PATH': os.environ['PATH']
+            'PATH': os.environ['PATH'],
+            'PYTHONPATH': ':'.join(sys.path)
         }
         argv = ['nosetests']
         argv.extend(noseopts)

--- a/test/common/test_api_utils.py
+++ b/test/common/test_api_utils.py
@@ -9,9 +9,9 @@
  This utility library contain helper functions for parsing response data from the RackHD APIs.
 """
 
+import fit_path  # NOQA: unused import
 import sys
 import subprocess
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/common")
 import fit_common
 
 import unicodedata

--- a/test/deploy/os_ova_install.py
+++ b/test/deploy/os_ova_install.py
@@ -13,11 +13,10 @@ usage:
     python run_tests.py -stack <stack ID> -test deploy/os_ova_install.py
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 import pdu_lib
 

--- a/test/deploy/rackhd_package_install.py
+++ b/test/deploy/rackhd_package_install.py
@@ -18,11 +18,11 @@ usage:
     python run_tests.py -stack <stack ID> -test deploy/rackhd_package_install.py
 '''
 
+import fit_path  # NOQA: unused import
+
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # set proxy if required

--- a/test/deploy/rackhd_source_install.py
+++ b/test/deploy/rackhd_source_install.py
@@ -20,11 +20,10 @@ usage:
     python run_tests.py -stack <stack ID> -test deploy/rackhd_source_install.py
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # set proxy if required

--- a/test/deploy/rackhd_stack_init.py
+++ b/test/deploy/rackhd_stack_init.py
@@ -16,14 +16,13 @@ This script initializes RackHD stack after install.
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
 import json
 import time
 import unittest
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 import pdu_lib
 

--- a/test/deploy/run_rackhd_installer.py
+++ b/test/deploy/run_rackhd_installer.py
@@ -7,11 +7,10 @@ George Paulos
 This wrapper script installs RackHD into the selected stack and runs the stack init routine, no tests
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 class rackhd_installer(fit_common.unittest.TestCase):

--- a/test/deploy/run_rackhd_smoke_test.py
+++ b/test/deploy/run_rackhd_smoke_test.py
@@ -7,11 +7,10 @@ George Paulos
 This wrapper script installs RackHD and runs Smoke Test.
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 class rackhd_smoke_test(fit_common.unittest.TestCase):

--- a/test/fit_path/__init__.py
+++ b/test/fit_path/__init__.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+fit_path_root = os.path.dirname(os.path.abspath(__file__ + '/..'))
+sys.path.append(fit_path_root)
+sys.path.append(os.path.join(fit_path_root, 'common'))

--- a/test/fit_path/setup.py
+++ b/test/fit_path/setup.py
@@ -1,0 +1,18 @@
+try:
+    import ez_setup
+    ez_setup.use_setuptools()
+except ImportError:
+    pass
+
+from setuptools import setup
+
+setup(
+    name='fit test pathing',
+    version='0.1',
+    author='James Turnquist',
+    author_email='james.turnquist@dell.com',
+    description='setup pathing for RackHD/test',
+    license='Apache 2.0',
+    packages=[],
+    entry_points={}
+)

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -23,6 +23,7 @@ urllib3==1.19.1
 # WARNING: do not just replace this file with "pip freeze > requirements.txt".
 # You need to keep the following line as is! (freeze will turn it into
 # a https/git reference)
+-e fit_path
 -e stream-monitor
 
 # WARNING: there is an ubuntu bug that causes a bad package to get listed when doing a freeze.

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -8,10 +8,10 @@ George Paulos
 '''
 
 # set path to common libraries
+import fit_path  # NOQA: unused import
 import sys
 import subprocess
 
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # validate command line args

--- a/test/templates/fit_test_template.py
+++ b/test/templates/fit_test_template.py
@@ -12,8 +12,7 @@ It also shows an example of using the unittest class method.
 It also shows examples of using dependencies between tests with nosedep.
 '''
 
-import sys
-import subprocess
+import fit_path  # NOQA: unused import
 import unittest
 from json import dumps
 
@@ -26,8 +25,6 @@ from nosedep import depends
 # Import the logging feature
 import flogging
 
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test")
 from common import fit_common
 
 # set up the logging

--- a/test/templates/run_wrapper_template.py
+++ b/test/templates/run_wrapper_template.py
@@ -6,12 +6,8 @@ Author(s):
 FIT test wrapper script template
 '''
 
-import sys
-import subprocess
+import fit_path  # NOQA: unused import
 import unittest
-
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test")
 
 from common import fit_common
 

--- a/test/tests/api-cit/v2_0/nodes_tests_fit.py
+++ b/test/tests/api-cit/v2_0/nodes_tests_fit.py
@@ -3,12 +3,10 @@ Copyright 2016, EMC, Inc.
 
 Author(s):
 '''
+import fit_path  # NOQA: unused import
 import sys
 import subprocess
 import json
-
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test")
 
 import unittest
 from common import fit_common

--- a/test/tests/bootstrap/test_redfish10_os_bootstrap_base.py
+++ b/test/tests/bootstrap/test_redfish10_os_bootstrap_base.py
@@ -42,13 +42,12 @@ The "server' URL points to the location of the OS executables in an image reposi
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
 import random
 
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # This node catalog section will be replaced with fit_common.node_select() when it is checked in

--- a/test/tests/compute/test_rackhd11_computenode_pollers.py
+++ b/test/tests/compute/test_rackhd11_computenode_pollers.py
@@ -7,11 +7,10 @@ This test checks pollers under API 1.1
 '''
 
 
+import fit_path  # NOQA: unused import
 import sys
 import subprocess
 
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 import test_api_utils
 

--- a/test/tests/compute/test_rackhd20_computenode_pollers.py
+++ b/test/tests/compute/test_rackhd20_computenode_pollers.py
@@ -7,11 +7,10 @@ This test checks pollers under API 1.1
 '''
 
 
+import fit_path  # NOQA: unused import
 import sys
 import subprocess
 
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 import test_api_utils
 

--- a/test/tests/query/test_rackhd11_query.py
+++ b/test/tests/query/test_rackhd11_query.py
@@ -6,12 +6,11 @@ Author(s): George Paulos
 This tests the API 1.1 query feature
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
 
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 from nose.plugins.attrib import attr

--- a/test/tests/query/test_rackhd20_query.py
+++ b/test/tests/query/test_rackhd20_query.py
@@ -6,12 +6,11 @@ Author(s): George Paulos
 This tests the API 2.0 query feature
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
 
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 from nose.plugins.attrib import attr

--- a/test/tests/rackhd11/test_rackhd11_api_catalogs.py
+++ b/test/tests/rackhd11/test_rackhd11_api_catalogs.py
@@ -6,10 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 import flogging
 

--- a/test/tests/rackhd11/test_rackhd11_api_config.py
+++ b/test/tests/rackhd11/test_rackhd11_api_config.py
@@ -6,11 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd11/test_rackhd11_api_files.py
+++ b/test/tests/rackhd11/test_rackhd11_api_files.py
@@ -6,11 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd11/test_rackhd11_api_lookups.py
+++ b/test/tests/rackhd11/test_rackhd11_api_lookups.py
@@ -6,11 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd11/test_rackhd11_api_misc.py
+++ b/test/tests/rackhd11/test_rackhd11_api_misc.py
@@ -6,11 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd11/test_rackhd11_api_nodes.py
+++ b/test/tests/rackhd11/test_rackhd11_api_nodes.py
@@ -6,11 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 

--- a/test/tests/rackhd11/test_rackhd11_api_obms.py
+++ b/test/tests/rackhd11/test_rackhd11_api_obms.py
@@ -6,11 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd11/test_rackhd11_api_pollers.py
+++ b/test/tests/rackhd11/test_rackhd11_api_pollers.py
@@ -6,11 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 

--- a/test/tests/rackhd11/test_rackhd11_api_profiles.py
+++ b/test/tests/rackhd11/test_rackhd11_api_profiles.py
@@ -6,11 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd11/test_rackhd11_api_schemas.py
+++ b/test/tests/rackhd11/test_rackhd11_api_schemas.py
@@ -6,11 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd11/test_rackhd11_api_skus.py
+++ b/test/tests/rackhd11/test_rackhd11_api_skus.py
@@ -6,11 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd11/test_rackhd11_api_tags.py
+++ b/test/tests/rackhd11/test_rackhd11_api_tags.py
@@ -6,11 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Local methods

--- a/test/tests/rackhd11/test_rackhd11_api_templates.py
+++ b/test/tests/rackhd11/test_rackhd11_api_templates.py
@@ -6,10 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd11/test_rackhd11_api_workflows.py
+++ b/test/tests/rackhd11/test_rackhd11_api_workflows.py
@@ -6,11 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 

--- a/test/tests/rackhd20/test_rackhd20_api_catalogs.py
+++ b/test/tests/rackhd20/test_rackhd20_api_catalogs.py
@@ -6,10 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 

--- a/test/tests/rackhd20/test_rackhd20_api_config.py
+++ b/test/tests/rackhd20/test_rackhd20_api_config.py
@@ -6,11 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd20/test_rackhd20_api_dhcp.py
+++ b/test/tests/rackhd20/test_rackhd20_api_dhcp.py
@@ -6,11 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Local methods

--- a/test/tests/rackhd20/test_rackhd20_api_files.py
+++ b/test/tests/rackhd20/test_rackhd20_api_files.py
@@ -6,11 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd20/test_rackhd20_api_lookups.py
+++ b/test/tests/rackhd20/test_rackhd20_api_lookups.py
@@ -6,11 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd20/test_rackhd20_api_misc.py
+++ b/test/tests/rackhd20/test_rackhd20_api_misc.py
@@ -6,11 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd20/test_rackhd20_api_nodes.py
+++ b/test/tests/rackhd20/test_rackhd20_api_nodes.py
@@ -6,11 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 

--- a/test/tests/rackhd20/test_rackhd20_api_obms.py
+++ b/test/tests/rackhd20/test_rackhd20_api_obms.py
@@ -6,11 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 

--- a/test/tests/rackhd20/test_rackhd20_api_pollers.py
+++ b/test/tests/rackhd20/test_rackhd20_api_pollers.py
@@ -6,11 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 

--- a/test/tests/rackhd20/test_rackhd20_api_profiles.py
+++ b/test/tests/rackhd20/test_rackhd20_api_profiles.py
@@ -6,11 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd20/test_rackhd20_api_schemas.py
+++ b/test/tests/rackhd20/test_rackhd20_api_schemas.py
@@ -6,11 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd20/test_rackhd20_api_skus.py
+++ b/test/tests/rackhd20/test_rackhd20_api_skus.py
@@ -6,11 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd20/test_rackhd20_api_tags.py
+++ b/test/tests/rackhd20/test_rackhd20_api_tags.py
@@ -6,11 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Local methods

--- a/test/tests/rackhd20/test_rackhd20_api_templates.py
+++ b/test/tests/rackhd20/test_rackhd20_api_templates.py
@@ -6,10 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd20/test_rackhd20_api_users.py
+++ b/test/tests/rackhd20/test_rackhd20_api_users.py
@@ -6,11 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd20/test_rackhd20_api_views.py
+++ b/test/tests/rackhd20/test_rackhd20_api_views.py
@@ -6,11 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/rackhd20/test_rackhd20_api_workflows.py
+++ b/test/tests/rackhd20/test_rackhd20_api_workflows.py
@@ -6,11 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 

--- a/test/tests/redfish10/test_redfish10_api_accountservice.py
+++ b/test/tests/redfish10/test_redfish10_api_accountservice.py
@@ -6,10 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/redfish10/test_redfish10_api_chassis.py
+++ b/test/tests/redfish10/test_redfish10_api_chassis.py
@@ -6,10 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 import json
 

--- a/test/tests/redfish10/test_redfish10_api_eventservice.py
+++ b/test/tests/redfish10/test_redfish10_api_eventservice.py
@@ -6,10 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/redfish10/test_redfish10_api_managers.py
+++ b/test/tests/redfish10/test_redfish10_api_managers.py
@@ -6,10 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/redfish10/test_redfish10_api_registries.py
+++ b/test/tests/redfish10/test_redfish10_api_registries.py
@@ -6,10 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/redfish10/test_redfish10_api_schemas.py
+++ b/test/tests/redfish10/test_redfish10_api_schemas.py
@@ -6,10 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/redfish10/test_redfish10_api_sessionservice.py
+++ b/test/tests/redfish10/test_redfish10_api_sessionservice.py
@@ -6,10 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 # Select test group here using @attr

--- a/test/tests/redfish10/test_redfish10_api_systems.py
+++ b/test/tests/redfish10/test_redfish10_api_systems.py
@@ -6,10 +6,10 @@ George Paulos
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 

--- a/test/tests/redfish10/test_redfish10_api_taskservice.py
+++ b/test/tests/redfish10/test_redfish10_api_taskservice.py
@@ -5,11 +5,11 @@ Copyright 2016, EMC, Inc.
 
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
 import json
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 

--- a/test/tests/redfish10/test_redfish10_system_reset_base.py
+++ b/test/tests/redfish10/test_redfish10_system_reset_base.py
@@ -5,6 +5,7 @@ Copyright 2016, EMC, Inc.
            and verify the task status is correct and the power command occurs
 
 '''
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
@@ -12,7 +13,6 @@ import time
 import string
 import json
 
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 import test_api_utils
 

--- a/test/tests/switch/test_rackhd11_switch_pollers.py
+++ b/test/tests/switch/test_rackhd11_switch_pollers.py
@@ -6,12 +6,11 @@ Author(s):
 FIT test script template
 '''
 
+import fit_path  # NOQA: unused import
 import sys
 import subprocess
 import pprint
 
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 import test_api_utils
 

--- a/test/tests/switch/test_rackhd11_switch_telemetry.py
+++ b/test/tests/switch/test_rackhd11_switch_telemetry.py
@@ -6,13 +6,12 @@ Author(s):
 Test for switch telemetry.
 '''
 
+import fit_path  # NOQA: unused import
 import sys
 import subprocess
 import json
 import time
 
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 

--- a/test/tests/switch/test_rackhd20_switch_pollers.py
+++ b/test/tests/switch/test_rackhd20_switch_pollers.py
@@ -6,12 +6,11 @@ Author(s):
 FIT test script template
 '''
 
+import fit_path  # NOQA: unused import
 import sys
 import subprocess
 import pprint
 
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 import test_api_utils
 

--- a/test/tests/switch/test_rackhd20_switch_telemetry.py
+++ b/test/tests/switch/test_rackhd20_switch_telemetry.py
@@ -6,13 +6,12 @@ Author(s):
 Test for switch telemetry.
 '''
 
+import fit_path  # NOQA: unused import
 import sys
 import subprocess
 import json
 import time
 
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 

--- a/test/util/display_SYSINFO_settings.py
+++ b/test/util/display_SYSINFO_settings.py
@@ -5,12 +5,11 @@
   This script will generate a list of discovered nodes and display the system information for the nodes 
 """
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
 
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 import test_api_utils
 

--- a/test/util/display_node_FIRMWARE_versions.py
+++ b/test/util/display_node_FIRMWARE_versions.py
@@ -5,14 +5,13 @@
 This is a utility to  display variuos node firmware and manufacturer info.
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
 import json
 import pprint
 
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 import test_api_utils
 

--- a/test/util/display_rackhd_nodes.py
+++ b/test/util/display_rackhd_nodes.py
@@ -8,15 +8,13 @@
 
 #pylint: disable=relative-import
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
 import json
 import pprint
 from nosedep import depends
-
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 import test_api_utils
 

--- a/test/util/load_sku_packs.py
+++ b/test/util/load_sku_packs.py
@@ -6,12 +6,11 @@ Author(s):
 This script load SKU packs from sources specified in install_default.json
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
 
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 from nose.plugins.attrib import attr

--- a/test/util/node_list.py
+++ b/test/util/node_list.py
@@ -7,12 +7,11 @@ Author(s):
 George Paulos
 '''
 
+import fit_path  # NOQA: unused import
 import os
 import sys
 import subprocess
 import argparse
-# set path to common libraries
-sys.path.append(subprocess.check_output("git rev-parse --show-toplevel", shell=True).rstrip("\n") + "/test/common")
 import fit_common
 
 


### PR DESCRIPTION
RAC-4178 Updates to RackHD/test to cleanup module pathing.

Standardized how RackHD/test finds test and test/common.  This
elimintates the need for inlined 'git-rev-parse' style statements
throughout the code.  Doing the following in an individual test
will set up the module pathing

import fit_path  # NOQA: unused import

The # NOQA: comment at the end of the line is to make pyflakes
not complain about the import appearing to be unused.

At stuart stanley's suggestion, 'git' was removed altogether
as a dependency for creating import pathing.  Thanks Stuart!