### PR TITLE
[Skip CI]by default, not to build OVA with customized property, which not supported by vSphere

### DIFF
--- a/packer/HWIMO-BUILD
+++ b/packer/HWIMO-BUILD
@@ -233,7 +233,7 @@ fi
 
 if [ "${CUSTOMIZED_PROPERTY_OVA}" == "true" ];
 then
-    add_IP_property_to_ova.sh ${BASENAME} 
+    add_IP_property_to_ova.sh ${OVA} 
 fi # End of [ "${CUSTOMIZED_PROPERTY_OVA}" == "true" ]
 
 

--- a/packer/HWIMO-BUILD
+++ b/packer/HWIMO-BUILD
@@ -209,15 +209,16 @@ else
     echo "${INFO_HEADER}No signing to be performed.. skip."
 fi
 
-# Conver the VM Disk and VMX folder into an OVA
-
 BASENAME=${VM_NAME}
 OVA="${BASENAME}.ova"
-ovftool $SIGN_ARGS -o ${VMDIR}/${VM_NAME}.vmx $OVA
 
-if [ $? != 0 ]; then
-    echo "${ERROR_HEADER} ovftool exec failed.. exit"
-    exit 4
+# Conver the VM Disk and VMX folder into an OVA
+if [ "$BUILD_TYPE"  == "vmware" ];  then
+    ovftool $SIGN_ARGS -o ${VMDIR}/${VM_NAME}.vmx $OVA
+    if [ $? != 0 ]; then
+        echo "${ERROR_HEADER} ovftool exec failed.. exit"
+        exit 4
+    fi
 fi
 
 # Do Virus Scan
@@ -233,7 +234,11 @@ fi
 
 if [ "${CUSTOMIZED_PROPERTY_OVA}" == "true" ];
 then
-    add_IP_property_to_ova.sh ${OVA} 
+    bash add_IP_property_to_ova.sh ${OVA}
+    if [ $? != 0 ]; then
+         echo "${ERROR_HEADER} add_IP_property_to_ova.sh ${OVA} failed! Abort!"
+         exit 5
+    fi
 fi # End of [ "${CUSTOMIZED_PROPERTY_OVA}" == "true" ]
 
 

--- a/packer/HWIMO-BUILD
+++ b/packer/HWIMO-BUILD
@@ -11,6 +11,7 @@
 # * ATLAS_NAME     - optional, required only when UPLOAD_BOX_TO_ATLAS is true.
 # * ATLAS_TOKEN    - optional, required only when UPLOAD_BOX_TO_ATLAS is true.
 # * ATLAS_VERSION  - optional, by default is "".when UPLOAD_BOX_TO_ATLAS is true, the box will be uploaded to ATLAS as ATLAS_VERSION( format only accepts like 1.2.3).
+# * CUSTOMIZED_PROPERTY_OVA - optional, by default false, only effective when BUILD_TYPE is vmware.. if true, the OVA can be specified IP during deployment. only supported by vCenter
 ###################################################
 
 INFO_HEADER="[Info]"
@@ -70,7 +71,6 @@ fi
 
 
 # By default. use ansible playbook : rackhd_local.yml
-# can become an ENV VAR in the future
 if  [ ! -n "${ANSIBLE_PLAYBOOK}" ];  then
     ANSIBLE_PLAYBOOK=rackhd_local
 fi
@@ -93,6 +93,23 @@ else
        echo "${INFO_HEADER} Install RackHD Package without specific version."
    fi
 fi
+
+
+# By default. disable CUSTOMIZED_PROPERTY_OVA, because only supported by vCenter. not by vSphere
+if  [ ! -n "${CUSTOMIZED_PROPERTY_OVA}" ];  then
+    CUSTOMIZED_PROPERTY_OVA=false;
+fi
+
+if [ "$BUILD_TYPE"  == "vmware" ]
+then
+    if [ "${CUSTOMIZED_PROPERTY_OVA}" == "true" ];
+    then
+         echo "${INFO_HEADER} the OVA created will carry with customized property, like admin port IP "
+    else
+         echo "${INFO_HEADER} the OVA created will not carry with customized property."
+    fi
+fi
+
 
 ############################  Parameter Process ################ end #############
 
@@ -214,85 +231,10 @@ else
 fi
 
 
