### PR TITLE
rac-261 stream monitor base matcher logic.

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,8 +1,11 @@
 on-skupack
 myenv_*
+.vscode
 log_output
 startup.sh
 nohup.out
 *~
 auth.json
 testfile
+rackhd_test_check.txt
+fit_path/fit_test_pathing.egg-info/

--- a/test/mkcheck.sh
+++ b/test/mkcheck.sh
@@ -23,7 +23,7 @@ if [ -f ${output_file} ]; then
 fi
 
 # make changes to flake8 parameters in .flake8 file
-flake8 --config=../.flake8 --statistics --tee --output-file=${output_file}
+flake8 --config=../.flake8 --statistics --tee --output-file=${output_file} $@
 if [ $? -ne 0 ]; then
     if [ "${format}" == "text" ]; then
         cat ${output_file}

--- a/test/stream-monitor/flogging/infra_logging.py
+++ b/test/stream-monitor/flogging/infra_logging.py
@@ -136,7 +136,7 @@ class _LoggerSetup(object):
     def __makedirs_dash_p(self, *args, **kwargs):
         try:
             os.makedirs(*args, **kwargs)
-        except OSError, e:
+        except OSError as e:
             # be happy if someone already created the path
             if e.errno != errno.EEXIST:
                 raise
@@ -198,7 +198,7 @@ class _LoggerSetup(object):
 
     def __do_level_names(self):
         lvl_copy = dict(_levelNames)
-        for adj in xrange(0, 10):
+        for adj in range(0, 10):
             for lvl_key, lvl_value in lvl_copy.items():
                 if isinstance(lvl_key, str) and lvl_key != 'NOTSET':
                     new_name = "{0}_{1}".format(lvl_key, adj)

--- a/test/stream-monitor/sm_plugin/__init__.py
+++ b/test/stream-monitor/sm_plugin/__init__.py
@@ -1,6 +1,6 @@
 """
 Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 """
-from stream_monitor import StreamMonitorPlugin, smp_get_stream_monitor_plugin
+from stream_monitor import StreamMonitorPlugin, smp_get_stream_monitor, smp_get_stream_monitor_plugin
 
-__all__ = ['StreamMonitorPlugin', 'smp_get_stream_monitor_plugin']
+__all__ = [StreamMonitorPlugin, smp_get_stream_monitor_plugin, smp_get_stream_monitor]

--- a/test/stream-monitor/sm_plugin/stream_monitor.py
+++ b/test/stream-monitor/sm_plugin/stream_monitor.py
@@ -4,7 +4,7 @@ Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 import logging
 import os
 from nose.plugins import Plugin
-from stream_sources import LoggingMarker
+from stream_sources import LoggingMarker, SelfTestStreamMonitor
 import sys
 from nose.pyversion import format_exception
 from nose.plugins.xunit import Tee
@@ -79,6 +79,7 @@ class StreamMonitorPlugin(Plugin):
         # tood: check class "enabled_for_nose()"
         if len(self.__stream_plugins) == 0:
             self.__stream_plugins['logging'] = LoggingMarker()
+            self.__stream_plugins['self-test'] = SelfTestStreamMonitor()
         else:
             # This is basically for self-testing the plugin, since the
             # logging monitor stays around between test-classes. If we don't do
@@ -190,6 +191,9 @@ class StreamMonitorPlugin(Plugin):
             if hasattr(pg, 'handle_capture'):
                 pg.handle_capture(log_level, cap_type, test, sout, serr, tb)
 
+    def get_stream_monitor_by_name(self, name):
+        return self.__stream_plugins[name]
+
 
 def smp_get_stream_monitor_plugin():
     """
@@ -198,3 +202,8 @@ def smp_get_stream_monitor_plugin():
     """
     smp = StreamMonitorPlugin.get_singleton_instance()
     return smp
+
+
+def smp_get_stream_monitor(monitor_name):
+    smp = StreamMonitorPlugin.get_singleton_instance()
+    return smp.get_stream_monitor_by_name(monitor_name)

