### PR TITLE
RAC-4289 FIT port/protocol selection bugs

### DIFF
--- a/test/common/fit_common.py
+++ b/test/common/fit_common.py
@@ -212,24 +212,18 @@ def add_globals():
     global VERBOSITY
 
     # set api port and protocol from command line
-    if fitargs()['port'] != "None":
-        API_PORT = fitargs()['port']
-
-    if fitargs()['http'] == "True":
+    if fitargs()['http'] is True:
         API_PROTOCOL = "http"
-        if API_PORT == "None":
-            API_PORT = fitports()['http']
-
-    if fitargs()['https'] == "True":
+        API_PORT = str(fitports()['http'])
+    elif fitargs()['https'] is True:
         API_PROTOCOL = "https"
-        if API_PORT == "None":
-            API_PORT = fitports()['https']
+        API_PORT = str(fitports()['https'])
+    else:  # default protocol is http
+        API_PROTOCOL = "http"
+        API_PORT = str(fitports()['http'])
 
-    if fitargs()['rackhd_host'] == "localhost":
-        if API_PROTOCOL == "None":
-            API_PROTOCOL = 'http'
-        if API_PORT == "None":
-            API_PORT = '8080'
+    if fitargs()['port'] != "None":  # port override via command line argument -port
+        API_PORT = fitargs()['port']
 
     # add globals section to base configuration
     TEST_PATH = fit_path.fit_path_root + '/'
@@ -244,7 +238,7 @@ def add_globals():
         }
     })
 
-    # set OVA template from command line
+    # set OVA template from command line argument -template
     if fitargs()["template"] == "None":
         fitargs()["template"] = fitcfg()['install-config']['template']
 
@@ -609,20 +603,6 @@ def rackhdapi(url_cmd, action='get', payload=[], timeout=None, headers={}):
                 'headers':result_data.headers.get('content-type'),
                 'timeout':False}
     '''
-
-    # Automatic protocol selection: unless protocol is specified, test protocols, save settings globally
-    global API_PROTOCOL
-    global API_PORT
-
-    if API_PROTOCOL == "None":
-        if API_PORT == "None":
-            API_PORT = str(fitports()['http'])
-        if restful("http://" + fitargs()['rackhd_host'] + ":" + str(API_PORT) + "/", rest_timeout=2)['status'] == 0:
-            API_PROTOCOL = 'https'
-            API_PORT = str(fitports()['https'])
-        else:
-            API_PROTOCOL = 'http'
-            API_PORT = str(fitports()['http'])
 
     # Retrieve authentication token for the session
     if AUTH_TOKEN == "None":


### PR DESCRIPTION
Resubmit of RAC-4289 with review changes:
•When rackhd_host is localhost it was always setting port to 8080. This is old code from the pre 'fit-config' days. I removed that code. Now the default port setting is pulled from the install_default.json config file.
•-http/-https arguments to force protocol were not working because of type mismatch from string to Boolean.
•I removed the automatic protocol selection code in rackhdapi(), which was an OnRack leftover that does not work any more in the RackHD world. This code was supposed to check to see if the http endpoints are available, if not then select https. The default protocol is now set to http. If https is desired, then use the -https parameter on the command line. I think that this is simpler and less error-prone than the automatic method that can be difficult to control and diagnose.

This is the way it works now:
•If no command-line overrides are used, the default protocol is http and the default http port is set from install_default.json in the ports section.
•If -https option is used, then https is active protocol and https port is set from install_default.json in the ports section.
•if -port override option is used, then this is the port used for the selected protocol, whether http or https

I hope this meets everybody's needs.

@nortonluo @hohene @jimturnquist @johren @anhou 
