### PR TITLE
RAC-4205 cleanup stream monitor hound errors

### DIFF
--- a/test/mkcheck.sh
+++ b/test/mkcheck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2017, EMC, Inc.
+# Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 
 # Run code checks (pylint, flake8, etc)
 #

--- a/test/stream-monitor/flogging/infra_logging.py
+++ b/test/stream-monitor/flogging/infra_logging.py
@@ -1,5 +1,5 @@
 """
-Copyright 2016, EMC, Inc.
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 
 This file contains the mechanisms to do logging from within
 the test infrastructure.
@@ -16,11 +16,11 @@ import gevent
 import os
 import errno
 import shutil
-import sys
 
 
 class _GeventInfoFilter(logging.Filter):
     _main_greenlet = gevent.getcurrent()
+
     def __init__(self, *args, **kwargs):
         super(_GeventInfoFilter, self).__init__(*args, **kwargs)
 
@@ -37,7 +37,6 @@ class _GeventInfoFilter(logging.Filter):
     #  and log shortening event (to keep abs context)
     # todo: add logger name to output
     def filter(self, record):
-        pname = record.pathname
         if record.pathname.startswith(self.__path_trim):
             record.pathname = record.pathname[len(self.__path_trim):]
         cur = gevent.getcurrent()
@@ -47,24 +46,27 @@ class _GeventInfoFilter(logging.Filter):
             gname = getattr(cur, 'log_facility', str(cur))
         record.greenlet = '{0!s}'.format(gname)
 
-        # This section removes the process, path, and greenlet information 
-        # from any mssage that starts with any of the characters ' +-'. 
+        # This section removes the process, path, and greenlet information
+        # from any mssage that starts with any of the characters ' +-'.
         # These are well known stream monitor messages and this informtion
         # is not required to be displayed.
         # TODO: there is probably a better way to do this but this will
         #       work until it is setup.
         if any(elem in record.msg[0] for elem in r' +-?%'):
-            record.location_info_string = ''
-        else:    
-            record.location_info_string = '{r.process} {r.processName} {r.pathname}:{r.funcName}@{r.lineno} {r.greenlet}'.format(r=record)
+            lif = ''
+        else:
+            lif = '{r.process} {r.processName} {r.pathname}:{r.funcName}@{r.lineno} {r.greenlet}'.format(r=record)
+        record.location_info_string = lif
 
         return True
 
     def __str__(self):
         return 'infra-context-adding-filter'
 
+
 class _LevelLoggerClass(Logger):
     _log_call_matcher = re.compile(r'''^(?P<base>[a-zA-Z]\w*?)_(?P<post_num>\d)$''')
+
     def __getattr__(self, key):
         """
         We intercept getattrs and map look for entries of the form:
@@ -117,7 +119,8 @@ class _LevelLoggerClass(Logger):
 
 
 class _LoggerSetup(object):
-    _SAVED_LOGDIR_COUNT=10
+    _SAVED_LOGDIR_COUNT = 10
+
     def __init__(self):
         self.__prelog_data = []
         self.__do_dirs()
@@ -128,7 +131,7 @@ class _LoggerSetup(object):
             lg.log(level, fmat, *args, **kwargs)
 
     def __prelog(self, level, fmat, *args, **kwargs):
-        self.__prelog_data.append( (level, fmat, args, kwargs) )
+        self.__prelog_data.append((level, fmat, args, kwargs))
 
     def __makedirs_dash_p(self, *args, **kwargs):
         try:
@@ -195,7 +198,7 @@ class _LoggerSetup(object):
 
     def __do_level_names(self):
         lvl_copy = dict(_levelNames)
-        for adj in xrange(0,10):
+        for adj in xrange(0, 10):
             for lvl_key, lvl_value in lvl_copy.items():
                 if isinstance(lvl_key, str) and lvl_key != 'NOTSET':
                     new_name = "{0}_{1}".format(lvl_key, adj)
@@ -214,7 +217,7 @@ class _LoggerSetup(object):
             'version': 1,
             'filters': {
                 'ctx_add_filter': {
-                    '()' : _GeventInfoFilter
+                    '()': _GeventInfoFilter
                 }
             },
             'handlers': {
@@ -315,7 +318,7 @@ class _LoggerSetup(object):
         }
         logging.config.dictConfig(cdict)
         # And squelch the annoying root level urllib messages!
-        # (you do need both, alas). 
+        # (you do need both, alas).
         # todo: record this traffic in its own logfile?
         logging.getLogger("urllib3").setLevel(logging.WARNING)
         logging.getLogger("requests").setLevel(logging.WARNING)
@@ -340,6 +343,7 @@ class _LoggerSetup(object):
 
 setLoggerClass(_LevelLoggerClass)
 
+
 def getLogger(name=None):
     if name is None:
         rl = logging.getLogger()
@@ -347,30 +351,39 @@ def getLogger(name=None):
         rl = logging.getLogger(name)
     return rl
 
+
 def _getLoggerBase(names, name):
     if name is not None:
         names.append(name)
     return getLogger('.'.join(names))
 
+
 def getInfraRunLogger(name=None):
     return _getLoggerBase(['infra', 'run'], name)
+
 
 def getInfraDataLogger(name=None):
     return _getLoggerBase(['infra', 'data'], name)
 
+
 def getTestRunLogger(name=None):
     return _getLoggerBase(['test', 'run'], name)
+
 
 def getTestDataLogger(name=None):
     return _getLoggerBase(['test', 'data'], name)
 
+
 _logger_setup_instance = _LoggerSetup()
+
 
 def logger_reset_configuration():
     _logger_setup_instance.reset_configuration()
 
+
 def logger_config_api(verbosity):
     _logger_setup_instance.set_level(verbosity)
+
 
 def logger_get_logging_dir():
     return _logger_setup_instance.get_logging_dir()

--- a/test/stream-monitor/flogging/infra_logopts.py
+++ b/test/stream-monitor/flogging/infra_logopts.py
@@ -1,11 +1,12 @@
 """
-Copyright 2017, EMC, Inc.
+Copyright (c) 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 """
 import logging
 import re
 import argparse
 import optparse
 import sys