--- a/test/stream-monitor/stream_sources/__init__.py
+++ b/test/stream-monitor/stream_sources/__init__.py
@@ -2,5 +2,6 @@
 Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 """
 from log_type import LoggingMarker
+from self_test_source import SelfTestStreamMonitor
 
-__all__ = [LoggingMarker]
+__all__ = [LoggingMarker, SelfTestStreamMonitor]

--- a/test/stream-monitor/stream_sources/log_type.py
+++ b/test/stream-monitor/stream_sources/log_type.py
@@ -4,11 +4,11 @@ Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 from logging import Logger, DEBUG, INFO
 from logging import getLogger as real_getLogger
 from logging import _srcfile  # yes, this is evil. No, we don't have a choice.
-from .monitor_abc import StreamMonitorABC
+from .monitor_abc import StreamMonitorBaseClass
 import sys
 
 
-class LoggingMarker(StreamMonitorABC):
+class LoggingMarker(StreamMonitorBaseClass):
     _all_blocks = 0
 
     def __init__(self):

--- a/test/stream-monitor/stream_sources/monitor_abc.py
+++ b/test/stream-monitor/stream_sources/monitor_abc.py
@@ -1,7 +1,116 @@
-# todo: ABC
+"""
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+This file holds a base class information for writing a stream-monitor. It is
+intended to provide life-cycle and common grouping methods. It works items
+derived from the classes in stream_matcher_base and stream_matchers_results to
+manage stream-based-pattern matching.
+"""
+
+from .stream_matchers_base import StreamGroupsRoot, StreamGroupsOrdered, StreamGroupsUnordered
+from .stream_matchers_results import StreamRunResults
 
 
-class StreamMonitorABC(object):
-    pass
+class StreamMonitorBaseClass(object):
+    def __init__(self):
+        """
+        Setup the basic state. An implementation for a specific monitor must
+        be a stream-monitor plugin so that the methods are called at the proper
+        times.
+        """
+        self._in_test = False
+        self.__match_groups = None
+        self.__group_stack = None
+        self.__seen_before_test = []
+        self.__seen_during_test = []
 
-    # todo must implement @classmethod enabled_for_nose()
+    def handle_begin(self):
+        """
+        called at stream-monitor plugin begin. We create a matchgroup and
+        group stacks. (See 'push_group' for info on groups)
+
+        At this time, we only support "seeing" things _during_ a test. The
+        '__in_test' state was put in here to help me think about how to possibly
+        structure things when/if phasing gets added.
+        """
+        self.__match_groups = StreamGroupsRoot()
+        self.__group_stack = [self.__match_groups]
+        self.__in_test = False
+
+    def handle_start_test(self, test):
+        """
+        called at stream-monitor start-test. Pass on the start-test to the main
+        group and clear the evens we have "seen".
+        """
+        self.__match_groups.handle_start_test(test)
+        self.__seen_before_test = []
+        self.__seen_during_test = []
+        self.__in_test = True
+
+    def handle_stop_test(self, test):
+        """
+        called at stream-monitor stop-test.
+        """
+        self.__in_test = False
+
+    def _add_matcher(self, matcher):
+        """
+        sub-class callable method to add a matcher to the current group
+        """
+        current = self.__group_stack[-1]
+        current.add_matcher(matcher)
+
+    def _add_event(self, event_data):
+        """
+        sub-class callable method to add an event to what we have "seen".
+        """
+        if self.__in_test:
+            self.__seen_during_test.append(event_data)
+        else:
+            self.__seen_before_test.append(event_data)
+
+    def push_group(self, ordered=False):
+        """
+        This is "take one" at groups of matchers. The root level group is an
+        "unordered" group, and thus any matchers added to it can be matched in
+        any order. From there, additional ordered or unordered groups can be
+        pushed into this class to build up and/or combinations. This really is
+        just a basic set at this point until more data comes in on common use-styles.
+
+        The __group_stack property keeps track of our current depth.
+        """
+        if ordered:
+            ng = StreamGroupsOrdered()
+        else:
+            ng = StreamGroupsUnordered()
+
+        current = self.__group_stack[-1]
+        current.add_group(ng)
+        self.__group_stack.append(ng)
+
+    def pop_group(self):
+        """
+        The pop method to go with push_group. Basically sanity checks depth and
+        handles moving "up" a level.
+        """
+        assert len(self.__group_stack) > 1, \
+            'attempted to pop root group!'
+        self.__group_stack = self.__group_stack[:-1]
+
+    def finish(self):
+        """
+        Called when data injection is complete and the events should be
+        checked vs the matchers. This is primarily for self-tests.
+        """
+        assert len(self.__seen_before_test) == 0, 'not implemented yet'
+        assert len(self.__group_stack) == 1, \
+            'did not pop all pushed groups: {0}'.format(self.__group_stack)
+
+        results = StreamRunResults()
+        for event_data in self.__seen_during_test:
+            res = self.__match_groups.check_event(event_data)
+            results.add_result(res)
+
+        res = self.__match_groups.check_ending()
+        results.add_result(res)
+        return results

--- a/test/stream-monitor/stream_sources/self_test_source.py
+++ b/test/stream-monitor/stream_sources/self_test_source.py
@@ -1,0 +1,49 @@
+"""
+Copyright (c) 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+A set of super-simple matchers to use to self-test the matching framework.
+"""
+import sys
+from .monitor_abc import StreamMonitorBaseClass
+from .stream_matchers_base import StreamMatchBase
+
+
+class _SelfTestMatcher(StreamMatchBase):
+    """
+    Implementation of a StreamMatchBase matcher that checks for simple text equality.
+    """
+    def __init__(self, match_text, description, min=1, max=1):
+        self.__match_text = match_text
+        super(_SelfTestMatcher, self).__init__(description, min=min, max=max)
+
+    def _match(self, other_text):
+        return other_text == self.__match_text
+
+    def dump(self, ofile=sys.stdout, indent=0):
+        super(_SelfTestMatcher, self).dump(ofile=ofile, indent=indent)
+        ins = ' ' * indent
+        print >>ofile, "{0} match_text='{1}'".format(ins, self.__match_text)
+
+
+class SelfTestStreamMonitor(StreamMonitorBaseClass):
+    """
+    Implementation of a StreamMonitorBaseClass that does simple direct text matching.
+    """
+    @classmethod
+    def enabled_for_nose(true):
+        return True
+
+    def match_single(self, match_val, description=None):
+        """
+        Add a matcher to this monitor.
+        """
+        if description is None:
+            description = "match_single({0})".format(match_val)
+        m = _SelfTestMatcher(match_val, description, 1, 1)
+        self._add_matcher(m)
+
+    def inject(self, text):
+        """
+        Allows manual injections of 'events' (in this case, simple text)
+        """
+        self._add_event(text)

--- a/test/stream-monitor/stream_sources/stream_matchers_base.py
+++ b/test/stream-monitor/stream_sources/stream_matchers_base.py
@@ -1,0 +1,425 @@
+"""
+Copyright 2017, EMC, Inc.
+
+This is the base for the various stream matchers.
+"""
+import logging
+from .stream_matchers_results import MatcherResult, MatcherUnderMatch, MatcherOverMatch, MatcherCleanHitResult
+from .stream_matchers_results import MatcherOrderedMissMatch
+import sys
+try:
+    from cStringIO import StringIO as _StringIO
+except ImportError:
+    from StringIO import StringIO as _StringIO
+from pprint import PrettyPrinter
+
+log = logging.getLogger('nose.plugins.stream_monitor.matchers')
+
+
+class _IndentedPrettyPrinter(PrettyPrinter):
+    """
+    Utility extension of pretty printer to indent the entire
+    output by a certain amount.
+    """
+    def __init__(self, per_line_indent=0, **kwargs):
+        self.__per_line_indent_str = ' ' * per_line_indent
+        PrettyPrinter.__init__(self, **kwargs)
+
+    def pprint(self, object):
+        rs = self.pformat(object)
+        self._stream.write(rs)
+        self._stream.write('\n')
+
+    def pformat(self, object):
+        fs = PrettyPrinter.pformat(self, object)
+        rs = _StringIO()
+        for line in fs.split('\n'):
+            if len(line) != 0:
+                rs.write(self.__per_line_indent_str)
+                rs.write(line)
+            rs.write('\n')
+        return rs.getvalue()
+
+
+class _MatcherBatcher(object):
+    """
+    Match-result batch container.
+
+    There is one of these per event, with the various StreamGroups adding
+    (matcher, result-of-trying-event-against-the-matcher) pairs via add_result.
+    """
+    def __init__(self, event_data):
+        self.__saved_event_data = event_data
+        self.__results_seen = []
+
+    def add_result(self, matcher, result):
+        """
+        Adds a matcher (the object capable of trying to match the event) and the
+        result of that attempt to this batch.
+
+        Note that a 'result' can be another _MatcherBatcher when the matcher is a sub-group (like
+        a an ordered-group inside of unordered-group).
+        """
+        if result is not None:
+            assert isinstance(result, MatcherResult) or isinstance(result, _MatcherBatcher), \
+                'result was {0}, not a required {1} or {2}'.format(
+                result, MatcherResult, _MatcherBatcher)
+
+        self.__results_seen.append((matcher, result))
+
+    def __get_a_result_status(self, result):
+        """
+        Internal method to decode the error/ok state from the different
+        types of results.
+
+        returns (is_error, is_ok)
+        """
+        if result is None:
+            return False, False
+        elif isinstance(result, MatcherResult):
+            return result.is_error, result.is_ok
+        elif isinstance(result, _MatcherBatcher):
+            return result.has_error, result.has_ok
+        else:
+            assert False, 'wrong type {0}'.format(result)
+
+    def __get_result_statuses(self):
+        """
+        Iterator for getting the (is_error, is_ok) state for each result.
+        """
+        for _, result in self.__results_seen:
+            is_error, is_ok = self.__get_a_result_status(result)
+            yield is_error, is_ok
+
+    @property
+    def has_error(self):
+        """
+        Returns the composite "is_error" for the entire batch. If there
+        are any results that are errors, the entire batch is.
+        """
+        for has_error, _ in self.__get_result_statuses():
+            if has_error:
+                return True
+        return False
+
+    @property
+    def has_ok(self):
+        """
+        Returns if any part of this batch was "ok" (no error).
+        """
+        for _, has_ok in self.__get_result_statuses():
+            if has_ok:
+                return True
+        return False
+
+    @property
+    def is_terminal(self):
+        """
+        Indicates if this batch is terminal or not. Since "terminal" only
+        applies to a direct-matcher, we always return False.
+        """
+        return False
+
+    def dump(self, ofile=sys.stderr, indent=0, is_sub_batch=False):
+        """
+        Method to dump our state for use in reporting a failed test.
+        """
+        ins = ' ' * indent
+        indent += 2
+        pp = _IndentedPrettyPrinter(per_line_indent=indent, stream=ofile)
+        if is_sub_batch:
+            print >>ofile, "{0}----matcher group's results".format(ins)
+        else:
+            print >>ofile, "{0}Matched {1} matchers on event:".format(ins, len(self.__results_seen))
+            pp.pprint(self.__saved_event_data)
+        inx = 0
+        ins += ' '  # indent detail one more space.
+        for matcher, result in self.__results_seen:
+            inx += 1
+            is_error, is_ok = self.__get_a_result_status(result)
+            print >>ofile, "{0}result {1:02d} of {2:02d} is_error={3:5} is_ok={4:5}".format(
+                ins, inx, len(self.__results_seen), str(is_error), str(is_ok))
+            if is_sub_batch:
+                print >>ofile, "{0} Matcher '{1}' (from group)".format(ins, matcher.description)
+            else:
+                matcher.dump(ofile, indent)
+            if result is None:
+                print >>ofile, "{0}result: not-matched(None)"
+            elif isinstance(result, _MatcherBatcher):
+                result.dump(ofile, indent, is_sub_batch=True)
+            else:
+                result.dump(ofile, indent)
+
+        print >>ofile
+
+
+class StreamMatchBase(object):
+    """
+    Base class for stream-matchers.
+
+    It handles the common bits of match-ranges (I.E., "we can have between 2 and 5 of these")
+    along with descriptions and common diagnostic output routines.
+
+    A matcher is three 'matchable' states:
+    1) Have not found enough matches yet for this to be ok (still_requires_match)
+    2) Have found enough matches to be "ok", but have not gone over into overmatch.
+    3) Still technically legal to match, but in overmatch. This last one is still a bit fuzzy
+       and is more of a conceptual rather than literal state.
+    """
+    def __init__(self, description, min=1, max=1):
+        self.__min = min
+        self.__max = max
+        self.__match_count = 0
+        self.__overmatch = None
+        self.__missmatch = None
+        self.__still_matchable = True
+        self.description = description
+
+    def dump(self, ofile=sys.stdout, indent=0):
+        """
+        Method to dump our state for use in reporting a failed test.
+        """
+        ins = ' ' * indent
+        print >>ofile, "{0}Matcher '{1}'".format(ins, self.description)
+        print >>ofile, "{0} matched={1}, min={2}, max={3}".format(
+            ins, self.__match_count, self.__min, self.__max),
+
+        extra = []
+        if self.__overmatch is not None:
+            extra.append("overmatched={0}".format(self.__overmatch))
+        if self.__missmatch is not None:
+            extra.append("missmatch={0}".format(self.__missmatch))
+        if len(extra) == 0:
+            if self.__match_count >= self.__min and self.__match_count <= self.__max:
+                extra.append("in-count-range")
+            else:
+                extra.append("out-of-range-but-not-marked-yet(count={0}, min={1}, max={2})".format(
+                    self.__match_count, self.__min, self.__max))
+
+        print >>ofile, ', '.join(extra)
+        print >>ofile, "{0} still_matchable={1}, still_requires_match={2}".format(
+            ins, self.is_still_matchable, self.still_requires_match)
+
+    @property
+    def is_still_matchable(self):
+        """
+        property to indicate if the matcher is still valid to check against.
+        Currently this is not altered and always returns True.
+        """
+        return self.__still_matchable
+
+    @property
+    def still_requires_match(self):
+        """
+        Property to indicate that more matches are needed before the minimum count is hit.
+        """
+        return self.__match_count < self.__min
+
+    def check_ending(self):
+        """
+        End-of-run check method. We check for if ending now causes this matcher to go
+        invalid because it was not matched enough times.
+        """
+        if self.__match_count < self.__min:
+            res = MatcherUnderMatch(
+                self.description, self.__min, self.__max, self.__match_count)
+        else:
+            res = None
+        return res
+
+    def _match(self, other_thing):
+        raise NotImplemented('subclass must implement this')
+
+    def check_event(self, event_data, break_on_miss=False):
+        """
+        Method that does the grunt work of checking an event against this matcher
+        and deals with all the possible error conditions.
+        """
+        # Step 1: see if the matcher even matches the event data!
+        low_level_matched = self._match(event_data)
+        if low_level_matched:
+            # It did, so bump the match count
+            self.__match_count += 1
+            if self.__missmatch is not None:
+                # We are already in a state where we are part of an ordered
+                # set, and we matched something _beyond_ this one in that set.
+                # (see break_on_miss below). We bump the count in the mismatch result
+                # for diagnostic output.
+                self.__missmatch.bump_matched()
+                res = self.__missmatch
+            elif self.__match_count > self.__max:
+                # And we have matched too many. If we just went over the edge,
+                # create an overmatch result, otherwise bump the count on the
+                # one we already made.
+                if self.__overmatch is None:
+                    self.__overmatch = MatcherOverMatch(
+                        self.description, self.__min, self.__max, self.__match_count)
+                else:
+                    self.__overmatch.adjust_count(self.__match_count)
+                res = self.__overmatch
+            else:
+                # Yay! It's a match! Set the 'is_terminal' on it to "consume" the event (stops
+                # further matching attempts)
+                res = MatcherCleanHitResult(self.description, is_terminal=True)
+        else:
+            # So, it wasn't a match....
+            if break_on_miss:
+                # break_on_miss means we are part of an ordered set and we HAD to match. If
+                # we were already broken, just bump the count otherwise create the mismatch instance.
+                if self.__missmatch is None:
+                    self.__missmatch = MatcherOrderedMissMatch(
+                        self.description, self.__min, self.__max, self.__match_count)
+                else:
+                    self.__missmatch.bump_missed()
+                res = self.__missmatch
+            else:
+                # We return None to indicate no match.
+                res = None
+        return res
+
+
+class _StreamGroupsBase(object):
+    """
+    This is the base for groups of matchers. This base handles
+    the common junk like diag dumps, and so on.
+
+    Right now the matching system is limited to -during- the test
+    itself.
+    """
+    def __init__(self, group_type):
+        """
+        param group_type is a string used to help show whats going on
+        when dumping on errors.
+        """
+        self._in_test_matchers = []
+        self.__group_type = group_type
+
+    def dump(self, ofile=sys.stdout, indent=0):
+        """
+        Method to dump our state for use in reporting a failed test.
+        """
+        ins = ' ' * indent
+        mcount = 0
+        gcount = 0
+        for m in self._in_test_matchers:
+            if isinstance(m, StreamMatchBase):
+                mcount += 1
+            elif isinstance(m, _StreamGroupsBase):
+                gcount += 1
+            else:
+                assert False, 'matcher in list that is neither matcher or group {0}'.format(m)
+
+        print >>ofile, "{0}{1} group of {2} matchers ({3} direct-matchers, {4} sub-groups) is_still_matchable={5})".format(
+            ins, self.__group_type, len(self._in_test_matchers), mcount, gcount, self.is_still_matchable)
+        indent += 2
+        for m in self._in_test_matchers:
+            m.dump(ofile, indent)
+
+    def handle_start_test(self, test):
+        """
+        Clear out the matchers that have been pushed in when the test starts.
+        """
+        self._in_test_matchers = []
+
+    @property
+    def is_still_matchable(self):
+        """
+        If any matcher in our list is still matchable, so are we.
+        """
+        for m in self._in_test_matchers:
+            if m.is_still_matchable:
+                return True
+        return False
+
+    def add_matcher(self, matcher):
+        """
+        Add a single matcher to the group.
+        """
+        assert isinstance(matcher, StreamMatchBase), \
+            'matcher {0} must be a {1} but was a {2}'.format(matcher, StreamMatchBase, type(matcher))
+        self._in_test_matchers.append(matcher)
+
+    def add_group(self, group):
+        """
+        Add an entire group of matchers to this group.
+        """
+        assert isinstance(group, _StreamGroupsBase), \
+            '{0} must be a {1}'.format(group, _StreamGroupsBase)
+        self._in_test_matchers.append(group)
+
+    def check_ending(self):
+        """
+        Called by stream-monitor at end-of-test
+        """
+        match_batch = _MatcherBatcher('finish')
+        for matcher in self._in_test_matchers:
+            res = matcher.check_ending()
+            if res is not None:
+                match_batch.add_result(matcher, res)
+        return match_batch
+
+
+class StreamGroupsOrdered(_StreamGroupsBase):
+    """
+    Ordered set of matchers.
+    """
+    def __init__(self):
+        super(StreamGroupsOrdered, self).__init__('ordered/sequence')
+
+    def check_event(self, event_data):
+        """
+        Implement the event-check logic for an ordered group. "Ordered" means that each matcher added
+        has to be hit in sequence. For example, we can create a group that says "A then B",
+        and if we see event-type B before A, we will error.
+
+        This gets a little more tricky when we set up something like "between 1 and 4 A, then B", since
+        the following scenarios exist:
+        * AB, AAB, AAAB, AAAAB -> all valid
+        * B -> out-of-order
+        * ABA -> out-of-order because even though the 'A' matcher could consume up to three more, once we "moved past it" by
+            hitting the 'B', the 'A' matcher has to be disabled.
+        """
+        match_batch = _MatcherBatcher(event_data)
+        for matcher in self._in_test_matchers:
+            if matcher.still_requires_match:
+                # MUST match
+                res = matcher.check_event(event_data, break_on_miss=True)
+                match_batch.add_result(matcher, res)
+                return match_batch
+            elif matcher.is_still_matchable:
+                # CAN match, but it's ok if it doesn't.
+                # todo: need to add 'lock' once something -past- this point
+                #  matches.
+                res = matcher.check_event(event_data)
+                if res is not None:
+                    match_batch.add_result(matcher, res)
+                    return match_batch
+
+        return match_batch
+
+
+class StreamGroupsUnordered(_StreamGroupsBase):
+    """
+    Unordered set of matchers.
+    """
+    def __init__(self):
+        super(StreamGroupsUnordered, self).__init__('unordered')
+
+    def check_event(self, event_data):
+        """
+        Implement the event-check logic for an unordered group. "Unordered" means that
+        while each matcher is tried in order they were added until one matches.
+        """
+        match_batch = _MatcherBatcher(event_data)
+        for matcher in self._in_test_matchers:
+            if matcher.is_still_matchable:
+                res = matcher.check_event(event_data)
+                match_batch.add_result(matcher, res)
+                if res is not None and res.is_terminal:
+                    return match_batch
+
+        return match_batch
+
+
+class StreamGroupsRoot(StreamGroupsUnordered):
+    pass

--- a/test/stream-monitor/stream_sources/stream_matchers_results.py
+++ b/test/stream-monitor/stream_sources/stream_matchers_results.py
@@ -1,0 +1,214 @@
+"""
+Copyright (c) 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+"""
+import copy
+import sys
+from StringIO import StringIO
+
+
+class StreamRunResults(object):
+    """
+    Composite of results information from a specific run
+    """
+    def __init__(self):
+        self.__all_res_list = []
+        self.__ok_res_list = []
+        self.__error_res_list = []
+
+    def add_result(self, result):
+        self.__all_res_list.append(result)
+        if result.has_error:
+            self.__error_res_list.append(result)
+        elif result.has_ok:
+            self.__ok_res_list.append(result)
+        # The 'else' here would basically be an empty result
+
+    @property
+    def had_errors(self):
+        return len(self.__error_res_list) > 0
+
+    @property
+    def is_ok(self):
+        return len(self.__ok_res_list) > 0 and len(self.__error_res_list) == 0
+
+    @property
+    def ok_count(self):
+        return len(self.__ok_res_list)
+
+    @property
+    def error_count(self):
+        return len(self.__error_res_list)
+
+    def get_error_list(self):
+        return copy.copy(self.__error_res_list)
+
+    def assert_errors(self, testcase, comment=None):
+        """
+        Utility routine to generate a single big unittest failure built
+        from the errors-list.
+
+        Note, you can also use get_error_list() and do your own.
+        """
+        if len(self.__error_res_list) == 0:
+            return  # no errors, no need to fail the test!
+        if comment is None:
+            comment = ""
+        fs = StringIO()
+        print >>fs, "Asynch stream matchers encountered {0} failures out of {1} matchers {2}".format(
+            len(self.__error_res_list), len(self.__all_res_list), comment)
+        print >>fs
+        for er in self.__error_res_list:
+            er.dump(fs, 2)
+
+        testcase.fail(fs.getvalue())
+
+    def __str__(self):
+        rs = 'results(ok={0},error={1})'.format(len(self.__ok_res_list),
+                                                len(self.__error_res_list))
+        return rs
+
+    def __repr__(self):
+        return str(self)
+
+
+class MatcherResult(object):
+    """
+    Base class for all match-results. The interesting properties are:
+      is_error : there was a match failure of some sort. For example, a matcher was
+          set up to match between 1 and 3 times and 4 matching events were seen.
+      is_terminal : true if the given match should terminate event processing. For example,
+          an overmatch (matched 4 times, but expected between 1 and 3) is terminal, since
+          the event was "consumed" in generating the overmatch. A clean miss, however, is
+          not terminal, since outside of an ordered group, more matches can attempted.
+      is_ok : currently just !is_error, but groups of matchers can currently be
+          "blank" and thus be neither errors nor ok (yet). Keeping the api the same for now.
+    """
+    def __init__(self, description, used_for, is_error, is_terminal):
+        self.description = description
+        self.__used_for = used_for
+        self.is_error = is_error
+        self.is_terminal = is_terminal
+        if self.is_error:
+            self.is_ok = False
+        else:
+            self.is_ok = True
+
+    def _update_description(self, new_description):
+        self.description = new_description
+
+    def dump(self, ofile=sys.stdout, indent=0):
+        ins = ' ' * indent
+        print >>ofile, "{0}Match result type '{1}', description='{2}'".format(
+            ins, self.__class__.__name__, self.description)
+        print >>ofile, "{0} this match-result is used for {1}".format(ins, self.__used_for)
+        print >>ofile, "{0} is_error={1}, is_terminal={2}, is_ok={3}".format(
+            ins, str(self.is_error), str(self.is_terminal), str(self.is_ok))
+
+
+class MatcherCleanHitResult(MatcherResult):
+    """
+    Used to represent a solid basic match.
+    """
+    def __init__(self, description, is_terminal=False):
+        super(MatcherCleanHitResult, self).__init__(
+            description, "representing a basic solid match",
+            is_error=False, is_terminal=is_terminal)
+
+
+class MatcherOverMatch(MatcherResult):
+    """
+    Used to represent too many matches for a given matcher. For example, expecting
+    between 2 and 3 of something, and getting 4 of them.
+    """
+    def __init__(self, description, min, max, count, is_terminal=True):
+        super(MatcherOverMatch, self).__init__(
+            description, "representing too many matches for a given matcher",
+            is_error=True, is_terminal=is_terminal)
+        self.__base_description = description
+        self.__count = count
+        self.__max = max
+        self.__min = min
+        self.__update_description()
+
+    def adjust_count(self, new_count):
+        """
+        Used to alter the overmatch with additional (over) matches, mostly
+        for diagnostic purposes.
+        """
+        self.__count = new_count
+        self.__update_description()
+
+    def __update_description(self):
+        new_descr = "{0} overmatched (count={1}, min={2}, max={3})".format(
+            self.__base_description, self.__count, self.__min, self.__max)
+        self._update_description(new_descr)
+
+
+class MatcherOrderedMissMatch(MatcherResult):
+    """
+    Used to represent an error caused by misordered matches. For example,
+    if the expectaion was to match from 1 to 2 of A and then 2 to 3 of B, but
+    we saw 'ABA' or 'B'.
+    """
+    def __init__(self, description, min, max, matched_count):
+        super(MatcherOrderedMissMatch, self).__init__(
+            description,
+            "representing misordered matches where A should follow B, but B was hit first",
+            is_error=True, is_terminal=True)
+        self.__base_description = description
+        self.__matched_at_fail = matched_count
+        self.__matched_after = 0
+        self.__missed_after = 0
+        self.__max = max
+        self.__min = min
+        self.__update_description()
+
+    def bump_matched(self):
+        """
+        marks that a(nother) match happened after the matcher was missed. For example,
+        if the expectation was 'AB', but we got 'BAA', The mismatch would get created
+        for A (when its matcher 'missed' when seeing B). This method would get called
+        twice for the two 'A's after that.
+        """
+        self.__matched_after += 1
+        self.__update_description()
+
+    def bump_missed(self):
+        """
+        marks that (another) miss happened. For example, if we were expected 'AB', but
+        got 'BB', a mismwatch would be created for A (when its matcher 'missed' when the
+        first 'B' was seen). Then this method would get called on the second 'B', since
+        we would still be look for A.
+
+        Note: I'm not 100% sure this is the right way to record this. These are, however,
+        used only for reporting the failure to help do diagnostics.
+        """
+        self.__missed_after += 1
+        self.__update_description()
+
+    def __update_description(self):
+        nd = "{0} out-of-order at {1} matched. Matches after {2}, Misses after {3}".format(
+            self.__base_description, self.__matched_at_fail, self.__matched_after,
+            self.__missed_after)
+        self._update_description(nd)
+
+
+class MatcherUnderMatch(MatcherResult):
+    """
+    Used to indicate we saw too few of something. For example, if we expected between
+    2 and 5 of 'A', but only saw 1 of them.
+    """
+    def __init__(self, description, min, max, count):
+        super(MatcherUnderMatch, self).__init__(
+            description, "representing too few matches for a given matcher",
+            is_error=True, is_terminal=False)
+        self.__base_description = description
+        self.__count = count
+        self.__max = max
+        self.__min = min
+        self.__update_description()
+
+    def __update_description(self):
+        new_descr = "{0} undermatched (count={1}, min={2}, max={3})".format(
+            self.__base_description, self.__count, self.__min, self.__max)
+        self._update_description(new_descr)

--- a/test/stream-monitor/test/plugin_test_helper.py
+++ b/test/stream-monitor/test/plugin_test_helper.py
@@ -1,6 +1,7 @@
 """
 Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 """
+from __future__ import print_function
 import unittest
 import os
 from nose.plugins import PluginTester
@@ -36,10 +37,10 @@ class _BaseStreamMonitorPluginTesterVerify(_BaseStreamMonitorPluginTester):
 
         # We print out the output from the run tests, trusting in the capture
         # code to hide it.
-        print '*' * 70
+        print('*' * 70)
         for what in self.output:
-            print ">", what.rstrip()
-        print '*' * 70
+            print(">", what.rstrip())
+        print('*' * 70)
 
         # Now check for success (_expect_nose_success can be set by a subclass
         # to mark that it expects an error to occur, and then let it handle its

--- a/test/stream-monitor/test/plugin_test_helper.py
+++ b/test/stream-monitor/test/plugin_test_helper.py
@@ -11,11 +11,23 @@ class _BaseStreamMonitorPluginTester(PluginTester, unittest.TestCase):
     activate = '--with-stream-monitor'
     _smp = StreamMonitorPlugin()
     _smp._self_test_print_step_enable()
+    _purge_step_sequence = True
     plugins = [_smp]
+
+    def tearDown(self):
+        """
+        Check the _purse_step_sequence and clear out the self-test-sequence
+        record if set. This base-class doesn't do verification of the results, nor
+        does it check the sequence. _BaseStreamMonitorPluginTesterVerify does both,
+        and will thus set the purge-var to valse.
+        """
+        if self._purge_step_sequence:
+            self._smp._self_test_sequence_seen()
 
 
 class _BaseStreamMonitorPluginTesterVerify(_BaseStreamMonitorPluginTester):
     _expect_nose_success = True
+    _purge_step_sequence = False
 
     def runTest(self):
         # This is called once for each class derived from it. We don't really

--- a/test/stream-monitor/test/support/stream-base/one_pass/test_one_pass.py
+++ b/test/stream-monitor/test/support/stream-base/one_pass/test_one_pass.py
@@ -1,2 +1,5 @@
+from __future__ import print_function
+
+
 def test_one():
-    print "test_one"
+    print("test_one")

--- a/test/stream-monitor/test/support/stream-source/logging/stderr_nocap/test_stderr_nocap.py
+++ b/test/stream-monitor/test/support/stream-source/logging/stderr_nocap/test_stderr_nocap.py
@@ -1,14 +1,15 @@
 """
 Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 """
+from __future__ import print_function
 import unittest
 
 
 class TestLoggerStderrNoError(unittest.TestCase):
     # should not see anything from this class.
     def setUp(self):
-        print "STDERR-MATCH-DATA: {0} setUp".format(self.__class__.__name__)
+        print("STDERR-MATCH-DATA: {0} setUp".format(self.__class__.__name__))
         super(TestLoggerStderrNoError, self).setUp()
 
     def test_stderr_from_testcase(self):
-        print "STDERR-MATCH-DATA: {0} test_stderr_from_testcase".format(self.__class__.__name__)
+        print("STDERR-MATCH-DATA: {0} test_stderr_from_testcase".format(self.__class__.__name__))

--- a/test/stream-monitor/test/support/stream-source/logging/stdout_errcap/test_stdout_errcap.py
+++ b/test/stream-monitor/test/support/stream-source/logging/stdout_errcap/test_stdout_errcap.py
@@ -1,17 +1,18 @@
 """
 Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 """
+from __future__ import print_function
 import unittest
 
 
 class TestLoggerStdoutError(unittest.TestCase):
     def setUp(self):
-        print "STDOUT-MATCH-DATA: {0} setUp".format(self.__class__.__name__)
+        print("STDOUT-MATCH-DATA: {0} setUp".format(self.__class__.__name__))
         super(TestLoggerStdoutError, self).setUp()
 
     def test_stdout_from_testcase(self):
-        print "STDOUT-MATCH-DATA: {0} test_stdout_from_testcase".format(self.__class__.__name__)
+        print("STDOUT-MATCH-DATA: {0} test_stdout_from_testcase".format(self.__class__.__name__))
         raise Exception("error in test rather than fail type thing")
 
     def test_no_stdout_from_testcase(self):
-        print "STDOUT-MUST-NOT-SEE: {0} test_no_stdout_from_testcase".format(self.__class__.__name__)
+        print("STDOUT-MUST-NOT-SEE: {0} test_no_stdout_from_testcase".format(self.__class__.__name__))

--- a/test/stream-monitor/test/support/stream-source/logging/stdout_failcap/test_stdout_failcap.py
+++ b/test/stream-monitor/test/support/stream-source/logging/stdout_failcap/test_stdout_failcap.py
@@ -1,17 +1,18 @@
 """
 Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 """
+from __future__ import print_function
 import unittest
 
 
 class TestLoggerStdoutFail(unittest.TestCase):
     def setUp(self):
-        print "STDOUT-MATCH-DATA: {0} setUp".format(self.__class__.__name__)
+        print("STDOUT-MATCH-DATA: {0} setUp".format(self.__class__.__name__))
         super(TestLoggerStdoutFail, self).setUp()
 
     def test_stdout_from_testcase(self):
-        print "STDOUT-MATCH-DATA: {0} test_stdout_from_testcase".format(self.__class__.__name__)
+        print("STDOUT-MATCH-DATA: {0} test_stdout_from_testcase".format(self.__class__.__name__))
         self.assertTrue(False, "failed test to check against")
 
     def test_no_stdout_from_testcase(self):
-        print "STDOUT-MUST-NOT-SEE: {0} test_no_stdout_from_testcase".format(self.__class__.__name__)
+        print("STDOUT-MUST-NOT-SEE: {0} test_no_stdout_from_testcase".format(self.__class__.__name__))

--- a/test/stream-monitor/test/support/stream-source/logging/stdout_nocap/test_stdout_nocap.py
+++ b/test/stream-monitor/test/support/stream-source/logging/stdout_nocap/test_stdout_nocap.py
@@ -1,14 +1,15 @@
 """
 Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 """
+from __future__ import print_function
 import unittest
 
 
 class TestLoggerStdoutNoError(unittest.TestCase):
     # should not see anything from this class.
     def setUp(self):
-        print "STDOUT-MATCH-DATA: {0} setUp".format(self.__class__.__name__)
+        print("STDOUT-MATCH-DATA: {0} setUp".format(self.__class__.__name__))
         super(TestLoggerStdoutNoError, self).setUp()
 
     def test_stdout_from_testcase(self):
-        print "STDOUT-MATCH-DATA: {0} test_stdout_from_testcase".format(self.__class__.__name__)
+        print("STDOUT-MATCH-DATA: {0} test_stdout_from_testcase".format(self.__class__.__name__))

--- a/test/stream-monitor/test/test_logopts.py
+++ b/test/stream-monitor/test/test_logopts.py
@@ -77,13 +77,9 @@ class _OutputScannerBase(plugin_test_helper.resolve_no_verify_helper_class()):
 
     def tearDown(self, *args, **kwargs):
         """
