### PR TITLE
RAC-4289_FIT_https_port_bug

### DIFF
--- a/test/common/fit_common.py
+++ b/test/common/fit_common.py
@@ -217,12 +217,12 @@ def add_globals():
     if fitargs()['port'] != "None":
         API_PORT = fitargs()['port']
 
-    if fitargs()['http'] == True:
+    if fitargs()['http'] is True:
         API_PROTOCOL = "http"
         if API_PORT == "None":
             API_PORT = fitports()['http']
 
-    if fitargs()['https'] == True:
+    if fitargs()['https'] is True:
         API_PROTOCOL = "https"
         if API_PORT == "None":
             API_PORT = fitports()['https']

--- a/test/common/fit_common.py
+++ b/test/common/fit_common.py
@@ -217,21 +217,15 @@ def add_globals():
     if fitargs()['port'] != "None":
         API_PORT = fitargs()['port']
 
-    if fitargs()['http'] == "True":
+    if fitargs()['http'] == True:
         API_PROTOCOL = "http"
         if API_PORT == "None":
             API_PORT = fitports()['http']
 
-    if fitargs()['https'] == "True":
+    if fitargs()['https'] == True:
         API_PROTOCOL = "https"
         if API_PORT == "None":
             API_PORT = fitports()['https']
-
-    if fitargs()['rackhd_host'] == "localhost":
-        if API_PROTOCOL == "None":
-            API_PROTOCOL = 'http'
-        if API_PORT == "None":
-            API_PORT = '8080'
 
     # add globals section to base configuration
     TEST_PATH = fit_path.fit_path_root + '/'


### PR DESCRIPTION
'fit_common' fixed for two bugs:

- When rackhd_host is localhost it was always setting port to 8080. This is old code from the pre 'fit-config' days. Just removed that code.
- -http/-https arguments to force protocol were not working, Just changed argument check from string to Boolean.

@nortonluo @hohene @jimturnquist @johren 