-#### BEGIN ###### Modify the OVF file and update checksum ##############
-#
-#Background:
-#   for the purpose of RackHD deployment enviroment without DHCP on admin port (e.x.: eth0),
-#   "OVF Environment" is leveraged to configure VM's IP during OVA/OVF deployment
-#
-#Implementation:
-#   1. define customized fields in OVF template file(XML format)
-#   2. when deploy RackHD OVA , you can specific the eth0 IP (thru OVF Env Parameter) like ```ovftool --prop:adminIP=1.2.3.4 .....```
-#   3. in VM OS's bootup scripts: use VMWare Tool to retrieve IP and set the primary NIC(eth0 for example)
-#
-#  Reference: http://www.v-front.de/2014/01/building-self-configuring-nested-esxi.html
-#
-###################################################################
-rm -f $"${BASENAME}.mf" # remove checksum file, otherwise, existing mf file will prevent ovftool coverting
-echo "covert to OVF"
-OVF=$"${BASENAME}.ovf"
-ovftool $OVA  $OVF
-echo "modify the OVF"
-
-#######################################################
-# Note : this is ESXi format. (other ESX version may varies )
-# Add ProductSection/Property xml nodes under VirtualSystem xml node( kind of declare OVF Enviromental Properties)
-#######################################################
-
-################
-#[ OVF Template Injection Step #1 ]
-# Below 'sed' will "insert" below XML tree at the end of <VirtualSystem> tag of the OVF template file.
-#     |-ProductSection
-#     |----Info
-#     |----Product
-#     |----Category
-#     |----Property #1
-#     |----Property #..
-#     |----Property #n
-#################
-sed -i 's/<\/VirtualSystem>/ \
-  <ProductSection>    \
-     <Info>Information about the installed software<\/Info> \
-     <Product>Rackhd<\/Product> \
-     <Category>adminnetwork<\/Category>  \
-     <Property ovf:key="adminIP" ovf:type="string" ovf:userConfigurable="true"> \
-        <Label>adminIP<\/Label> \
-     <\/Property> \
-     <Property ovf:key="adminGateway" ovf:type="string" ovf:userConfigurable="true"> \
-        <Label>adminGateway<\/Label> \
-     <\/Property> \
-     <Property ovf:key="adminNetmask" ovf:type="string" ovf:userConfigurable="true"> \
-        <Label>adminNetmask<\/Label> \
-     <\/Property> \
-     <Property ovf:key="adminDNS" ovf:type="string" ovf:userConfigurable="true"> \
-        <Label>adminDNS<\/Label> \
-     <\/Property>  \
-  <\/ProductSection> \
-<\/VirtualSystem>   \
-/'  $OVF
-################
-#[ OVF Template Injection Step #2 ]
-# specific the "OVF enviroment transport" method to VMWare Tools
-###############
-sed -i 's/<VirtualHardwareSection>/<VirtualHardwareSection ovf:transport="com.vmware.guestInfo" > /' $OVF
-
-
-
-echo "recovert back to OVA"
-###############
-#[ OVF Template Injection Step #3 ]
-# update checksum
-###############
-NewChk=$(sha1sum $OVF | awk '{print $1}')
-sed  -i -E  "s/SHA1\(.*ovf\)=.*$/SHA1\($OVF\)= $NewChk/g"  $"${BASENAME}.mf"
-##############
-#[ OVF Template Injection Step #4 ]
-# re-package into OVA
-##############
-rm $OVA
-ovftool $OVF $OVA
-### END ####### Modify the OVF file and update checksum ##############
-
+if [ "${CUSTOMIZED_PROPERTY_OVA}" == "true" ];
+then
+    add_IP_property_to_ova.sh ${BASENAME} 
+fi # End of [ "${CUSTOMIZED_PROPERTY_OVA}" == "true" ]
 
 
 # Create MD5 & Sha256 checksum file

--- a/packer/add_IP_property_to_ova.sh
+++ b/packer/add_IP_property_to_ova.sh
@@ -33,6 +33,11 @@ fi
 rm -f $"${BASENAME}.mf" # remove checksum file, otherwise, existing mf file will prevent ovftool converting
 echo "convert ${OVA} to OVF file, named ${OVF}"
 ovftool $OVA  $OVF
+if [ $? != 0 ]; then
+    echo "[Error] ovftool exec failed..(ovftool $OVA  $OVF) exit"
+    exit 1
+fi
+
 echo "modify the OVF adding property."
 
 #######################################################