-        The mirror of setUp. We restore stderr and then do our one magic trick:
-        We clear out the call sequence of the stream-monitor plugin. WE don't use it, but
-        can't turn it off and if we don't clear it, OUR calls will end up in the
-        next test's sequence!
+        The mirror of setUp. We restore stderr, and call our super.
         """
         sys.stderr = self.__save_stderr
-        self._smp._self_test_sequence_seen()
         super(_OutputScannerBase, self).tearDown(*args, **kwargs)
 
     def __common_test_expected(self, expect_level, emit_level, logger_name, log_file):

--- a/test/stream-monitor/test/test_logopts.py
+++ b/test/stream-monitor/test/test_logopts.py
@@ -145,7 +145,7 @@ class _OutputScannerBase(plugin_test_helper.resolve_no_verify_helper_class()):
                 lg = logging.getLogger(lg_name)
                 start_level = logging.getLevelName('DEBUG_9')
                 end_level = logging.getLevelName('CRITICAL_0')
-                for lvl in xrange(start_level, end_level):
+                for lvl in range(start_level, end_level):
                     lg.log(lvl, 'MATCH-START %s %d(%s) MATCH-END',
                            lg_name, lvl, logging.getLevelName(lvl))
 

--- a/test/stream-monitor/test/test_matchers.py
+++ b/test/stream-monitor/test/test_matchers.py
@@ -4,6 +4,7 @@ Copyright (c) 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 Self-test of the matcher infrastructure. This is less about individual matchers,
 and more about if the various sequences and groups work (and fail!) as expected.
 """