+
 
 class _LoggingConfigFilter(logging.Filter):
     """
@@ -48,6 +49,7 @@ class _LoggingConfigFilter(logging.Filter):
             self.__levelno, self.__which_loggers, self.__unmatched_levelno)
         return rs
 
+
 class _ArgparseToOptparseWrapper(object):
     def __init__(self, parser):
         """
@@ -69,6 +71,7 @@ class _ArgparseToOptparseWrapper(object):
     def error(self, message):
         print >>sys.stderr, message
         sys.exit(2)
+
 
 class LoggerArgParseHelper(object):
     def __init__(self, parser):
@@ -110,8 +113,7 @@ class LoggerArgParseHelper(object):
         set_group.add_argument(
             '--sm-set-file-level', nargs=3, dest='set_file_level',
             metavar=('file-pattern', '[handler-name[:logger-name] [level-name-or-value]]'),
-            help="Same as --sm-set-combo-level, but restricts the change in output to only the files that match the file-pattern")
-
+            help="Same as --sm-set-combo-level, but restricts the change in output to the files that match the file-pattern")
 
     def __display_filter(self, indent, filter, detail):
         """
@@ -133,7 +135,7 @@ class LoggerArgParseHelper(object):
             indent_txt, handler.get_name(), handler.__class__.__name__,
             handler.level, extra_info)
         for filter in handler.filters:
-            self.__display_filter(indent+1, filter, detail)
+            self.__display_filter(indent + 1, filter, detail)
 
     def __recurse_list(self, indent, logger, detail):
         """
@@ -143,12 +145,12 @@ class LoggerArgParseHelper(object):
         indent_txt = ' ' * indent
         print >>sys.stderr, 'L{0}{1}: level={2}'.format(indent_txt, logger.name, logger.level)
         for handler in logger.handlers:
-            self.__display_handler(indent+1, handler, detail)
+            self.__display_handler(indent + 1, handler, detail)
         for lg_name, lg_obj in logging.Logger.manager.loggerDict.items():
             if isinstance(lg_obj, logging.PlaceHolder):
                 continue
             if lg_obj.parent == logger:
-                self.__recurse_list(indent+3, lg_obj, detail)
+                self.__recurse_list(indent + 3, lg_obj, detail)
 
     def __do_list(self, detail):
         """
@@ -170,7 +172,8 @@ class LoggerArgParseHelper(object):
             else:
                 valid_names.append(lv_key)
 
-        self.__parser.error("Invalid level '{0}'. Valid numbers: {1}, names: {2}".format(
+        self.__parser.error(
+            "Invalid level '{0}'. Valid numbers: {1}, names: {2}".format(
                 level_arg, valid_nums, valid_names))
 
     def __parse_level(self, level):
@@ -218,7 +221,8 @@ class LoggerArgParseHelper(object):
                 logger_list.append(lg_obj)
 
         if len(logger_list) == 0:
-            self.__parser.error("Could not locate any loggers matching '{0}'".format(
+            self.__parser.error(
+                "Could not locate any loggers matching '{0}'".format(
                     search_lg_name))
         return logger_list
 
@@ -276,7 +280,7 @@ class LoggerArgParseHelper(object):
         orig_level = handler.level
         name = 'Filter({0}@{1})'.format(for_names, levelno)
         filter = _LoggingConfigFilter(for_names, levelno, orig_level, name,
-                                      file_pat = file_pat)
+                                      file_pat=file_pat)
         handler.addFilter(filter)
         handler.setLevel(logging.NOTSET)
 

--- a/test/stream-monitor/flogging/logger_sets.py
+++ b/test/stream-monitor/flogging/logger_sets.py
@@ -1,8 +1,8 @@
 """
-Copyright 2017, EMC, Inc.
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 """
 
-# todo: document API (especially for common aka test-writer actor)
+
 class _LoggerSet(object):
     def __init__(self, name=None):
         from .infra_logging import getInfraRunLogger, getInfraDataLogger, getTestRunLogger, getTestDataLogger
@@ -29,4 +29,3 @@ class _LoggerSet(object):
 def get_loggers(name=None):
     # todo: auto-push test-file name into the name of the logger
     return _LoggerSet(name=name)
-

--- a/test/stream-monitor/setup.py
+++ b/test/stream-monitor/setup.py
@@ -1,5 +1,5 @@
 """
-todo: add
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 """
 try:
     import ez_setup
@@ -13,13 +13,13 @@ setup(
     name='stream monitors',
     version='0.1',
     author='Stuart Stanley',
-    author_email = 'stuart.stanley@dell.com',
-    description = 'Stream-monitors and test-log-groupers',
-    license = 'Apache 2.0',
-    packages = ['sm_plugin', 'stream_sources', 'flogging'],
-    entry_points = {
+    author_email='stuart.stanley@dell.com',
+    description='Stream-monitors and test-log-groupers',
+    license='Apache 2.0',
+    packages=['sm_plugin', 'stream_sources', 'flogging'],
+    entry_points={
         'nose.plugins.0.10': [
-            'stream_monitor = sm_plugin:StreamMonitorPlugin'
-            ]
-        }
-    )
+            'stream_monitor=sm_plugin:StreamMonitorPlugin'
+        ]
+    }
+)

--- a/test/stream-monitor/sm_plugin/__init__.py
+++ b/test/stream-monitor/sm_plugin/__init__.py
@@ -1,3 +1,6 @@
+"""
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+"""
 from stream_monitor import StreamMonitorPlugin, smp_get_stream_monitor_plugin
 
-__all__ = [ 'StreamMonitorPlugin', 'smp_get_stream_monitor_plugin' ]
+__all__ = ['StreamMonitorPlugin', 'smp_get_stream_monitor_plugin']

--- a/test/stream-monitor/sm_plugin/stream_monitor.py
+++ b/test/stream-monitor/sm_plugin/stream_monitor.py
@@ -1,3 +1,6 @@
+"""
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+"""
 import logging
 import os
 from nose.plugins import Plugin
@@ -10,10 +13,12 @@ from StringIO import StringIO
 from logging import ERROR, WARNING
 from flogging import LoggerArgParseHelper
 
+
 class StreamMonitorPlugin(Plugin):
     _singleton = None
     name = "stream-monitor"
     encoding = 'UTF-8'
+
     def __init__(self, *args, **kwargs):
         assert StreamMonitorPlugin._singleton is None, \
             "infrastructure fault: more than one StreamMonitorPlugin exists"
@@ -58,7 +63,7 @@ class StreamMonitorPlugin(Plugin):
 
     def configure(self, options, conf):
         self.__take_step('configure', options=options, conf=conf)
-        super(StreamMonitorPlugin, self).configure(options,conf)
+        super(StreamMonitorPlugin, self).configure(options, conf)
         if not self.enabled:
             return
         if getattr(conf.options, 'collect_only', False):
@@ -117,7 +122,7 @@ class StreamMonitorPlugin(Plugin):
         in the context of looking at a single test, it's really annoying. So, this logic
         is stolen from the xunit plugin (which does capture better than capture!). We are
         basically tucking away stdout/stderrs while letting the data flow to prior levels
-        using the Tee. 
+        using the Tee.
         """
         self.__capture_stack.append((sys.stdout, sys.stderr))
         self.__current_stdout = StringIO()
