### PR TITLE
RAC-4289 FIT https port/protocol bug

### DIFF
--- a/test/common/fit_common.py
+++ b/test/common/fit_common.py
@@ -217,12 +217,12 @@ def add_globals():
     if fitargs()['port'] != "None":
         API_PORT = fitargs()['port']
 
-    if fitargs()['http'] == True:
+    if fitargs()['http'] is True:
         API_PROTOCOL = "http"
         if API_PORT == "None":
             API_PORT = fitports()['http']
 
-    if fitargs()['https'] == True:
+    if fitargs()['https'] is True:
         API_PROTOCOL = "https"
         if API_PORT == "None":
             API_PORT = fitports()['https']

--- a/test/common/fit_common.py
+++ b/test/common/fit_common.py
@@ -217,21 +217,15 @@ def add_globals():
     if fitargs()['port'] != "None":
         API_PORT = fitargs()['port']
 
-    if fitargs()['http'] == "True":
+    if fitargs()['http'] == True:
         API_PROTOCOL = "http"
         if API_PORT == "None":
             API_PORT = fitports()['http']
 
-    if fitargs()['https'] == "True":
+    if fitargs()['https'] == True:
         API_PROTOCOL = "https"
         if API_PORT == "None":
             API_PORT = fitports()['https']
-
-    if fitargs()['rackhd_host'] == "localhost":
-        if API_PROTOCOL == "None":
-            API_PROTOCOL = 'http'
-        if API_PORT == "None":
-            API_PORT = '8080'
 
     # add globals section to base configuration
     TEST_PATH = fit_path.fit_path_root + '/'


### PR DESCRIPTION
'fit_common.py' fixed for port and protocol selection bugs:

- When rackhd_host is localhost it was always setting port to 8080. This is old code from the pre 'fit-config' days. I removed that code. Now the default port setting is pulled from the install_default.json config file.
- -http/-https arguments to force protocol were not working because the properties were changed to Boolean. 
- I removed the automatic protocol selection code in rackhdapi(), which was an OnRack leftover that does not work any more in the RackHD world. This code was supposed to check to see if the http endpoints are available, if not then select https. The default protocol is now set to http. If https is desired, then use the -https parameter on the command line. I think that this is simpler and less error-prone than the automatic method that can be difficult to control and diagnose.
- there were conditions where the automatic auth key generator was not working because it was always using https (Onrack leftover). Made the auth key generator use selected protocol.

This is the way it works now:

- If no command-line overrides are used, the default protocol is http and the default http port is set from install_default.json in the ports section.
- If -https option is used, then https is active protocol and https port is set from install_default.json in the ports section.
- if -port override option is used, then this is the port used for the selected protocol, whether http or https

I hope this meets everybody's needs. 

@nortonluo @hohene @jimturnquist @johren
