### PR TITLE
Adding back lines for CIT test

### DIFF
--- a/test/tests/api/v2_0/nodes_tests.py
+++ b/test/tests/api/v2_0/nodes_tests.py
@@ -283,6 +283,7 @@ class NodesTests(object):
                 resps.append(self.__get_data())
         for resp in resps:
             assert_not_equal(0, len(resp), message='No Workflows found for Node')
+        Api().nodes_get_workflow_by_id('fooey')
 
     @test(groups=['node_post_workflows-api2'], depends_on_groups=['node_workflows-api2'])
     def test_node_workflows_post(self):


### PR DESCRIPTION
Relates to RAC-1984, https://github.com/RackHD/on-http/pull/551

Small PR returning a line of code that was removed from a test by mistake.

I made a mistake with a previous PR which removed three lines from this CIT test. The line added to the CIT test by this PR was originally in this test and exposes data which is used in later tests.