@@ -188,7 +193,7 @@ class StreamMonitorPlugin(Plugin):
 
 def smp_get_stream_monitor_plugin():
     """
-    Get the plugin that nose will have created. ONLY nose should 
+    Get the plugin that nose will have created. ONLY nose should
     create the main instance!
     """
     smp = StreamMonitorPlugin.get_singleton_instance()

--- a/test/stream-monitor/stream_sources/__init__.py
+++ b/test/stream-monitor/stream_sources/__init__.py
@@ -1,1 +1,6 @@
+"""
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+"""
 from log_type import LoggingMarker
+
+__all__ = [LoggingMarker]

--- a/test/stream-monitor/stream_sources/log_type.py
+++ b/test/stream-monitor/stream_sources/log_type.py
@@ -1,9 +1,11 @@
-from logging import Logger, DEBUG, INFO, getLoggerClass
+"""
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+"""
+from logging import Logger, DEBUG, INFO
 from logging import getLogger as real_getLogger
 from logging import _srcfile  # yes, this is evil. No, we don't have a choice.
 from .monitor_abc import StreamMonitorABC
 import sys
-from itertools import count
 
 
 class LoggingMarker(StreamMonitorABC):
@@ -43,13 +45,13 @@ class LoggingMarker(StreamMonitorABC):
         self.__mark_all_loggers('', ' Start Of Test Block: {}'.format(self._all_blocks))
 
     def handle_start_test(self, test):
