### PR TITLE
RAC-4233 Bugfix API config tests

### DIFF
--- a/test/tests/rackhd11/test_rackhd11_api_config.py
+++ b/test/tests/rackhd11/test_rackhd11_api_config.py
@@ -11,9 +11,8 @@ import os
 import sys
 import subprocess
 import fit_common
-
-# Select test group here using @attr
 from nose.plugins.attrib import attr
+
 @attr(all=True, regression=True, smoke=True)
 class rackhd11_api_config(fit_common.unittest.TestCase):
     def test_api_11_config(self):
@@ -43,7 +42,9 @@ class rackhd11_api_config(fit_common.unittest.TestCase):
 
     def test_api_11_config_patch(self):
         api_data_save = fit_common.rackhdapi('/api/1.1/config')['json']
-        if ("logColorEnable" in api_data_save and api_data_save['logColorEnable'] is True):
+        if ("logColorEnable" not in api_data_save):
+            api_data_save['logColorEnable'] = False
+        if (api_data_save['logColorEnable'] is True):
             data_payload = {"logColorEnable": False}
         else:
             data_payload = {"logColorEnable": True}
@@ -59,7 +60,7 @@ class rackhd11_api_config(fit_common.unittest.TestCase):
         api_data = fit_common.rackhdapi("/api/1.1/config", action="patch", payload=api_data_save)
         self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
         api_data = fit_common.rackhdapi('/api/1.1/config')
-        self.assertEqual(api_data['json'], api_data_save)
+        self.assertEqual(api_data['json'], api_data_save, "Patch failure, config not returned to default.")
 
 if __name__ == '__main__':
     fit_common.unittest.main()

--- a/test/tests/rackhd11/test_rackhd11_api_config.py
+++ b/test/tests/rackhd11/test_rackhd11_api_config.py
@@ -25,7 +25,6 @@ class rackhd11_api_config(fit_common.unittest.TestCase):
         self.assertIn('apiServerAddress', api_data['json'], 'apiServerAddress field error')
         self.assertIn('apiServerPort', api_data['json'], 'apiServerPort field error')
         self.assertIn('broadcastaddr', api_data['json'], 'broadcastaddr field error')
-        self.assertIn('CIDRNet', api_data['json'], 'CIDRNet field error')
         self.assertIn('subnetmask', api_data['json'], 'subnetmask field error')
         self.assertIn('mongo', api_data['json'], 'mongo field error')
 
@@ -44,14 +43,19 @@ class rackhd11_api_config(fit_common.unittest.TestCase):
 
     def test_api_11_config_patch(self):
         api_data_save = fit_common.rackhdapi('/api/1.1/config')['json']
-        data_payload = {"CIDRNet": "127.0.0.1/22"}
+        if ("logColorEnable" in api_data_save and api_data_save['logColorEnable'] == True):
+            data_payload = {"logColorEnable": False}
+        else:
+            data_payload = {"logColorEnable": True}
         api_data = fit_common.rackhdapi("/api/1.1/config", action="patch", payload=data_payload)
         self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
         for item in api_data['json']:
-            if fit_common.VERBOSITY >= 2:
-                print "Checking:", item
             self.assertNotEqual(item, '', 'Empty JSON Field:' + item)
         self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
+        if ("logColorEnable" in api_data_save and api_data_save['logColorEnable'] == True):
+            self.assertEqual(api_data['json']['logColorEnable'], False, "Incorrect patched value for 'logColorEnable'")
+        else:
+            self.assertEqual(api_data['json']['logColorEnable'], True, "Incorrect patched value for 'logColorEnable'")
         api_data = fit_common.rackhdapi("/api/1.1/config", action="patch", payload=api_data_save)
         self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
         api_data = fit_common.rackhdapi('/api/1.1/config')

--- a/test/tests/rackhd11/test_rackhd11_api_config.py
+++ b/test/tests/rackhd11/test_rackhd11_api_config.py
@@ -43,7 +43,7 @@ class rackhd11_api_config(fit_common.unittest.TestCase):
 
     def test_api_11_config_patch(self):
         api_data_save = fit_common.rackhdapi('/api/1.1/config')['json']
-        if ("logColorEnable" in api_data_save and api_data_save['logColorEnable'] == True):
+        if ("logColorEnable" in api_data_save and api_data_save['logColorEnable'] is True):
             data_payload = {"logColorEnable": False}
         else:
             data_payload = {"logColorEnable": True}