+from __future__ import print_function
 import unittest
 import plugin_test_helper
 import inspect
@@ -24,7 +25,7 @@ class _InnerResults(object):
     def dump_exception(self):
         if self.__exception_str is not None:
             for line in self.__exception_str.split('\n'):
-                print line
+                print(line)
 
 
 class TestMatcherGroups(plugin_test_helper.resolve_no_verify_helper_class()):

--- a/test/stream-monitor/test/test_matchers.py
+++ b/test/stream-monitor/test/test_matchers.py
@@ -1,0 +1,315 @@
+"""
+Copyright (c) 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+Self-test of the matcher infrastructure. This is less about individual matchers,
+and more about if the various sequences and groups work (and fail!) as expected.
+"""
+import unittest
+import plugin_test_helper
+import inspect
+import traceback
+import re
+from sm_plugin import smp_get_stream_monitor
+
+
+class _InnerResults(object):
+    def __init__(self, results_obj, exception_str=None):
+        self.__exception_str = exception_str
+        self.results = results_obj
+
+    @property
+    def is_exception(self):
+        return isinstance(self.results, Exception)
+
+    def dump_exception(self):
+        if self.__exception_str is not None:
+            for line in self.__exception_str.split('\n'):
+                print line
+
+
+class TestMatcherGroups(plugin_test_helper.resolve_no_verify_helper_class()):
+    """
+    This is the test-container for the stream-monitor matchers.
+
+    This is a nose-plugin tester based test-container, which means that makeSuite is
+    called once for each "test_xxxx" method in this class and returns a list of
+    test-cases to run. Each of those is run _within_ the context of its own complete
+    nose environment (complete with the plugin(s) we are testing!) , and then the
+    "test_xxxx" method is called.
+
+    This, however, means one normally needs to make a complete class for each test case,
+    since if you don't, all the test-cases from makeSuite get called once for each
+    outer test-case. Also, errors from the makeSuite test cases are not reported
+    directly to the outer-context, which means test counts and such would be off.
+
+    To streamline this a little, makeSuite "peeks" at the outer test-name and only
+    returns a single test-case containing the inner-test-case for the exact same name.
+    It also passes the outer-test-case into the inner own so that it can set its
+    results into TestMatcherGroups.test_suite_result['test_name_xxxx'], allowing the
+    outer tests to do the work of looking at results, while the inner ones just do
+    the sequencing.
+    """
+    test_suite_results = {}
+    longMessage = True   # this turns on printing of arguments for unittest.assert*s
+
+    def __get_inner_results(self):
+        our_frame = inspect.currentframe()
+        # climb looking for the first thing starting with 'test_'. We
+        # could just pop one up, but that would make things like
+        # self.assertRaises() fail.
+        while our_frame is not None and not our_frame.f_code.co_name.startswith('test_'):
+            our_frame = our_frame.f_back
+        assert our_frame is not None, \
+            "alleged impossible situation where no 'test_' was found in stack"
+
+        # get our callers name
+        parent_name = our_frame.f_code.co_name
+
+        # now fetch results put there by the method with the same name
+        # inside a TC from makeSuite() below.
+        iresult = self.test_suite_results[parent_name]
+
+        # if it was an assertion, throw it again (allow self.Raises and such)
+        if iresult.is_exception:
+            # dump the traceback to stdout. If the exception is caught by the
+            # specific test, then it will show up nicely in capture.
+            iresult.dump_exception()
+            raise iresult.results
+        return iresult.results
+
+    def test_TC_test_error(self):
+        self.assertRaisesRegexp(NameError,
+                                "global name 'will_throw_an_error' is not defined$",
+                                self.__get_inner_results)
+
+    def test_TC_test_fail(self):
+        self.assertRaisesRegexp(AssertionError, 'this_will_throw_a_fail$',
+                                self.__get_inner_results)
+
+    def test_TC_test_pass(self):
+        iresult = self.__get_inner_results()
+        self.assertEqual(iresult, 'I_passed!!!',
+                         "expected 'I_passed!!!' got '{0}'".format(iresult))
+
+    def __assert_basic_results(self, ok, oks=1, errs=0):
+        iresult = self.__get_inner_results()
+        self.assertEqual(iresult.is_ok, ok,
+                         'is_ok was {0} not expected {1}'.format(iresult.is_ok, ok))
+        self.assertEqual(
+            iresult.had_errors, (not ok),
+            'had_errors was {0} not expected {1}'.format(iresult.had_errors, not ok))
+        self.assertEqual(
+            iresult.ok_count, oks,
+            'ok_count was {0} not expected {1}'.format(iresult.ok_count, oks))
+        self.assertEqual(
+            iresult.error_count, errs,
+            'error_count was {0} not expected {1}'.format(iresult.error_count, errs))
+        return iresult
+
+    def __test_error_asserts(self, inner_results, fails, matchers, events, match_results):
+        """
+        Spot check of assert_errors from results:
+        * make sure an error is thrown
+        * make sure fails/matchers count is expected
+        * make sure events occured in right order
+        * make sure match-results types occured in right order
+        """
+        with self.assertRaises(AssertionError) as cm:
+            inner_results.assert_errors(self)
+
+        the_exception = cm.exception
+        tes = str(the_exception)
+        # Start by checking the failures and matchers counts were what we expected
+        count_match = 'Asynch stream matchers encountered {0} failures out of {1} matchers'.format(
+            fails, matchers)
+        self.assertRegexpMatches(tes, count_match, 'incorrect failures/matchers')
+        # Now make sure we had all the events in the right order
+        ere = re.compile(r'''Matched \d+ matchers on event:$\s+'(?P<event_txt>.*)'$''',
+                         re.MULTILINE)
+        found_events = []
+        for match in ere.finditer(tes):
+            found_events.append(match.group('event_txt'))
+        self.assertListEqual(events, found_events, 'events expected != found')
+
+        # And finally look for the 'Match result type' lines show up in the expected order
+        mrtre = re.compile('''Match result type '(?P<result_type>.*?)',''')
+        found_mrt = []
+        for match in mrtre.finditer(tes):
+            found_mrt.append(match.group('result_type'))
+        self.assertListEqual(match_results, found_mrt, 'expected match-types != found')
+
+    def test_match_single(self):
+        """test that a single simple matcher:match is successful"""
+        self.__assert_basic_results(ok=True, oks=1, errs=0)
+
+    def test_overmatch(self):
+        """test double match on singler matcher generates error"""
+        ires = self.__assert_basic_results(ok=False, oks=1, errs=1)
+        self.__test_error_asserts(
+            ires, fails=1, matchers=3, events=['ook'],
+            match_results=['MatcherOverMatch'])
+
+    def test_zero_vs_one_undermatch(self):
+        """test no matches on a required one match generates error"""
+        ires = self.__assert_basic_results(ok=False, oks=0, errs=1)
+        self.__test_error_asserts(
+            ires, fails=1, matchers=1, events=['finish'],
+            match_results=['MatcherUnderMatch'])
+
+    def test_any_order_first_first(self):
+        """test any-order group works with 1st than 2nd match"""
+        ires = self.__assert_basic_results(ok=True, oks=2, errs=0)
+        ires.assert_errors(self)    # should have none
+
+    def test_any_order_2nd_first(self):
+        """test any-order group works with 1st than 2nd match"""
+        ires = self.__assert_basic_results(ok=True, oks=2, errs=0)
+        ires.assert_errors(self)    # should have none
+
+    def test_ordered_works_single(self):
+        """test in-order group works with single match"""
+        ires = self.__assert_basic_results(ok=True, oks=1, errs=0)
+        ires.assert_errors(self)    # should have none
+
+    def test_ordered_works_double(self):
+        """test in-order group works with double match"""
+        ires = self.__assert_basic_results(ok=True, oks=2, errs=0)
+        ires.assert_errors(self)    # should have none
+
+    def test_ordered_out_of_order_double(self):
+        """test in-order group fails with out-of-order double match"""
+        ires = self.__assert_basic_results(ok=False, oks=0, errs=3)
+        self.__test_error_asserts(
+            ires, fails=3, matchers=3,
+            events=['m2', 'm1', 'finish'],
+            match_results=['MatcherOrderedMissMatch', 'MatcherOrderedMissMatch', 'MatcherUnderMatch'])
+
+    def makeSuite(self):
+        class TC(unittest.TestCase):
+            """testme testme testme"""
+            def __init__(self, owner, test_method_name, *args, **kwargs):
+                self.__owner = owner
+                self.__this_method_this_time = test_method_name
+                super(TC, self).__init__(*args, **kwargs)
+
+            def shortDescription(self):
+                return self.__this_method_this_time
+
+            def __str__(self):
+                return '{0} ({1})'.format(
+                    self.__this_method_this_time,
+                    unittest.util.strclass(self.__class__))
+
+            def setUp(self):
+                """
+                Most of these tests use the self-test stream monitor, so get it now.
+                """
+                self.__stsm = smp_get_stream_monitor('self-test')
+
+            # Can I 1:! map each of these to a check routine up there? ^^^
+            def test_TC_test_error(self):
+                # Self-check of tester-class to check errors are seen
+                this = will_throw_an_error  # NOQA: undefined name
+
+            def test_TC_test_fail(self):
+                # Self-check of tester-class to check fail (self.asserts) are seen
+                self.assertFalse(True, 'this_will_throw_a_fail')
+
+            def test_TC_test_pass(self):
+                # Self-check of tester-class to check if pass is seen
+                return 'I_passed!!!'
+
+            def test_match_single(self):
+                self.__stsm.match_single('ook', 'check that monkey said something')
+                self.__stsm.inject('ook')
+                results = self.__stsm.finish()
+                return results
+
+            def test_overmatch(self):
+                self.__stsm.match_single(
+                    'ook', 'check that the monkey said only only one thing')
+                self.__stsm.inject('ook')
+                self.__stsm.inject('ook')
+                results = self.__stsm.finish()
+                return results
+
+            def test_zero_vs_one_undermatch(self):
+                self.__stsm.match_single('ook', 'speak no evil')
+                results = self.__stsm.finish()
+                return results
+
+            def test_any_order_first_first(self):
+                self.__stsm.match_single('m1', 'will match first')
+                self.__stsm.match_single('m2', 'will matcd second')
+                self.__stsm.inject('m1')
+                self.__stsm.inject('m2')
+                results = self.__stsm.finish()
+                return results
+
+            def test_any_order_2nd_first(self):
+                self.__stsm.match_single('m1', 'will match first')
+                self.__stsm.match_single('m2', 'will matcd second')
+                self.__stsm.inject('m2')
+                self.__stsm.inject('m1')
+                results = self.__stsm.finish()
+                return results
+
+            def test_ordered_works_single(self):
+                self.__stsm.push_group(ordered=True)
+                self.__stsm.match_single('m1', 'will match first')
+                self.__stsm.inject('m1')
+                self.__stsm.pop_group()
+                results = self.__stsm.finish()
+                return results
+
+            def test_ordered_works_double(self):
+                self.__stsm.push_group(ordered=True)
+                self.__stsm.match_single('m1', 'will match first')
+                self.__stsm.match_single('m2', 'will match second')
+                self.__stsm.inject('m1')
+                self.__stsm.inject('m2')
+                self.__stsm.pop_group()
+                results = self.__stsm.finish()
+                return results
+
+            def test_ordered_out_of_order_double(self):
+                self.__stsm.push_group(ordered=True)
+                self.__stsm.match_single('m1', 'will match first')
+                self.__stsm.match_single('m2', 'will match second')
+                self.__stsm.inject('m2')
+                self.__stsm.inject('m1')
+                self.__stsm.pop_group()
+                results = self.__stsm.finish()
+                return results
+
+            def runTests(self):
+                method_set = inspect.getmembers(self, self.__check_for_usable_test)
+                ran_one = False
+                for method_name, method in method_set:
+                    if method_name == self.__this_method_this_time:
+                        self.__run_test(method_name, method)
+                        ran_one = True
+                        break
+                assert ran_one, \
+                    'Unable to find test-method matching {0}'.format(self.__this_method_this_time)
+
+            def __run_test(self, method_name, method):
+                results = None
+                exception_str = None
+                try:
+                    results = method()
+                except Exception as ex:
+                    results = ex
+                    exception_str = traceback.format_exc()
+
+                results = _InnerResults(results, exception_str)
+
+                self.__owner.test_suite_results[method_name] = results
+
+            def __check_for_usable_test(self, item):
+                if inspect.ismethod(item):
+                    # ok, it's at least a method.
+                    if item.__name__.startswith('test_'):
+                        return True
+                return False
+        return [TC(self, self._testMethodName, 'runTests')]


