### PR TITLE
Revert "use newly build rackhd/files image instead of download directly" 

### DIFF
--- a/docker/docker-compose-centos.yml
+++ b/docker/docker-compose-centos.yml
@@ -15,6 +15,7 @@ services:
 
   files:
     image: rackhd/files:${TAG}
+    build: "./files"
     network_mode: "host"
     privileged: true
     volumes:

--- a/docker/docker-compose-mini.yml
+++ b/docker/docker-compose-mini.yml
@@ -30,6 +30,7 @@ services:
 
   files:
     image: rackhd/files:${TAG}
+    build: "./files"
     network_mode: "host"
     privileged: true
     volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - "./dhcp/defaults:/etc/defaults"
 
   files:
+    build: "./files"
     image: rackhd/files:${TAG}
     network_mode: "host"
     privileged: true

--- a/docker/files/Dockerfile
+++ b/docker/files/Dockerfile
@@ -1,0 +1,41 @@
+FROM alpine:latest
+
+RUN mkdir -p /RackHD/downloads
+
+ADD https://bintray.com/artifact/download/rackhd/binary/ipxe/monorail-efi32-snponly.efi \
+    /RackHD/downloads/monorail-efi32-snponly.efi
+ADD https://bintray.com/artifact/download/rackhd/binary/ipxe/monorail-efi64-snponly.efi \
+    /RackHD/downloads/monorail-efi64-snponly.efi
+ADD https://bintray.com/artifact/download/rackhd/binary/ipxe/monorail.ipxe \
+    /RackHD/downloads/monorail.ipxe
+ADD https://bintray.com/artifact/download/rackhd/binary/ipxe/monorail-undionly.kpxe \
+    /RackHD/downloads/monorail-undionly.kpxe
+ADD https://bintray.com/artifact/download/rackhd/binary/ipxe/monorail.intel.ipxe \
+    /RackHD/downloads/monorail.intel.ipxe
+
+ADD https://bintray.com/artifact/download/rackhd/binary/syslinux/undionly.kkpxe \
+    /RackHD/downloads/undionly.kkpxe
+
+
+RUN mkdir -p /RackHD/downloads/common
+
+ADD https://bintray.com/artifact/download/rackhd/binary/builds/base.trusty.3.16.0-25-generic.squashfs.img \
+    /RackHD/downloads/common/base.trusty.3.16.0-25-generic.squashfs.img
+ADD https://bintray.com/artifact/download/rackhd/binary/builds/discovery.overlay.cpio.gz \
+    /RackHD/downloads/common/discovery.overlay.cpio.gz
+ADD https://bintray.com/artifact/download/rackhd/binary/builds/initrd.img-3.16.0-25-generic \
+    /RackHD/downloads/common/initrd.img-3.16.0-25-generic
+ADD https://bintray.com/artifact/download/rackhd/binary/builds/vmlinuz-3.16.0-25-generic \
+    /RackHD/downloads/common/vmlinuz-3.16.0-25-generic
+ADD https://bintray.com/artifact/download/rackhd/binary/builds/discovery.docker.tar.xz \
+    /RackHD/downloads/common/discovery.docker.tar.xz
+ADD  https://bintray.com/artifact/download/rackhd/binary/builds/vmlinuz-0.5.0-rancher \
+    /RackHD/downloads/common/vmlinuz-0.5.0-rancher
+ADD https://bintray.com/artifact/download/rackhd/binary/builds/initrd-0.5.0-rancher \
+    /RackHD/downloads/common/initrd-0.5.0-rancher
+
+VOLUME /RackHD/files
+
+COPY ./docker-entrypoint.sh /docker-entrypoint.sh
+
+CMD [ "/docker-entrypoint.sh" ]

--- a/docker/files/docker-entrypoint.sh
+++ b/docker/files/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Copyright 2016, EMC, Inc.
+
+# set -x
+
+cp -a -f /RackHD/downloads/* /RackHD/files/
+
+while true; do
+  date;
+  sleep 120; # 2 minutes
+  # sleep 21600; # 6 hours
+done


### PR DESCRIPTION
This reverts commit 1d8b2c5c40d121336644678298727741c9f42edd.

Add micro docker dependency images to DockerFile in files