@@ -73,7 +78,7 @@ sed -i 's/<\/VirtualSystem>/ \
 /'  $OVF
 ################
 #[ OVF Template Injection Step #2 ]
-# specific the "OVF enviroment transport" method to VMWare Tools
+# specify the "OVF enviroment transport" method to VMWare Tools
 ###############
 sed -i 's/<VirtualHardwareSection>/<VirtualHardwareSection ovf:transport="com.vmware.guestInfo" > /' $OVF
 
@@ -92,5 +97,8 @@ sed  -i -E  "s/SHA1\(.*ovf\)=.*$/SHA1\($OVF\)= $NewChk/g"  $"${BASENAME}.mf"
 ##############
 rm -f $OVA  #remove old OVA
 ovftool $OVF $OVA
-
+if [ $? != 0 ]; then
+     echo "[Error] ovftool exec failed..(ovftool $OVF  $OVA) exit"
+     exit 1
+fi
 echo "[Info] the new OVA is created , with customized ovf property feature : ${OVA}"

--- a/packer/add_IP_property_to_ova.sh
+++ b/packer/add_IP_property_to_ova.sh
@@ -25,7 +25,7 @@ OVF=$"${BASENAME}.ovf"
 
 ### validate the OVA
 FILE_TYPE=`file ${OVA} | awk -F": " '{print $2}'`
-if "${FILE_TYPE}" != "POSIX tar archive"; then
+if [ "${FILE_TYPE}" != "POSIX tar archive" ] ; then
     echo "[Error]:  ${OVA} is not a valid OVA file"
     exit -1
 fi

--- a/packer/add_IP_property_to_ova.sh
+++ b/packer/add_IP_property_to_ova.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+set -e
+###################################################
+#Background:
+#   for the purpose of RackHD deployment enviroment without DHCP on admin port (e.x.: eth0),
+#   "OVF Environment" is leveraged to configure VM's IP during OVA/OVF deployment
+#
+#Implementation:
+#   1. define customized fields in OVF template file(XML format)
+#   2. when deploy RackHD OVA , you can specific the eth0 IP (thru OVF Env Parameter) like ```ovftool --prop:adminIP=1.2.3.4 .....```
+#   3. in VM OS's bootup scripts: use VMWare Tool to retrieve IP and set the primary NIC(eth0 for example)
+#
+#  Reference: http://www.v-front.de/2014/01/building-self-configuring-nested-esxi.html
+#
+###################################################################
+if  [ ! -n "$1" ];  then
+    echo "[Error] wrong usage of add_IP_property_to_ova.sh. the original ova file name should be given"
+    exit -1
+fi
+OVA=$1
+BASENAME=${OVA%.*}
+OVF=$"${BASENAME}.ovf"
+
+rm -f $"${BASENAME}.mf" # remove checksum file, otherwise, existing mf file will prevent ovftool coverting
+echo "covert ${OVA} to OVF file, named ${OVF}"
+ovftool $OVA  $OVF
+echo "modify the OVF adding property."
+
+#######################################################
+# Note : this is ESXi format. (other ESX version may varies )
+# Add ProductSection/Property xml nodes under VirtualSystem xml node( kind of declare OVF Enviromental Properties)
+#######################################################
+
+################
+#[ OVF Template Injection Step #1 ]
+# Below 'sed' will "insert" below XML tree at the end of <VirtualSystem> tag of the OVF template file.
+#     |-ProductSection
+#     |----Info
+#     |----Product
+#     |----Category
+#     |----Property #1
+#     |----Property #..
+#     |----Property #n
+#################
+sed -i 's/<\/VirtualSystem>/ \
+  <ProductSection>    \
+     <Info>Information about the installed software<\/Info> \
+     <Product>Rackhd<\/Product> \
+     <Category>adminnetwork<\/Category>  \
+     <Property ovf:key="adminIP" ovf:type="string" ovf:userConfigurable="true"> \
+        <Label>adminIP<\/Label> \
+     <\/Property> \
+     <Property ovf:key="adminGateway" ovf:type="string" ovf:userConfigurable="true"> \
+        <Label>adminGateway<\/Label> \
+     <\/Property> \
+     <Property ovf:key="adminNetmask" ovf:type="string" ovf:userConfigurable="true"> \
+        <Label>adminNetmask<\/Label> \
+     <\/Property> \
+     <Property ovf:key="adminDNS" ovf:type="string" ovf:userConfigurable="true"> \
+        <Label>adminDNS<\/Label> \
+     <\/Property>  \
+  <\/ProductSection> \
+<\/VirtualSystem>   \
+/'  $OVF
+################
+#[ OVF Template Injection Step #2 ]
+# specific the "OVF enviroment transport" method to VMWare Tools
+###############
+sed -i 's/<VirtualHardwareSection>/<VirtualHardwareSection ovf:transport="com.vmware.guestInfo" > /' $OVF
+
+
+
+echo "recovert back to OVA"
+###############
+#[ OVF Template Injection Step #3 ]
+# update checksum
+###############
+NewChk=$(sha1sum $OVF | awk '{print $1}')
+sed  -i -E  "s/SHA1\(.*ovf\)=.*$/SHA1\($OVF\)= $NewChk/g"  $"${BASENAME}.mf"
+##############
+#[ OVF Template Injection Step #4 ]
+# re-package into OVA
+##############
+rm -f $OVA  #remove old OVA
+ovftool $OVF $OVA
+
+echo "[Info] the new OVA is created , with customized ovf property feature : ${OVA}"