@@ -52,7 +52,7 @@ class rackhd11_api_config(fit_common.unittest.TestCase):
         for item in api_data['json']:
             self.assertNotEqual(item, '', 'Empty JSON Field:' + item)
         self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
-        if ("logColorEnable" in api_data_save and api_data_save['logColorEnable'] == True):
+        if ("logColorEnable" in api_data_save and api_data_save['logColorEnable'] is True):
             self.assertEqual(api_data['json']['logColorEnable'], False, "Incorrect patched value for 'logColorEnable'")
         else:
             self.assertEqual(api_data['json']['logColorEnable'], True, "Incorrect patched value for 'logColorEnable'")

--- a/test/tests/rackhd11/test_rackhd11_api_config.py
+++ b/test/tests/rackhd11/test_rackhd11_api_config.py
@@ -54,9 +54,9 @@ class rackhd11_api_config(fit_common.unittest.TestCase):
             self.assertNotEqual(item, '', 'Empty JSON Field:' + item)
         self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
         if ("logColorEnable" in api_data_save and api_data_save['logColorEnable'] is True):
-            self.assertEqual(api_data['json']['logColorEnable'], False, "Incorrect patched value for 'logColorEnable'")
+            self.assertEqual(api_data['json']['logColorEnable'], False, "Incorrect value for 'logColorEnable', should be False")
         else:
-            self.assertEqual(api_data['json']['logColorEnable'], True, "Incorrect patched value for 'logColorEnable'")
+            self.assertEqual(api_data['json']['logColorEnable'], True, "Incorrect value for 'logColorEnable', should be True")
         api_data = fit_common.rackhdapi("/api/1.1/config", action="patch", payload=api_data_save)
         self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
         api_data = fit_common.rackhdapi('/api/1.1/config')

--- a/test/tests/rackhd20/test_rackhd20_api_config.py
+++ b/test/tests/rackhd20/test_rackhd20_api_config.py
@@ -54,9 +54,9 @@ class rackhd20_api_config(fit_common.unittest.TestCase):
             self.assertNotEqual(item, '', 'Empty JSON Field:' + item)
         self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
         if ("logColorEnable" in api_data_save and api_data_save['logColorEnable'] is True):
-            self.assertEqual(api_data['json']['logColorEnable'], False, "Incorrect patched value for 'logColorEnable'")
+            self.assertEqual(api_data['json']['logColorEnable'], False, "Incorrect value for 'logColorEnable', should be False")
         else:
-            self.assertEqual(api_data['json']['logColorEnable'], True, "Incorrect patched value for 'logColorEnable'")
+            self.assertEqual(api_data['json']['logColorEnable'], True, "Incorrect value 'logColorEnable', should be True")
         api_data = fit_common.rackhdapi("/api/2.0/config", action="patch", payload=api_data_save)
         self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
         api_data = fit_common.rackhdapi('/api/2.0/config')

--- a/test/tests/rackhd20/test_rackhd20_api_config.py
+++ b/test/tests/rackhd20/test_rackhd20_api_config.py
@@ -43,7 +43,7 @@ class rackhd20_api_config(fit_common.unittest.TestCase):
 
     def test_api_20_config_patch(self):
         api_data_save = fit_common.rackhdapi('/api/2.0/config')['json']
-        if ("logColorEnable" in api_data_save and api_data_save['logColorEnable'] == True):
+        if ("logColorEnable" in api_data_save and api_data_save['logColorEnable'] is True):
             data_payload = {"logColorEnable": False}
         else:
             data_payload = {"logColorEnable": True}
@@ -52,7 +52,7 @@ class rackhd20_api_config(fit_common.unittest.TestCase):
         for item in api_data['json']:
             self.assertNotEqual(item, '', 'Empty JSON Field:' + item)
         self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
-        if ("logColorEnable" in api_data_save and api_data_save['logColorEnable'] == True):
+        if ("logColorEnable" in api_data_save and api_data_save['logColorEnable'] is True):
             self.assertEqual(api_data['json']['logColorEnable'], False, "Incorrect patched value for 'logColorEnable'")
         else:
             self.assertEqual(api_data['json']['logColorEnable'], True, "Incorrect patched value for 'logColorEnable'")

