### PR TITLE
RAC-4326-fix-rackhd_package_install.py

### DIFF
--- a/test/deploy/rackhd_package_install.py
+++ b/test/deploy/rackhd_package_install.py
@@ -4,7 +4,7 @@ Copyright 2016, EMC, Inc.
 Author(s):
 George Paulos
 
-This script installs RackHD from BIntray packages onto blank Ubuntu 14 or 16 OS via Ansible installer.
+This script installs RackHD from Bintray packages onto blank Ubuntu 14 or 16 OS via Ansible installer.
 If test bed is behind proxy wall, make sure to enter proxy URL in config/install_default.json
 This script performs the following functions:
     - loads prerequisite packages git, ansible, etc.
@@ -19,11 +19,10 @@ usage:
 '''
 
 import fit_path  # NOQA: unused import
-
 import os
-import sys
-import subprocess
 import fit_common
+import flogging
+log = flogging.get_loggers()
 
 # set proxy if required
 PROXYVARS = ''
@@ -34,7 +33,6 @@ if fit_common.fitproxy()['host'] != '':
 
 class rackhd_package_install(fit_common.unittest.TestCase):
     def test01_install_rackhd_dependencies(self):
-        print "**** Installing RackHD dependencies."
         # update sudoers to preserve proxy environment
         sudoersproxy = open("sudoersproxy", 'w')
         sudoersproxy.write('Defaults env_keep="HOME no_proxy http_proxy https_proxy"\n')
@@ -59,7 +57,6 @@ class rackhd_package_install(fit_common.unittest.TestCase):
             )['exitcode'], 0, "Startup files failure.")
 
     def test02_clone_rackhd_source(self):
-        print "**** Cloning RackHD repo."
         # clone base repo
         fit_common.remote_shell('rm -rf ~/rackhd')
         self.assertEqual(fit_common.remote_shell(PROXYVARS + "git clone "
@@ -68,7 +65,6 @@ class rackhd_package_install(fit_common.unittest.TestCase):
                                                 )['exitcode'], 0, "RackHD git clone failure.")
 
     def test03_run_ansible_installer(self):
-        print "**** Run RackHD Ansible installer."
         self.assertEqual(fit_common.remote_shell(PROXYVARS +
                                                  "cd ~/rackhd/packer/ansible/;"
                                                  "ansible-playbook -i 'local,' -c local rackhd_package.yml",
@@ -76,7 +72,6 @@ class rackhd_package_install(fit_common.unittest.TestCase):
                                                  )['exitcode'], 0, "RackHD Install failure.")
 
     def test04_install_network_config(self):
-        print "**** Installing RackHD network config."
         # collect nic names
         getifs = fit_common.remote_shell("ifconfig -s -a |tail -n +2 |grep -v -e Iface -e lo -e docker")
         # clean out login stuff
@@ -91,8 +86,8 @@ class rackhd_package_install(fit_common.unittest.TestCase):
         control_cfg.write(
                             'auto ' + ifslist[1] + '\n'
                             'iface ' + ifslist[1] + ' inet static\n'
-                            'address 172.31.128.1\n'
-                            'netmask 255.255.252.0\n'
+                            'address ' + fit_common.fitrackhd()['dhcpGateway'] + '\n'
+                            'netmask ' + fit_common.fitrackhd()['dhcpSubnetMask'] + '\n'
                         )
         control_cfg.close()
         # copy file to ORA
@@ -100,35 +95,54 @@ class rackhd_package_install(fit_common.unittest.TestCase):
         self.assertEqual(fit_common.remote_shell('cp control.cfg /etc/network/interfaces.d/')['exitcode'], 0, "Control network config failure.")
         os.remove('control.cfg')
         # startup NIC
-        fit_common.remote_shell('ip addr add 172.31.128.1/22 dev ' + ifslist[1])
+        cidr = str(sum([bin(int(x)).count("1") for x in fit_common.fitrackhd()['dhcpSubnetMask'].split(".")])) # calculate CIDR
+        fit_common.remote_shell('ip addr add ' + fit_common.fitrackhd()['dhcpGateway'] + '/' + cidr + ' dev ' + ifslist[1])
         fit_common.remote_shell('ip link set ' + ifslist[1] + ' up')
-        self.assertEqual(fit_common.remote_shell('ping -c 1 -w 5 172.31.128.1')['exitcode'], 0, 'Control NIC failure.')
+        self.assertEqual(fit_common.remote_shell('ping -c 1 -w 5 ' + fit_common.fitrackhd()['dhcpGateway'])['exitcode'], 0, 'Control NIC failure.')
 
         # If PDU network adapter is present, configure
         try:
             ifslist[2]
         except IndexError:
-            print "**** No PDU network will be configured"
+            log.info_5("**** No PDU interface available, PDU will not be configured")
         else:
-            pdudirect_cfg = open('pdudirect.cfg', 'w')
-            pdudirect_cfg.write(
-                                'auto ' + ifslist[2] + '\n'
-                                'iface ' + ifslist[2] + ' inet static\n'
-                                'address 192.168.1.1\n'
-                                'netmask 255.255.255.0\n'
-                                )
-            pdudirect_cfg.close()
-            # copy file to ORA
-            fit_common.scp_file_to_ora('pdudirect.cfg')
-            self.assertEqual(fit_common.remote_shell('cp pdudirect.cfg /etc/network/interfaces.d/')['exitcode'], 0, "DHCP Config failure.")
-            os.remove('pdudirect.cfg')
-            # startup NIC
-            fit_common.remote_shell('ip addr add 192.168.1.1/24 dev ' + ifslist[2])
-            fit_common.remote_shell('ip link set ' + ifslist[2] + ' up')
-            self.assertEqual(fit_common.remote_shell('ping -c 1 -w 5 192.168.1.1')['exitcode'], 0, 'PDU NIC failure.')
+            # if 'pdu' is specified in stack, then configure PDU network
+            if 'pdu' in fit_common.fitcfg():
+                # process PDU IP configuration
+                pdusplit = fit_common.fitcfg()['pdu'].split(".")
+                pdu_prefix = pdusplit[0] + '.' + pdusplit[1] + '.' + pdusplit[2] + '.'
+                # build interface config file
+                pdudirect_cfg = open('pdudirect.cfg', 'w')
+                pdudirect_cfg.write(
+                                    'auto ' + ifslist[2] + '\n'
+                                    'iface ' + ifslist[2] + ' inet static\n'
+                                    'address ' + pdu_prefix + '1\n'
+                                    'netmask 255.255.255.0\n'
+                                    )
+                pdudirect_cfg.close()
+                # copy file to Host
+                fit_common.scp_file_to_host('pdudirect.cfg')
+                self.assertEqual(fit_common.remote_shell('cp pdudirect.cfg /etc/network/interfaces.d/')['exitcode'], 0, "DHCP Config failure.")
+                os.remove('pdudirect.cfg')
+                # startup NIC
+                fit_common.remote_shell('ip addr add ' + pdu_prefix + '1/24 dev ' + ifslist[2])
+                fit_common.remote_shell('ip link set ' + ifslist[2] + ' up')
+                self.assertEqual(fit_common.remote_shell('ping -c 1 -w 5 ' + pdu_prefix + '1')['exitcode'], 0, 'PDU NIC failure.')
+            else:
+                log.info_5("**** No PDU specified for this stack")
 
-        #create DHCP config
+        # create DHCP config
         fit_common.remote_shell('echo INTERFACES=' + ifslist[1] + ' > /etc/default/isc-dhcp-server')
+        # calculate control LAN IP configuration
+        ipsplit = fit_common.fitrackhd()['dhcpGateway'].split(".")
+        ip_prefix = ipsplit[0] + '.' + ipsplit[1] + '.' + ipsplit[2] + '.'
+        masksplit = fit_common.fitrackhd()['dhcpSubnetMask'].split(".")
+        dhcp_high = str(int(ipsplit[0])+(255-int(masksplit[0]))) + '.' \
+                    + str(int(ipsplit[1])+(255-int(masksplit[1]))) + '.' \
+                    + str(int(ipsplit[2])+(255-int(masksplit[2]))) + '.' \
+                    + '254'
+        dhcp_low = ip_prefix + str(int(ipsplit[3]) + 1)
+        # build interface config file
         dhcp_conf = open('dhcpd.conf', 'w')
         dhcp_conf.write(
                         'ddns-update-style none;\n'
@@ -139,19 +153,18 @@ class rackhd_package_install(fit_common.unittest.TestCase):
                         'log-facility local7;\n'
                         'deny duplicates;\n'
                         'ignore-client-uids true;\n'
-                        'subnet 172.31.128.0 netmask 255.255.252.0 {\n'
-                        '  range 172.31.128.2 172.31.131.254;\n'
+                        'subnet ' + ip_prefix + '0 netmask ' + fit_common.fitrackhd()['dhcpSubnetMask'] + ' {\n'
+                        '  range ' + dhcp_low + ' ' + dhcp_high + ';\n'
                         '  option vendor-class-identifier "PXEClient";\n'
                         '}\n'
                          )
         dhcp_conf.close()
-        # copy file to ORA
-        fit_common.scp_file_to_ora('dhcpd.conf')
+        # copy file to Host
+        fit_common.scp_file_to_host('dhcpd.conf')
         self.assertEqual(fit_common.remote_shell('cp dhcpd.conf /etc/dhcp/')['exitcode'], 0, "DHCP Config failure.")
         os.remove('dhcpd.conf')
 
     def test05_install_rackhd_config_files(self):
-        print "**** Installing RackHD config files."
         # create RackHD config
         hdconfig = fit_common.fitcfg()['rackhd-config']
         config_json = open('config.json', 'w')
@@ -170,14 +183,13 @@ class rackhd_package_install(fit_common.unittest.TestCase):
         os.remove('rabbitmq.config')
 
     def test06_startup(self):
-        print "Restart services."
         self.assertEqual(fit_common.remote_shell("service isc-dhcp-server restart")['exitcode'], 0, "isc-dhcp-server failure.")
         self.assertEqual(fit_common.remote_shell("service on-http restart")['exitcode'], 0, "on-http failure.")
         self.assertEqual(fit_common.remote_shell("service on-dhcp-proxy restart")['exitcode'], 0, "on-dhcp-proxy failure.")
         self.assertEqual(fit_common.remote_shell("service on-syslog restart")['exitcode'], 0, "on-syslog failure.")
         self.assertEqual(fit_common.remote_shell("service on-taskgraph restart")['exitcode'], 0, "on-taskgraph failure.")
         self.assertEqual(fit_common.remote_shell("service on-tftp restart")['exitcode'], 0, "on-tftp failure.")
-        print "**** Check installation."
+        log.info_5("**** Checking installation.")
         for dummy in range(0, 10):
             try:
                 fit_common.rackhdapi("/api/2.0/config")

--- a/test/deploy/rackhd_package_install.py
+++ b/test/deploy/rackhd_package_install.py
@@ -146,7 +146,7 @@ class rackhd_package_install(fit_common.unittest.TestCase):
             str(int(ipsplit[0]) + (255 - int(masksplit[0]))) + '.' + \
             str(int(ipsplit[1]) + (255 - int(masksplit[1]))) + '.' + \
             str(int(ipsplit[2]) + (255 - int(masksplit[2]))) + '.' + '254'
-        dhcp_low = ip_prefix + str(int(ipsplit[3]) + 1)
+        dhcp_low = ip_prefix + str(int(ipsplit[3]) + 2)
         # build interface config file
         dhcp_conf = open('dhcpd.conf', 'w')
         dhcp_conf.write('ddns-update-style none;\n'


### PR DESCRIPTION
This PR addresses technical debt in deploy/rackhd_package_install.py.

◾removed all IP addresses, harvest and calculate all IP addresses and netmasks from rackhd_config
◾convert function call scp_file_to_ora > scp_file_to_host
◾use FIT logging instead of print statements

@hohene @larry-dean @jimturnquist @stuart-stanley @RackHD/corecommitters