-        self.__mark_all_loggers('', 
-                                '+{0}.{1:02d} - STARTING TEST: %s'.format(self._all_blocks, self.__test_cnt), 
+        self.__mark_all_loggers('',
+                                '+{0}.{1:02d} - STARTING TEST: %s'.format(self._all_blocks, self.__test_cnt),
                                 str(test))
 
     def handle_stop_test(self, test):
-        self.__mark_all_loggers('', 
-                                '-{0}.{1:02d} - ENDING TEST: %s'.format(self._all_blocks, self.__test_cnt), 
+        self.__mark_all_loggers('',
+                                '-{0}.{1:02d} - ENDING TEST: %s'.format(self._all_blocks, self.__test_cnt),
                                 str(test))
         self.__test_cnt += 1
 
@@ -59,9 +61,9 @@ class LoggingMarker(StreamMonitorABC):
         if len(handlers) == 0:
             return  # Nothing to do!
         if _srcfile:
-            #IronPython doesn't track Python frames, so findCaller raises an
-            #exception on some versions of IronPython. We trap it here so that
-            #IronPython can use logging.
+            # IronPython doesn't track Python frames, so findCaller raises an
+            # exception on some versions of IronPython. We trap it here so that
+            # IronPython can use logging.
             try:
                 fn, lno, func = logger.findCaller()
             except ValueError:
@@ -119,7 +121,7 @@ class LoggingMarker(StreamMonitorABC):
         if bracket:
             # rep_cnt is used to fill in about X (20) chars with the repeated
             # text.
-            rep_cnt = int(20/len(bracket))
+            rep_cnt = int(20 / len(bracket))
             self.__mark_all_in_logger(level, logger, bracket * rep_cnt, [])
             self.__mark_all_in_logger(level, logger, fmat, args, **kwargs)
             self.__mark_all_in_logger(level, logger, bracket * rep_cnt, [])
@@ -159,4 +161,3 @@ class LoggingMarker(StreamMonitorABC):
                 observed_loggers[lg_name] = logger
 
         return observed_loggers
-

--- a/test/stream-monitor/test/log_stream_helper.py
+++ b/test/stream-monitor/test/log_stream_helper.py
@@ -1,9 +1,10 @@
 """
-Copyright 2017, EMC, Inc.
+Copyright (c) 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 """
 import os
 import re
 import logging
+
 
 class _TempLogfileObserver(object):
     """
@@ -63,7 +64,8 @@ class TempLogfileChecker(object):
     Crude logfile checker that holds the "business logic" to check for backtraces and
     capture stdout or stderr contents (or lack thereof!)
     """
-    def __init__(self, file_name, stringio_override = None):
+
+    def __init__(self, file_name, stringio_override=None):
         self.__lf_observer = _TempLogfileObserver(file_name, stringio_override)
         self.__file_name = file_name
 
@@ -129,11 +131,9 @@ class TempLogfileChecker(object):
                       '''
         if start_at_levelno is None:
             test_levelno = 1  # lowest legal value
-            info_base = 'not-matches-expected, lg_name={0}'.format(lg_name)
             exp_count = 0
         else:
             test_levelno = start_at_levelno
-            info_base = 'start_at_levelno={0}, lg_name={1}'.format(start_at_levelno, lg_name)
             # "CRITICAL_0" is our max log-value injected in makeSuite in test_logopts.pyh
             #  That -seems- backwards at first glance, but this is the -threshold- value we are
             #  working with normally. In this case, CRITICAL_0 will hold the highest possible int
@@ -144,8 +144,6 @@ class TempLogfileChecker(object):
         for match in self.__lf_observer.iter_on_re(line_re):
             count += 1
             test_level_name = levelno_to_name(test_levelno)
-            pass_info = '({0}, test_level_name={1}, test_levelno={2})'.format(
-                info_base, test_level_name, test_levelno)
             found_log_level_name = match.group("level")
             found_msg_logger_name = match.group("logger_name")
             found_msg_levelno = int(match.group("levelno"))
@@ -174,15 +172,15 @@ def levelno_to_name(levelno):
     for non-predefined levels.
 
     Each base name (DEBUG, INFO, etc) covers a range from base + 2 for base_0 to base - 7 for base_9.
-    Or more accuratlly: base + (2 - X) (where 'X' is the number from base_#. 
+    Or more accuratlly: base + (2 - X) (where 'X' is the number from base_#.
     For example debug_0 is 12 and debug_9 is 3.
     So first we want to isolate the tens digit for the range we are in to get the base...
     """
     # Add 7 to the levelno to shift into right ten's place (3->10 and 12->19)
-    adjusted_tens =    (7 + levelno) / 10
-    adjusted_base =    (adjusted_tens * 10)
+    adjusted_tens = (7 + levelno) / 10
+    adjusted_base = (adjusted_tens * 10)
     name = logging.getLevelName(adjusted_base)
-    # Now get the part to hang out after the '_'. 
+    # Now get the part to hang out after the '_'.
     remainder = (7 + levelno) % 10
     # and reverse because remainder is currently reversed vs range.
     remainder = 9 - remainder

--- a/test/stream-monitor/test/plugin_test_helper.py
+++ b/test/stream-monitor/test/plugin_test_helper.py
@@ -1,5 +1,8 @@
-import unittest, os
-import sys
+"""
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+"""
+import unittest
+import os
 from nose.plugins import PluginTester
 from sm_plugin import StreamMonitorPlugin
 
@@ -10,15 +13,17 @@ class _BaseStreamMonitorPluginTester(PluginTester, unittest.TestCase):
     _smp._self_test_print_step_enable()
     plugins = [_smp]
 
+
 class _BaseStreamMonitorPluginTesterVerify(_BaseStreamMonitorPluginTester):
     _expect_nose_success = True
+
     def runTest(self):
         # This is called once for each class derived from it. We don't really
         # have access to much other than success/failure and the raw string output
         # for -all- the tests that were run in the derived class.
 
         # We print out the output from the run tests, trusting in the capture
-        # code to hide it. 
+        # code to hide it.
         print '*' * 70
         for what in self.output:
             print ">", what.rstrip()
@@ -28,9 +33,8 @@ class _BaseStreamMonitorPluginTesterVerify(_BaseStreamMonitorPluginTester):
         # to mark that it expects an error to occur, and then let it handle its
         # own checking inside its verify)
         if self._expect_nose_success:
-            self.assertTrue(self.nose.success, 
+            self.assertTrue(self.nose.success,
                             '----a contained test or tests failed----')
-            
 
         self.__call_sequence = self._smp._self_test_sequence_seen()
         self.verify()
@@ -57,13 +61,15 @@ class _BaseStreamMonitorPluginTesterVerify(_BaseStreamMonitorPluginTester):
         self.__check_next('afterTest', ['test'], {'test': test_name})
 
     def _check_sequence_post_test(self):
-        log_dict = self.__check_next('finalize', ['result'])
+        # disable flake8 for log_dict not being used. The act of
+        # getting it makes sure it got filled in.
+        log_dict = self.__check_next('finalize', ['result'])  # noqa: F841
         # todo: poke into log_dict for run/errors/failures.
         # (it's like {'result': <nose.result.TextTestResult run=1 errors=0 failures=0>})
 
     def __check_next(self, step_name, required_keys, match_dict=None):
         if len(self.__call_sequence) == 0:
-            next_thing = ( 'no-more-steps-found', {} )
+            next_thing = ('no-more-steps-found', {})
         else:
             next_thing = self.__call_sequence[0]
             self.__call_sequence = self.__call_sequence[1:]
@@ -96,8 +102,10 @@ class _BaseStreamMonitorPluginTesterVerify(_BaseStreamMonitorPluginTester):
 def resolve_helper_class():
     return _BaseStreamMonitorPluginTesterVerify
 
+
 def resolve_no_verify_helper_class():
     return _BaseStreamMonitorPluginTester
+
 
 def resolve_suitepath(*args):
     support = os.path.join(os.path.dirname(__file__), 'support')

--- a/test/stream-monitor/test/support/stream-base/two_pass/test_two_pass.py
+++ b/test/stream-monitor/test/support/stream-base/two_pass/test_two_pass.py
@@ -1,5 +1,11 @@
+"""
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+"""
+
+
 def test_one_of_two_pass():
     pass
+
 
 def test_two_of_two_pass():
     pass

--- a/test/stream-monitor/test/support/stream-source/logging/backtrace/test_backtrace.py
+++ b/test/stream-monitor/test/support/stream-source/logging/backtrace/test_backtrace.py
@@ -1,5 +1,9 @@
+"""
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+"""
 import unittest
 from logging import getLogger
+
 
 class TestLoggerBacktrace(unittest.TestCase):
     def setUp(self):
@@ -8,5 +12,5 @@ class TestLoggerBacktrace(unittest.TestCase):
 
     def test_backtrace_from_oops(self):
         # the next statement will fail because "i_dont_exist" does not exist :)
-        _ = i_dont_exist
-
+        # the trailing comment makes it so flake doesn't error on it like it should.
+        _ = i_dont_exist  # noqa: F841,F821

--- a/test/stream-monitor/test/support/stream-source/logging/one_pass/test_one_log_pass.py
+++ b/test/stream-monitor/test/support/stream-source/logging/one_pass/test_one_log_pass.py
@@ -1,5 +1,9 @@
+"""
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+"""
 import unittest
 from logging import getLogger
+
 
 class TestOneLoggerTest(unittest.TestCase):
     def setUp(self):

--- a/test/stream-monitor/test/support/stream-source/logging/stderr_errcap/test_stderr_errcap.py
+++ b/test/stream-monitor/test/support/stream-source/logging/stderr_errcap/test_stderr_errcap.py
@@ -1,5 +1,9 @@
+"""
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+"""
 import unittest
 import sys
+
 
 class TestLoggerStderrError(unittest.TestCase):
     def setUp(self):
@@ -12,4 +16,3 @@ class TestLoggerStderrError(unittest.TestCase):
 
     def test_no_stderr_from_testcase(self):
         print >>sys.stderr, "STDERR-MUST-NOT-SEE: {0} test_no_stderr_from_testcase".format(self.__class__.__name__)
-

--- a/test/stream-monitor/test/support/stream-source/logging/stderr_failcap/test_stderr_failcap.py
+++ b/test/stream-monitor/test/support/stream-source/logging/stderr_failcap/test_stderr_failcap.py
@@ -1,5 +1,9 @@
+"""
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+"""
 import unittest
 import sys
+
 
 class TestLoggerStderrFail(unittest.TestCase):
     def setUp(self):
@@ -12,4 +16,3 @@ class TestLoggerStderrFail(unittest.TestCase):
 
     def test_no_stderr_from_testcase(self):
         print >>sys.stderr, "STDERR-MUST-NOT-SEE: {0} test_no_stderr_from_testcase".format(self.__class__.__name__)
-

--- a/test/stream-monitor/test/support/stream-source/logging/stderr_nocap/test_stderr_nocap.py
+++ b/test/stream-monitor/test/support/stream-source/logging/stderr_nocap/test_stderr_nocap.py
@@ -1,4 +1,8 @@
+"""
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+"""
 import unittest
+
 
 class TestLoggerStderrNoError(unittest.TestCase):
     # should not see anything from this class.
@@ -8,4 +12,3 @@ class TestLoggerStderrNoError(unittest.TestCase):
 
     def test_stderr_from_testcase(self):
         print "STDERR-MATCH-DATA: {0} test_stderr_from_testcase".format(self.__class__.__name__)
-

--- a/test/stream-monitor/test/support/stream-source/logging/stdout_errcap/test_stdout_errcap.py
+++ b/test/stream-monitor/test/support/stream-source/logging/stdout_errcap/test_stdout_errcap.py
@@ -1,4 +1,8 @@
+"""
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+"""
 import unittest
+
 
 class TestLoggerStdoutError(unittest.TestCase):
     def setUp(self):
@@ -11,4 +15,3 @@ class TestLoggerStdoutError(unittest.TestCase):
 
     def test_no_stdout_from_testcase(self):
         print "STDOUT-MUST-NOT-SEE: {0} test_no_stdout_from_testcase".format(self.__class__.__name__)
-

--- a/test/stream-monitor/test/support/stream-source/logging/stdout_failcap/test_stdout_failcap.py
+++ b/test/stream-monitor/test/support/stream-source/logging/stdout_failcap/test_stdout_failcap.py
@@ -1,4 +1,8 @@
+"""
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+"""
 import unittest
+
 
 class TestLoggerStdoutFail(unittest.TestCase):
     def setUp(self):
@@ -11,4 +15,3 @@ class TestLoggerStdoutFail(unittest.TestCase):
 
     def test_no_stdout_from_testcase(self):
         print "STDOUT-MUST-NOT-SEE: {0} test_no_stdout_from_testcase".format(self.__class__.__name__)
-

--- a/test/stream-monitor/test/support/stream-source/logging/stdout_nocap/test_stdout_nocap.py
+++ b/test/stream-monitor/test/support/stream-source/logging/stdout_nocap/test_stdout_nocap.py
@@ -1,4 +1,8 @@
+"""
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+"""
 import unittest
+
 
 class TestLoggerStdoutNoError(unittest.TestCase):
     # should not see anything from this class.
@@ -8,4 +12,3 @@ class TestLoggerStdoutNoError(unittest.TestCase):
 
     def test_stdout_from_testcase(self):
         print "STDOUT-MATCH-DATA: {0} test_stdout_from_testcase".format(self.__class__.__name__)
-

--- a/test/stream-monitor/test/support/stream-source/logging/two_pass/test_two_log_pass.py
+++ b/test/stream-monitor/test/support/stream-source/logging/two_pass/test_two_log_pass.py
@@ -1,5 +1,9 @@
+"""
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+"""
 import unittest
 from logging import getLogger
+
 
 class TestTwoLoggerTest(unittest.TestCase):
     def setUp(self):

--- a/test/stream-monitor/test/test_infra_logging.py
+++ b/test/stream-monitor/test/test_infra_logging.py
@@ -1,5 +1,5 @@
 """
-Copyright 2016, EMC, Inc.
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 
 This file contains (very very crude, at the moment!) self
 tests of the logging infrastructure.
@@ -7,6 +7,7 @@ tests of the logging infrastructure.
 from flogging.infra_logging import logger_get_logging_dir
 import os
 from unittest import TestCase
+
 
 class TestInfraLogging(TestCase):
     def test_canary(self):
@@ -30,7 +31,6 @@ class TestInfraLogging(TestCase):
         # broken links.
         self.assertTrue(os.path.exists(self.__lg_sym_path),
                         "'{0}' is a link that exists, but what it points to does not exist".format(self.__lg_sym_path))
-
 
     def test_symlink_is_relative(self):
         """test run_last.d symlink is relative and not absolute"""

--- a/test/stream-monitor/test/test_log_stream.py
+++ b/test/stream-monitor/test/test_log_stream.py
@@ -1,7 +1,7 @@
+"""
+Copyright (c) 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+"""
 import plugin_test_helper
-import os
-import re
-import sys
 from log_stream_helper import TempLogfileChecker
 
 
@@ -13,22 +13,24 @@ class TestSMPLoggingSingleOk(plugin_test_helper.resolve_helper_class()):
         self._check_sequence_test('test_single_log_to_run (test_one_log_pass.TestOneLoggerTest)')
         self._check_sequence_post_test()
 
+
 class TestSMPLoggingTwoOk(plugin_test_helper.resolve_helper_class()):
     suitepath = plugin_test_helper.resolve_suitepath('stream-source', 'logging', 'two_pass')
     _test_file = 'test_two_log_pass'
     _test_class = 'TestTwoLoggerTest'
-    _test_methods = ['test_one_of_two_to_run','test_two_of_two_to_run']
+    _test_methods = ['test_one_of_two_to_run', 'test_two_of_two_to_run']
 
     def verify(self):
         self._check_sequence_pre_test()
         self._check_sequences(self._test_methods, self._test_class, self._test_file)
         self._check_sequence_post_test()
 
+
 class _BacktraceBase(plugin_test_helper.resolve_helper_class()):
     """
     Kind of a first stab at a more general plugin tester. I want to use
     the same suitepath based test file, but I want to have a test for each
-    log file and so on. 
+    log file and so on.
 
     subclasses need to define klass._backtrace_finder_file and
     klass._backtrace_finger_count. This base class will verify that the
@@ -43,7 +45,7 @@ class _BacktraceBase(plugin_test_helper.resolve_helper_class()):
     def setUp(self):
         self.__logfile_checker = TempLogfileChecker(self._backtrace_finder_file)
         super(_BacktraceBase, self).setUp()
-        
+
     def verify(self):
         self.__logfile_checker.check_backtrace(
             self, 'ERROR', self.suitepath, self._test_class,
@@ -54,48 +56,57 @@ class _BacktraceBase(plugin_test_helper.resolve_helper_class()):
         self._check_sequences(self._test_methods, self._test_class, self._test_file)
         self._check_sequence_post_test()
 
+
 class TestSMPLoggingBacktrace_all_all_error(_BacktraceBase):
     _backtrace_finder_file = 'all_all.log'
     _backtrace_finder_count = 2
+
 
 class TestSMPLoggingBacktrace_infra_run_error(_BacktraceBase):
     _backtrace_finder_file = 'infra_run.log'
     _backtrace_finder_count = 1
 
+
 class TestSMPLoggingBacktrace_test_run_error(_BacktraceBase):
     _backtrace_finder_file = 'test_run.log'
     _backtrace_finder_count = 1
+
 
 class TestSMPLoggingBacktrace_infra_data_error(_BacktraceBase):
     _backtrace_finder_file = 'infra_data.log'
     _backtrace_finder_count = 0
 
+
 class TestSMPLoggingBacktrace_test_data_error(_BacktraceBase):
     _backtrace_finder_file = 'test_data.log'
     _backtrace_finder_count = 0
+
 
 class TestSMPLoggingBacktrace_console_capture_error(_BacktraceBase):
     _backtrace_finder_file = 'console_capture.log'
     _backtrace_finder_count = 1
 
+
 class _CaptureBase(plugin_test_helper.resolve_helper_class()):
     _capture_method = None
+
     def setUp(self):
         self.__logfile_checker = TempLogfileChecker(self._capture_finder_file)
         super(_CaptureBase, self).setUp()
-        
+
     def verify(self):
         if self._capture_method is None:
             cm = self._test_methods[0]  # default to first
         else:
             cm = self._capture_method
         self.__logfile_checker.check_capture(
-            self, self._capture_type, self._capture_level, self._test_class, cm, 
+            self, self._capture_type, self._capture_level, self._test_class, cm,
             self._capture_finder_count)
 
         self._check_sequence_pre_test()
         self._check_sequences(self._test_methods, self._test_class, self._test_file)
         self._check_sequence_post_test()
+
 
 class _StdoutNoCaptureBase(_CaptureBase):
     suitepath = plugin_test_helper.resolve_suitepath('stream-source', 'logging', 'stdout_nocap')
@@ -107,16 +118,27 @@ class _StdoutNoCaptureBase(_CaptureBase):
     _capture_finder_count = 0
     _expect_nose_success = False
 
+
 class TestSMPLoggingStdout_all_all_no_error(_StdoutNoCaptureBase):
     _capture_finder_file = 'all_all.log'
+
+
 class TestSMPLoggingStdout_infra_run_no_error(_StdoutNoCaptureBase):
     _capture_finder_file = 'infra_run.log'
+
+
 class TestSMPLoggingStdout_infra_data_no_error(_StdoutNoCaptureBase):
     _capture_finder_file = 'infra_data.log'
+
+
 class TestSMPLoggingStdout_test_run_no_error(_StdoutNoCaptureBase):
     _capture_finder_file = 'test_run.log'
+
+
 class TestSMPLoggingStdout_test_data_no_error(_StdoutNoCaptureBase):
     _capture_finder_file = 'test_data.log'
+
+
 class TestSMPLoggingStdout_console_capture_no_error(_StdoutNoCaptureBase):
     _capture_finder_file = 'console_capture.log'
 
@@ -131,24 +153,36 @@ class _StdoutErrCaptureBase(_CaptureBase):
     _capture_method = 'test_stdout_from_testcase'
     _expect_nose_success = False
 
+
 class TestSMPLoggingStdout_all_all_error(_StdoutErrCaptureBase):
     _capture_finder_file = 'all_all.log'
     _capture_finder_count = 2
+
+
 class TestSMPLoggingStdout_infra_run_error(_StdoutErrCaptureBase):
     _capture_finder_file = 'infra_run.log'
     _capture_finder_count = 1
+
+
 class TestSMPLoggingStdout_infra_data_error(_StdoutErrCaptureBase):
     _capture_finder_file = 'infra_data.log'
     _capture_finder_count = 0
+
+
 class TestSMPLoggingStdout_test_run_error(_StdoutErrCaptureBase):
     _capture_finder_file = 'test_run.log'
     _capture_finder_count = 1
-class TestSMPLoggingStdout_infra_data_error(_StdoutErrCaptureBase):
+
+
+class TestSMPLoggingStdout_test_data_error(_StdoutErrCaptureBase):
     _capture_finder_file = 'test_data.log'
     _capture_finder_count = 0
+
+
 class TestSMPLoggingStdout_console_capture_error(_StdoutErrCaptureBase):
     _capture_finder_file = 'console_capture.log'
     _capture_finder_count = 1
+
 
 class _StdoutFailCaptureBase(_CaptureBase):
     suitepath = plugin_test_helper.resolve_suitepath('stream-source', 'logging', 'stdout_failcap')
@@ -160,24 +194,36 @@ class _StdoutFailCaptureBase(_CaptureBase):
     _capture_method = 'test_stdout_from_testcase'
     _expect_nose_success = False
 
+
 class TestSMPLoggingStdout_all_all_fail(_StdoutFailCaptureBase):
     _capture_finder_file = 'all_all.log'
     _capture_finder_count = 2
+
+
 class TestSMPLoggingStdout_infra_run_fail(_StdoutFailCaptureBase):
     _capture_finder_file = 'infra_run.log'
     _capture_finder_count = 1
+
+
 class TestSMPLoggingStdout_infra_data_fail(_StdoutFailCaptureBase):
     _capture_finder_file = 'infra_data.log'
     _capture_finder_count = 0
+
+
 class TestSMPLoggingStdout_test_run_fail(_StdoutFailCaptureBase):
     _capture_finder_file = 'test_run.log'
     _capture_finder_count = 1
-class TestSMPLoggingStdout_infra_data_fail(_StdoutFailCaptureBase):
+
+
+class TestSMPLoggingStdout_test_data_fail(_StdoutFailCaptureBase):
     _capture_finder_file = 'test_data.log'
     _capture_finder_count = 0
+
+
 class TestSMPLoggingStdout_console_capture_fail(_StdoutFailCaptureBase):
     _capture_finder_file = 'console_capture.log'
     _capture_finder_count = 1
+
 
 class _StderrNoCaptureBase(_CaptureBase):
     suitepath = plugin_test_helper.resolve_suitepath('stream-source', 'logging', 'stderr_nocap')
@@ -189,16 +235,27 @@ class _StderrNoCaptureBase(_CaptureBase):
     _capture_finder_count = 0
     _expect_nose_success = False
 
+
 class TestSMPLoggingStderr_all_all_no_error(_StderrNoCaptureBase):
     _capture_finder_file = 'all_all.log'
+
+
 class TestSMPLoggingStderr_infra_run_no_error(_StderrNoCaptureBase):
     _capture_finder_file = 'infra_run.log'
+
+
 class TestSMPLoggingStderr_infra_data_no_error(_StderrNoCaptureBase):
     _capture_finder_file = 'infra_data.log'
+
+
 class TestSMPLoggingStderr_test_run_no_error(_StderrNoCaptureBase):
     _capture_finder_file = 'test_run.log'
+
+
 class TestSMPLoggingStderr_test_data_no_error(_StderrNoCaptureBase):
     _capture_finder_file = 'test_data.log'
+
+
 class TestSMPLoggingStderr_console_capture_no_error(_StderrNoCaptureBase):
     _capture_finder_file = 'console_capture.log'
 
@@ -213,24 +270,36 @@ class _StderrErrCaptureBase(_CaptureBase):
     _capture_method = 'test_stderr_from_testcase'
     _expect_nose_success = False
 
+
 class TestSMPLoggingStderr_all_all_error(_StderrErrCaptureBase):
     _capture_finder_file = 'all_all.log'
     _capture_finder_count = 2
+
+
 class TestSMPLoggingStderr_infra_run_error(_StderrErrCaptureBase):
     _capture_finder_file = 'infra_run.log'
     _capture_finder_count = 1
+
+
 class TestSMPLoggingStderr_infra_data_error(_StderrErrCaptureBase):
     _capture_finder_file = 'infra_data.log'
     _capture_finder_count = 0
+
+
 class TestSMPLoggingStderr_test_run_error(_StderrErrCaptureBase):
     _capture_finder_file = 'test_run.log'
     _capture_finder_count = 1
-class TestSMPLoggingStderr_infra_data_error(_StderrErrCaptureBase):
+
+
+class TestSMPLoggingStderr_test_data_error(_StderrErrCaptureBase):
     _capture_finder_file = 'test_data.log'
     _capture_finder_count = 0
+
+
 class TestSMPLoggingStderr_console_capture_error(_StderrErrCaptureBase):
     _capture_finder_file = 'console_capture.log'
     _capture_finder_count = 1
+
 
 class _StderrFailCaptureBase(_CaptureBase):
     suitepath = plugin_test_helper.resolve_suitepath('stream-source', 'logging', 'stderr_failcap')
@@ -242,22 +311,32 @@ class _StderrFailCaptureBase(_CaptureBase):
     _capture_method = 'test_stderr_from_testcase'
     _expect_nose_success = False
 
+
 class TestSMPLoggingStderr_all_all_fail(_StderrFailCaptureBase):
     _capture_finder_file = 'all_all.log'
     _capture_finder_count = 2
+
+
 class TestSMPLoggingStderr_infra_run_fail(_StderrFailCaptureBase):
     _capture_finder_file = 'infra_run.log'
     _capture_finder_count = 1
+
+
 class TestSMPLoggingStderr_infra_data_fail(_StderrFailCaptureBase):
     _capture_finder_file = 'infra_data.log'
     _capture_finder_count = 0
+
+
 class TestSMPLoggingStderr_test_run_fail(_StderrFailCaptureBase):
     _capture_finder_file = 'test_run.log'
     _capture_finder_count = 1
-class TestSMPLoggingStderr_infra_data_fail(_StderrFailCaptureBase):
+
+
+class TestSMPLoggingStderr_test_data_fail(_StderrFailCaptureBase):
     _capture_finder_file = 'test_data.log'
     _capture_finder_count = 0
+
+
 class TestSMPLoggingStderr_console_capture_fail(_StderrFailCaptureBase):
     _capture_finder_file = 'console_capture.log'
     _capture_finder_count = 1
-

--- a/test/stream-monitor/test/test_logopts.py
+++ b/test/stream-monitor/test/test_logopts.py
@@ -1,11 +1,9 @@
 """
-Copyright 2017, EMC, Inc.
+Copyright (c) 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 """
 import plugin_test_helper
-import os
-import re
 import sys
-from log_stream_helper import TempLogfileChecker, levelname_to_number
+from log_stream_helper import TempLogfileChecker
 import unittest
 import logging
 from StringIO import StringIO
@@ -16,7 +14,6 @@ class _Expector(object):
         """
         Simple class to automate some of the compare setups.
         """
-        at_levelno = levelname_to_number(at_level)
         self.at_level = at_level
         self.logger_name = use_logger
         self.expect_for_infra_run = None
@@ -95,7 +92,7 @@ class _OutputScannerBase(plugin_test_helper.resolve_no_verify_helper_class()):
             emit_levelno = logging.getLevelName(emit_level)
             expect_level = max(exp_levelno, emit_levelno)
         self.__lgfile_watchers[log_file].check_level_output(
-                self, expect_level, logger_name)
+            self, expect_level, logger_name)
 
     def test_infra_run_expected(self):
         self.__common_test_expected(
@@ -139,6 +136,7 @@ class _OutputScannerBase(plugin_test_helper.resolve_no_verify_helper_class()):
         We also 'publish' this class's expector, so the runTest method can see it.
         """
         expector = self._expector
+
         class TC(unittest.TestCase):
             def runTest(self):
                 """
@@ -164,28 +162,29 @@ set a different batch of command line args to nosetest, and define an
 "expector" to tell the inherited methods in _OutputScannerBase what to do and look for.
 """
 
+
 class OutputScannerBaseInfraRun(_OutputScannerBase):
-    args=[]
+    args = []
     _expector = _Expector('infra.run', 'DEBUG_5')
 
 
 class LevelsForAnOutputInfraRun(_OutputScannerBase):
-    args=['--sm-set-logger-level', 'infra.run', 'DEBUG_7']
+    args = ['--sm-set-logger-level', 'infra.run', 'DEBUG_7']
     _expector = _Expector('infra.run', 'DEBUG_7')
 
 
 class LevelsForAnOutputInfraData(_OutputScannerBase):
-    args=['--sm-set-logger-level', 'infra.data', 'DEBUG_9']
+    args = ['--sm-set-logger-level', 'infra.data', 'DEBUG_9']
     _expector = _Expector('infra.data', 'DEBUG_9')
 
 
 class LevelsForAnOutputTestRun(_OutputScannerBase):
-    args=['--sm-set-logger-level', 'test.run', 'WARNING_5']
+    args = ['--sm-set-logger-level', 'test.run', 'WARNING_5']
     _expector = _Expector('test.run', 'WARNING_5')
 
 
 class LevelsForAnOutputTestData(_OutputScannerBase):
-    args=['--sm-set-logger-level', 'test.data', 'INFO_9']
+    args = ['--sm-set-logger-level', 'test.data', 'INFO_9']
     _expector = _Expector('test.data', 'INFO_9')
 
 
@@ -194,8 +193,8 @@ class HandlerRemapForALogger(_OutputScannerBase):
     Note: this is paired with _OutputScannerBaseInfraRun, since that "proves" that
     by default, no debug is making it into log-capture. THIS lets the debugs out.
     """
-    args=['--sm-set-logger-level', 'infra.run', 'DEBUG_7',
-          '--sm-set-handler-level', 'console-capture', 'DEBUG_5']
+    args = ['--sm-set-logger-level', 'infra.run', 'DEBUG_7',
+            '--sm-set-handler-level', 'console-capture', 'DEBUG_5']
     _expector = _Expector('infra.run', 'DEBUG_7', concap_at='DEBUG_5')
 
 
@@ -206,19 +205,20 @@ class ComboRemapForALoggerSingleHandler(_OutputScannerBase):
     is basically the equiv of the combo of logger and handler levels set in
     HandlerRemapForALogger.
     """
-    args=['--sm-set-combo-level', 'console-capture', 'DEBUG_6']
+    args = ['--sm-set-combo-level', 'console-capture', 'DEBUG_6']
     _expector = _Expector('infra.run', 'DEBUG_6', concap_at='DEBUG_6')
+
 
 class ComboRemapForALoggerGlobHandlers(_OutputScannerBase):
     """
     Same as ComboRemapForALoggerSingleHandler, but we grab both console and
     console-capture handlers via wildcard.
     """
-    args=['--sm-set-combo-level', 'console*', 'DEBUG_8']
+    args = ['--sm-set-combo-level', 'console*', 'DEBUG_8']
     _expector = _Expector('infra.run', 'DEBUG_8', concap_at='DEBUG_8', real_at='DEBUG_8')
 
 
 class SetFileLevelTestAtD7(_OutputScannerBase):
-    args=['--sm-set-file-level', 'test_logopts.py', '*', 'DEBUG_7']
+    args = ['--sm-set-file-level', 'test_logopts.py', '*', 'DEBUG_7']
     _expector = _Expector('infra.run', 'DEBUG_7', concap_at='DEBUG_7', real_at='DEBUG_7')
     # note: todo/missing test -> also inject into a 2nd logger and only see data from IT at info

--- a/test/stream-monitor/test/test_stream_base.py
+++ b/test/stream-monitor/test/test_stream_base.py
@@ -1,7 +1,8 @@
 """
-Copyright 2016, EMC, Inc.
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 """
 import plugin_test_helper
+
 
 class TestSMPSingleOkSequence(plugin_test_helper.resolve_helper_class()):
     suitepath = plugin_test_helper.resolve_suitepath('stream-base', 'one_pass')
@@ -10,6 +11,7 @@ class TestSMPSingleOkSequence(plugin_test_helper.resolve_helper_class()):
         self._check_sequence_pre_test()
         self._check_sequence_test('test_one_pass.test_one')
         self._check_sequence_post_test()
+
 
 class TestSMPDoubleOkSequence(plugin_test_helper.resolve_helper_class()):
     suitepath = plugin_test_helper.resolve_suitepath('stream-base', 'two_pass')


### PR DESCRIPTION
Went through and fixed all mkcheck errors down in stream-monitor.
No functional change, and self-tests have been re-run.
Well, technically, there was some incorrectly named test-classes that were hiding three tests. These now pass.

Also fixed copyrights on any file I touched and mkcheck.sh itself for Reasons(tm)

@RackHD/corecommitters @johren @jimturnquist 