### PR TITLE
rac-3775 need logger-name in log-line

### DIFF
--- a/test/stream-monitor/flogging/infra_logging.py
+++ b/test/stream-monitor/flogging/infra_logging.py
@@ -32,6 +32,19 @@ class _GeventInfoFilter(logging.Filter):
         # pop up two levels to the 'fit_tests' directory.
         test_dir = os.path.dirname(os.path.dirname(our_dir))
         self.__path_trim = test_dir + '/'
+        self.__current_test_name = 'any tests'
+        self.__current_test_case_number = '**.**'
+
+    def sm_set_running_test(self, test_case_number, test_name):
+        """
+        Method to allow a stream-monitor plugin for test execution to tell us where
+        in execution we are.
+        param test_case_number: string of a test-case number for this test. Also includes
+            '+' for setup, '-' for teardown, '=' for in, and '*' for after.
+        param test_name: actual test name (may contain spaces)
+        """
+        self.__current_test_name = test_name
+        self.__current_test_case_number = test_case_number
 
     # todo: trim 'pathname' to root of tree, not global
     #  and log shortening event (to keep abs context)
@@ -45,6 +58,8 @@ class _GeventInfoFilter(logging.Filter):
         else:
             gname = getattr(cur, 'log_facility', str(cur))
         record.greenlet = '{0!s}'.format(gname)
+        record.test_name = self.__current_test_name
+        record.test_case_number = self.__current_test_case_number
 
         # This section removes the process, path, and greenlet information
         # from any mssage that starts with any of the characters ' +-'.
@@ -55,7 +70,9 @@ class _GeventInfoFilter(logging.Filter):
         if any(elem in record.msg[0] for elem in r' +-?%'):
             lif = ''
         else:
-            lif = '{r.process} {r.processName} {r.pathname}:{r.funcName}@{r.lineno} {r.greenlet}'.format(r=record)
+            u_lif = '{r.test_case_number} {r.process} {r.processName} {r.pathname}:{r.funcName}@{r.lineno} ' + \
+                '{r.greenlet} [{r.test_name}]'
+            lif = u_lif.format(r=record)
         record.location_info_string = lif
 
         return True
