### PR TITLE
[skip ci]docs: make sure vm.max_map_count >= 262144

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -23,6 +23,7 @@ $ docker-compose up           # Run RackHD and ELK.
 **Prerequisites:**
   * docker v1.10 or higher
   * docker-compose v1.6 or higher [Install Docker Compose](https://docs.docker.com/compose/install/)
+  * Please make sure vm.max_map_count >= 262144 ```sudo sysctl -w vm.max_map_count=262144```
 
 ```
 $ cd RackHD/docker


### PR DESCRIPTION
Otherwise, es container won't run normally
```max virtual memory areas vm.max_map_count [65530] likely too low, increase to at least [262144]```

@panpan0000 @PengTian0 