--- a/test/tests/rackhd20/test_rackhd20_api_config.py
+++ b/test/tests/rackhd20/test_rackhd20_api_config.py
@@ -25,7 +25,6 @@ class rackhd20_api_config(fit_common.unittest.TestCase):
         self.assertIn('apiServerAddress', api_data['json'], 'apiServerAddress field error')
         self.assertIn('apiServerPort', api_data['json'], 'apiServerPort field error')
         self.assertIn('broadcastaddr', api_data['json'], 'broadcastaddr field error')
-        self.assertIn('CIDRNet', api_data['json'], 'CIDRNet field error')
         self.assertIn('subnetmask', api_data['json'], 'subnetmask field error')
         self.assertIn('mongo', api_data['json'], 'mongo field error')
 
@@ -44,14 +43,19 @@ class rackhd20_api_config(fit_common.unittest.TestCase):
 
     def test_api_20_config_patch(self):
         api_data_save = fit_common.rackhdapi('/api/2.0/config')['json']
-        data_payload = {"CIDRNet": "127.0.0.1/22"}
+        if ("logColorEnable" in api_data_save and api_data_save['logColorEnable'] == True):
+            data_payload = {"logColorEnable": False}
+        else:
+            data_payload = {"logColorEnable": True}
         api_data = fit_common.rackhdapi("/api/2.0/config", action="patch", payload=data_payload)
         self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
         for item in api_data['json']:
-            if fit_common.VERBOSITY >= 2:
-                print "Checking:", item
             self.assertNotEqual(item, '', 'Empty JSON Field:' + item)
         self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
+        if ("logColorEnable" in api_data_save and api_data_save['logColorEnable'] == True):
+            self.assertEqual(api_data['json']['logColorEnable'], False, "Incorrect patched value for 'logColorEnable'")
+        else:
+            self.assertEqual(api_data['json']['logColorEnable'], True, "Incorrect patched value for 'logColorEnable'")
         api_data = fit_common.rackhdapi("/api/2.0/config", action="patch", payload=api_data_save)
         self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
         api_data = fit_common.rackhdapi('/api/2.0/config')

--- a/test/tests/rackhd20/test_rackhd20_api_config.py
+++ b/test/tests/rackhd20/test_rackhd20_api_config.py
@@ -11,9 +11,8 @@ import os
 import sys
 import subprocess
 import fit_common
-
-# Select test group here using @attr
 from nose.plugins.attrib import attr
+
 @attr(all=True, regression=True, smoke=True)
 class rackhd20_api_config(fit_common.unittest.TestCase):
     def test_api_20_config(self):
@@ -43,7 +42,9 @@ class rackhd20_api_config(fit_common.unittest.TestCase):
 
     def test_api_20_config_patch(self):
         api_data_save = fit_common.rackhdapi('/api/2.0/config')['json']
-        if ("logColorEnable" in api_data_save and api_data_save['logColorEnable'] is True):
+        if ("logColorEnable" not in api_data_save):
+            api_data_save['logColorEnable'] = False
+        if (api_data_save['logColorEnable'] is True):
             data_payload = {"logColorEnable": False}
         else:
             data_payload = {"logColorEnable": True}
@@ -59,7 +60,7 @@ class rackhd20_api_config(fit_common.unittest.TestCase):
         api_data = fit_common.rackhdapi("/api/2.0/config", action="patch", payload=api_data_save)
         self.assertEqual(api_data['status'], 200, "Was expecting code 200. Got " + str(api_data['status']))
         api_data = fit_common.rackhdapi('/api/2.0/config')
-        self.assertEqual(api_data['json'], api_data_save)
+        self.assertEqual(api_data['json'], api_data_save, "Patch failure, config not returned to default.")
 
 if __name__ == '__main__':
     fit_common.unittest.main()


### PR DESCRIPTION
This is a bugfix for the API config tests that were using a deprecated config key 'CIRDNET' and was causing failures under certain circumstances. This is causing the errors in the MN Smoke Test.

Removed the check for the  'CIRDNET' key.

Changed the patch test to a benign config key 'logColorEnable', which is a Boolean with two states. Added an assert to verify that the patch actually was applied, then return the config to the initial state.

Also removed the soon-to-be-deprecated 'verbosity' stuff.

@johren @hohene @jimturnquist @larry-dean @stuart-stanley