@@ -308,7 +325,7 @@ class _LoggerSetup(object):
             'formatters': {
                 'simple': {
                     'format': '%(asctime)s %(levelname)-7s %(message)-90s'
-                              ' %(location_info_string)s'
+                              ' %(name)s %(location_info_string)s'
                 },
                 'original': {
                     'format': '%(asctime)s %(process)d %(processName)s '

--- a/test/stream-monitor/stream_sources/log_type.py
+++ b/test/stream-monitor/stream_sources/log_type.py
@@ -23,6 +23,11 @@ class LoggingMarker(StreamMonitorBaseClass):
         # todo: use nose plugin debug options
         self.__loggers = self.__find_loggers()
         self.__test_cnt = 1
+        self.__test_number_str = ''
+        self.__set_test_number_str()
+
+    def __set_test_number_str(self):
+        self.__test_number_str = '{0}.{1:02d}'.format(self._all_blocks, self.__test_cnt)
 
     @classmethod
     def enabled_for_nose(self):
@@ -42,18 +47,49 @@ class LoggingMarker(StreamMonitorBaseClass):
         self.__loggers = self.__find_loggers()
         self._all_blocks += 1
         self.__test_cnt = 1
+        self.__set_test_number_str()
         self.__mark_all_loggers('', ' Start Of Test Block: {}'.format(self._all_blocks))
 
+    def handle_before_test(self, test):
+        """
+        Handle just before the given test starts. I.E., will cover setup and such.
+        We just tell our infra-logging where we are at.
+        """
+        self.__set_running_test_all_loggers(test, '+')
+
     def handle_start_test(self, test):
-        self.__mark_all_loggers('',
-                                '+{0}.{1:02d} - STARTING TEST: %s'.format(self._all_blocks, self.__test_cnt),
-                                str(test))
+        self.__mark_all_loggers('', '+%s - STARTING TEST: [%s]', self.__test_number_str, str(test))
+        self.__set_running_test_all_loggers(test, '>')
 
     def handle_stop_test(self, test):
-        self.__mark_all_loggers('',
-                                '-{0}.{1:02d} - ENDING TEST: %s'.format(self._all_blocks, self.__test_cnt),
-                                str(test))
+        self.__set_running_test_all_loggers(test, '-')
+        self.__mark_all_loggers('', '-%s - ENDING TEST: [%s]', self.__test_number_str, str(test))
+
+    def handle_after_test(self, test):
+        """
+        Handle after the test is complete and recorded (between tests, basically)
+        We just tell our infra-logging where we are at.
+        """
+        self.__set_running_test_all_loggers(test, '*')
         self.__test_cnt += 1
+        self.__set_test_number_str()
+
+    def __set_running_test_all_loggers(self, test, where):
+        """
+        Tell each logger where we are "at" in terms of which test is running. This
+        allows infra-logging to put the test-name into the log line.
+        param test: test case current being handled
+        param where: string about what step this is on.
+        """
+        loggers = self.__loggers.values()
+        loggers.append(real_getLogger())
+        for logger in loggers:
+            handlers = getattr(logger, 'handlers', [])
+            for handler in handlers:
+                for filter in handler.filters:
+                    if hasattr(filter, 'sm_set_running_test'):
+                        tns = '{0}{1}'.format(where, self.__test_number_str)
+                        filter.sm_set_running_test(tns, str(test))
 
     def __mark_all_in_logger(self, level, logger, msg, args, exc_info=None, extra=None):
         # Note: 'handlers' only exists on Logger() instances.

--- a/test/stream-monitor/test/plugin_test_helper.py
+++ b/test/stream-monitor/test/plugin_test_helper.py
@@ -4,8 +4,11 @@ Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 from __future__ import print_function
 import unittest
 import os
+import sys
 from nose.plugins import PluginTester
 from sm_plugin import StreamMonitorPlugin
+from log_stream_helper import TempLogfileChecker
+from StringIO import StringIO
 
 
 class _BaseStreamMonitorPluginTester(PluginTester, unittest.TestCase):
@@ -13,6 +16,7 @@ class _BaseStreamMonitorPluginTester(PluginTester, unittest.TestCase):
     _smp = StreamMonitorPlugin()
     _smp._self_test_print_step_enable()
     _purge_step_sequence = True
+    longMessage = True
     plugins = [_smp]
 
     def tearDown(self):
@@ -39,7 +43,7 @@ class _BaseStreamMonitorPluginTesterVerify(_BaseStreamMonitorPluginTester):
         # code to hide it.
         print('*' * 70)
         for what in self.output:
-            print(">", what.rstrip())
+            print("> {0}".format(what.rstrip()))
         print('*' * 70)
 
         # Now check for success (_expect_nose_success can be set by a subclass
@@ -112,12 +116,54 @@ class _BaseStreamMonitorPluginTesterVerify(_BaseStreamMonitorPluginTester):
                         arg_key, arg_str, m_str)
 
 
+class _BaseLogOutScannerBase(_BaseStreamMonitorPluginTester):
+    """
+    Plugin tester instance used for each real test block.
+    """
+    def setUp(self, *args, **kwargs):
+        """
+        This is called before all the test in the block, but in the context of the
+        plugin-under-test. We do the following:
+        * replace stderr with a StringIO stream.
+        * start a dict of log-file to our cheesy log-file-checkers on the stderr streamio.
+        * add to the dict of log-files with a cheesy log-file-checkers for each physical log file.
+        * init our super (to finish any wiring IT has to do)
+        """
+        checker_dict = {}
+        self.__save_stderr = sys.stderr
+        self.__stream_stderr = StringIO()
+        sys.stderr = self.__stream_stderr
+        checker_dict['stderr'] = TempLogfileChecker('stderr', self.__stream_stderr)
+
+        lg_names = ['all_all.log', 'console_capture.log', 'infra_data.log',
+                    'infra_run.log', 'test_data.log', 'test_run.log']
+        for lg_name in lg_names:
+            checker_dict[lg_name] = TempLogfileChecker(lg_name)
+        self._lgfile_watchers = checker_dict
+        super(_BaseLogOutScannerBase, self).setUp(*args, **kwargs)
+
+    def tearDown(self, *args, **kwargs):
+        """
+        The mirror of setUp. We restore stderr and then do our one magic trick:
+        We clear out the call sequence of the stream-monitor plugin. WE don't use it, but
+        can't turn it off and if we don't clear it, OUR calls will end up in the
+        next test's sequence!
+        """
+        sys.stderr = self.__save_stderr
+        self._smp._self_test_sequence_seen()
+        super(_BaseLogOutScannerBase, self).tearDown(*args, **kwargs)
+
+
 def resolve_helper_class():
     return _BaseStreamMonitorPluginTesterVerify
 
 
 def resolve_no_verify_helper_class():
     return _BaseStreamMonitorPluginTester
+
+
+def resolve_logoutput_scanner_helper_class():
+    return _BaseLogOutScannerBase
 
 
 def resolve_suitepath(*args):

--- a/test/stream-monitor/test/test_log_stream.py
+++ b/test/stream-monitor/test/test_log_stream.py
@@ -2,6 +2,7 @@
 Copyright (c) 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 """
 import plugin_test_helper
+import unittest
 from log_stream_helper import TempLogfileChecker
 
 
@@ -340,3 +341,30 @@ class TestSMPLoggingStderr_test_data_fail(_StderrFailCaptureBase):
 class TestSMPLoggingStderr_console_capture_fail(_StderrFailCaptureBase):
     _capture_finder_file = 'console_capture.log'
     _capture_finder_count = 1
+
+
+class _FullLineFormatChecker(plugin_test_helper.resolve_logoutput_scanner_helper_class()):
+    def makeSuite(self):
+        """
+        Required method that the nose-plugin-testing system calls to generate
+        the list of test cases to be run inside the plugin-context. It returns
+        a list with a single item in it that all the subclasses use.
+        """
+        class TC(unittest.TestCase):
+            def runTest(self):
+                import logging
+                lg_list = ['root', 'infra.run', 'infra.data', 'test.run', 'test.data']
+                for lg_name in lg_list:
+                    lg = logging.getLogger(lg_name)
+                    lg.info('MATCH-FMAT-START %s MATCH-END', lg_name)
+
+        return [TC()]
+
+    def __common_checker(self, logger_name, logger_file=None):
+        if logger_file is None:
+            logger_file = logger_name.replace('.', '_') + '.log'
+        file_watcher = self._lgfile_watchers[logger_file]
+        file_watcher.check_full_format(self, logger_name)
+
+    def test_infra_run_file(self):
+        self.__common_checker('infra.run')

--- a/test/stream-monitor/test/test_log_stream_fmat.py
+++ b/test/stream-monitor/test/test_log_stream_fmat.py
@@ -1,0 +1,71 @@
+"""
+Copyright (c) 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+"""
+import plugin_test_helper
+import unittest
+
+
+class FullLineFormatChecker(plugin_test_helper.resolve_logoutput_scanner_helper_class()):
+    def makeSuite(self):
+        """
+        Used for all out-test-cases to inject a log entry into each logger.
+        """
+        class TC(unittest.TestCase):
+            def runTest(self):
+                import logging
+                lg_list = ['root', 'infra.run', 'infra.data', 'test.run', 'test.data']
+                for lg_name in lg_list:
+                    lg = logging.getLogger(lg_name)
+                    lg.info('MATCH-FMAT-START %s MATCH-FMAT-END', lg_name)
+
+        return [TC()]
+
+    def __common_checker(self, logger_name):
+        logger_file = logger_name.replace('.', '_') + '.log'
+        self.__common_multi_logger_checker([logger_name], logger_file)
+
+    def __common_multi_logger_checker(self, match_lg_names, logger_file, bracketing_lg_names=None):
+        """
+        Helper method to invoke the file-watcher for the requested logger_file.
+
+        param match_lg_names is a list of logger names (like ['infra.run', 'infra.data']).
+            These will be expected to appear in the actual lines injected by makeSuite.TC
+        param logger_file is the key to our base-classes collection of file-watchers.
+        param bracketing_lg_names is a list of logger names that will appear in various
+            bracketing log lines (like "Start Of Test Block", "STARTING TEST", and "ENDING TEST")
+            If left as None, it is populated with the match_lg_params.
+        """
+        if bracketing_lg_names is None:
+            bracketing_lg_names = match_lg_names
+
+        file_watcher = self._lgfile_watchers[logger_file]
+        # alas, the test name is always our TC from makeSuite. Hard-code name:
+        test_name = 'runTest (test_log_stream_fmat.TC)'
+        our_file = __file__
+        if our_file.endswith('.pyc'):
+            our_file = our_file[:-1]  # turn into '.py' from '.pyc'!
+        file_watcher.check_full_format(self, match_lg_names, bracketing_lg_names, test_name, our_file)
+
+    def test_infra_run_file(self):
+        self.__common_checker('infra.run')
+
+    def test_infra_data_file(self):
+        self.__common_checker('infra.data')
+
+    def test_test_run_file(self):
+        self.__common_checker('test.run')
+
+    def test_test_data_file(self):
+        self.__common_checker('test.data')
+
+    def test_all_all(self):
+        self.__common_multi_logger_checker(
+            ['infra.data', 'test.data', 'test.run', 'infra.run'], 'all_all.log')
+
+    def test_console_capture(self):
+        self.__common_multi_logger_checker(
+            ['infra.data', 'test.data', 'test.run', 'infra.run'], 'console_capture.log', ['root'])
+
+    def test_stderr_capture(self):
+        self.__common_multi_logger_checker(
+            ['infra.data', 'test.data', 'test.run', 'infra.run'], 'stderr', ['root'])

--- a/test/stream-monitor/test/test_logopts.py
+++ b/test/stream-monitor/test/test_logopts.py
@@ -2,11 +2,8 @@
 Copyright (c) 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 """
 import plugin_test_helper
-import sys
-from log_stream_helper import TempLogfileChecker
 import unittest
 import logging
-from StringIO import StringIO
 
 
 class _Expector(object):
@@ -49,45 +46,16 @@ class _Expector(object):
             self.expect_for_real = real_at
 
 
-class _OutputScannerBase(plugin_test_helper.resolve_no_verify_helper_class()):
+class _OutputScannerBase(plugin_test_helper.resolve_logoutput_scanner_helper_class()):
     """
     Plugin tester instance used for each real test block.
     """
-    def setUp(self, *args, **kwargs):
-        """
-        This is called before all the test in the block, but in the context of the
-        plugin-under-test. We do the following:
-        * replace stderr with a StringIO stream.
-        * start a dict of log-file to our cheesy log-file-checkers on the stderr streamio.
-        * add to the dict of log-files with a cheesy log-file-checkers for each physical log file.
-        * init our super (to finish any wiring IT has to do)
-        """
-        checker_dict = {}
-        self.__save_stderr = sys.stderr
-        self.__stream_stderr = StringIO()
-        sys.stderr = self.__stream_stderr
-        checker_dict['stderr'] = TempLogfileChecker('stderr', self.__stream_stderr)
-
-        lg_names = ['all_all.log', 'console_capture.log', 'infra_data.log',
-                    'infra_run.log', 'test_data.log', 'test_run.log']
-        for lg_name in lg_names:
-            checker_dict[lg_name] = TempLogfileChecker(lg_name)
-        self.__lgfile_watchers = checker_dict
-        super(_OutputScannerBase, self).setUp(*args, **kwargs)
-
-    def tearDown(self, *args, **kwargs):
-        """
-        The mirror of setUp. We restore stderr, and call our super.
-        """
-        sys.stderr = self.__save_stderr
-        super(_OutputScannerBase, self).tearDown(*args, **kwargs)
-
     def __common_test_expected(self, expect_level, emit_level, logger_name, log_file):
         if expect_level is not None:
             exp_levelno = logging.getLevelName(expect_level)
             emit_levelno = logging.getLevelName(emit_level)
             expect_level = max(exp_levelno, emit_levelno)
-        self.__lgfile_watchers[log_file].check_level_output(
+        self._lgfile_watchers[log_file].check_level_output(
             self, expect_level, logger_name)
 
     def test_infra_run_expected(self):


### PR DESCRIPTION
This adds tests and code to include the following new data in each log-line:
* the logger name that originated the message, such as 'infra.run' and so-on
* the log-type stream-source's test-case-number (test_block.test_number), which is currently only in the special start/stop messages
* the test-name being executed.

Note that the test-name being part of every line unblocks the story to allow a user to say "turn up the logging on THIS test and this test ONLY to 11"...

Changes done to make this happen:
* added test-name, test-case-number, and name to infra-logging
* adjusted stream_monitor to callout to handle_before_test, handle_after_test, and made the callout method a common one that checks for the attribute before calling
* added the following to the log_type stream-source:
** added a utility method to set what test is being run and the current log-type based test-case-number to all infralogging loggers
** adjusted existing start_test and stop_test to call the new utility method
** added handlers for before_test and after_test that also call the new utility method
Note: the test-case-number includes a prefix character saying where in the test-case life-cycle things are. '+' for before test (basically setup), '>' for during, '-' for teardown, and '*' for outside of any test.
* Change in 'test' directory to support testing this:
** log_stream_helper go a new pile of check methods to do these formating validations (this also addresses technical debt in full line-format validation)
** Moved the base of the _OutputScannerBase from test_logopts.py into plugin_test_helper as _BaseLogOutScannerBase with associated resolve_logoutput_scanner_helper_class() module call.
** Changed test_logopts.py to use the new resolve_logoutput_scanner_helper_class() based class
** added test/test_log_stream_fmat.py with FullLineFormatChecker based on resolve_logoutput_scanner_helper_class() that coodinates checks of the contents of each logger file (or stderr)

Also had to make a few changes for python2/3 compatability (hound appears to have started using python3)

A sample of logfile-lines:
```
2017-02-22 11:24:47,948 DEBUG    Start Of Test Block: 45                                                                   infra.data
2017-02-22 11:24:47,950 DEBUG   +45.01 - STARTING TEST: [runTest (test_log_stream_fmat.TC)]                                infra.data
2017-02-22 11:24:47,951 INFO    MATCH-FMAT-START infra.data MATCH-FMAT-END                                                 infra.data >45.01 88250 MainProcess stream-monitor/test/test_log_stream_fmat.py:runTest@19 gl-main [runTest (test_log_stream_fmat.TC)]
2017-02-22 11:24:47,953 DEBUG   -45.01 - ENDING TEST: [runTest (test_log_stream_fmat.TC)]                                  infra.data
```
Remember that the "Start Of Test Block", "STARTING TEST:", and "ENDING TEST" "bracket" all message FROM the given test.

@RackHD/corecommitters @hohene @diontje @gpaulos 