### PR DESCRIPTION
This story was pre-dojo and is way too long. It is a good checkpoint of the asynch matching engine to date, however!

Primary feature chunks in here:
* Added the stream-monitor base plugin. This is the classes that specific stream monitors will be based on.
* Added a matcher engine (stream_matchers_base.py)
** ordered and unordered groups of matchers, along with a root group. The groups are the entry point for processing "events" and do a lot of the common logic.
** a StreamMatchBase that protocol-specific matchers will subclass to implement their special sauce. Handles a lot of common logic, leaving as little as possible to be done in the subclass. Mostly implementing '_match' to try and see if an event matches or not.
** a match-batch class to tie events to the results of various matchers in the groups
* Added various matched-types in stream_matchers_results
** MatcherResult (base class)
** MatcherUnderMatch -- indicates a match fail because not enough matches were seen on the given matcher
** MatcherOverMatch -- indicaes a match fail because too many matches were seen on the given matcher
** MatcherCleanHitResult -- indicates success. Yay!
** MatcherOrderedMissMatch -- indicates out-of-order seen in an ordered group
* Created a selftest stream-monitor with a simple exact string match matcher and injector
* And since this IS TDD, there is a test_matchers.py plugin tester.

The bigger pieces of "todo" left are:
* make it possible to do the injections from a different greenlet to actually simulate async
* add a "wait_for" type operation (right now there is a "finish" call that just examines already injected events)

However, I want to get this in and start doing much smaller stories for the pieces. Also, the next step is to add the AMQP stream watcher, which pretty much means those two "todos" happen in that sequence of stories.

Note: also modified "mkcheck.sh" to pass on arguments the flake8 to allow testing of a specific file (or in this case, subdirectory)

One thing to remember is that this is the engine bits. The dev-facing "api" is very open to amendment in the next stories.

@hohene @diontje @gpaulos @RackHD/corecommitters