--- a/packer/add_IP_property_to_ova.sh
+++ b/packer/add_IP_property_to_ova.sh
@@ -12,6 +12,8 @@ set -e
 #
 #  Reference: http://www.v-front.de/2014/01/building-self-configuring-nested-esxi.html
 #
+#Parameter:
+#   the OVA file name to be converted.
 ###################################################################
 if  [ ! -n "$1" ];  then
     echo "[Error] wrong usage of add_IP_property_to_ova.sh. the original ova file name should be given"
@@ -21,8 +23,15 @@ OVA=$1
 BASENAME=${OVA%.*}
 OVF=$"${BASENAME}.ovf"
 
-rm -f $"${BASENAME}.mf" # remove checksum file, otherwise, existing mf file will prevent ovftool coverting
-echo "covert ${OVA} to OVF file, named ${OVF}"
+### validate the OVA
+FILE_TYPE=`file ${OVA} | awk -F": " '{print $2}'`
+if "${FILE_TYPE}" != "POSIX tar archive"; then
+    echo "[Error]:  ${OVA} is not a valid OVA file"
+    exit -1
+fi
+
+rm -f $"${BASENAME}.mf" # remove checksum file, otherwise, existing mf file will prevent ovftool converting
+echo "convert ${OVA} to OVF file, named ${OVF}"
 ovftool $OVA  $OVF
 echo "modify the OVF adding property."
 
@@ -70,7 +79,7 @@ sed -i 's/<VirtualHardwareSection>/<VirtualHardwareSection ovf:transport="com.vm
 
 
 
-echo "recovert back to OVA"
+echo "reconvert back to OVA"
 ###############
 #[ OVF Template Injection Step #3 ]
 # update checksum


### PR DESCRIPTION
**background:**

originally, there's a feature in RackHD OVA which during deployment , we can specific the IP of the OVA, in a non-DHCP environment.
that make convenience for batch deployment for lots of RackHD OVA without manually setup IP.

But it turns out this feature only support by VMWare vCenter, not supported by vSphere.

Taken many user still use vSphere, so I have to make this advanced feature *not a default* one.

**What's Change:**

I didn't change anything from original line 217 - 295.
but just put them inside a "if" block.
and this "if" is by default false.



**Test Done**

1. Build:
use below command locally, and build successful
```
OS_VER=ubuntu-16.04   BUILD_TYPE=vmware   ANSIBLE_PLAYBOOK=rackhd_ci_builds   ./HWIMO-BUILD
```
2. Deploy ova(without customized property) to vSphere ( SH Lab ESXi 245) - successful
```ovftool   ........ vi://****:*****@*.*.*.245```
```
Opening OVA source: rackhd-ubuntu-16.04-bak.ova
The manifest does not validate
Opening VI target: vi://root@10.62.59.245:443/
Warning:
 - Line 98: Invalid value 'CONTROL' for element 'Connection'.
 - Line 109: Invalid value 'PDU' for element 'Connection'.
 - Line 120: Invalid value 'BMC' for element 'Connection'.
Deploying to VI: vi://root@10.62.59.245:443/
Progress: 9%
```
3. Deploy the  ova(with customized property) - also success. not shown the result.

Reviewer:

@yyscamper   @anhou   @PengTian0   @changev 

