### PR TITLE
RAC-4397 - Remove RackHD api 1.1 calls from CIT smoke-tests

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -10,7 +10,6 @@ kombu==3.0.30
 pika==0.10.0
 nose==1.3.7
 nosedep>=0.6
-on-http_api1_1>=1.0.0
 on-http_api2_0>=1.0.2
 on_http_redfish_1_0>=1.0.0
 pexpect==3.3

--- a/test/run.py
+++ b/test/run.py
@@ -5,32 +5,32 @@ import modules.amqp as amqp
 import argparse
 import sys
 
+
 def run_tests(group=['smoke-tests']):
 
-    import tests.api.v1_1 as api_1_1 
     import tests.api.v2_0 as api_2_0
     import tests.api.redfish_1_0 as api_redfish_1_0
 
-    register(groups=['api-v1.1'], depends_on_groups=api_1_1.tests)
     register(groups=['api-v2.0'], depends_on_groups=api_2_0.tests)
     register(groups=['api-redfish-1.0'], depends_on_groups=api_redfish_1_0.tests)
-    register(groups=['smoke-tests'], depends_on_groups=['api-v1.1','api-v2.0','api-redfish-1.0'])
-    register(groups=['regression-tests'], depends_on_groups=[ 'smoke-tests' ] + \
-        [ test for test in api_1_1.regression_tests + api_2_0.regression_tests ])
+    register(groups=['smoke-tests'], depends_on_groups=['api-v2.0', 'api-redfish-1.0'])
+    register(groups=['regression-tests'], depends_on_groups=['smoke-tests'] +
+                    [test for test in api_2_0.regression_tests])
 
     TestProgram(groups=group).run_and_exit()
+
 
 if __name__ == '__main__':
     # avoid eating valid proboscis args
     if len(sys.argv) > 1:
         parser = argparse.ArgumentParser()
         parser.add_argument('--config', default='config/config.ini', required=False)
-        if sys.argv[1] == '--httpd': 
+        if sys.argv[1] == '--httpd':
             parser.add_argument('--httpd', action='store_const', const=True)
             parser.add_argument('-a', '--address', default='0.0.0.0', required=False)
             parser.add_argument('-p', '--port', default=80, required=False)
             args = parser.parse_args()
-            httpd.run_server(args.address,args.port)
+            httpd.run_server(args.address, args.port)
             sys.exit(0)
         if sys.argv[1] == '--amqp':
             parser.add_argument('--amqp', action='store_const', const=True)
@@ -38,7 +38,7 @@ if __name__ == '__main__':
             parser.add_argument('-q', '--queue', default='poller.alert', required=False)
             parser.add_argument('-r', '--key', default='poller.alert.#', required=False)
             args = parser.parse_args()
-            amqp.run_listener(amqp.make_queue_obj(args.exchange,args.queue,args.key))
+            amqp.run_listener(amqp.make_queue_obj(args.exchange, args.queue, args.key))
             sys.exit(0)
 
     group = []
@@ -49,4 +49,3 @@ if __name__ == '__main__':
         run_tests(group)
         sys.exit(0)
     run_tests()
-

--- a/test/tests/api/v2_0/lookups_tests.py
+++ b/test/tests/api/v2_0/lookups_tests.py
@@ -27,7 +27,16 @@ class LookupsTests(object):
         self.id = ""
         self.patchedNode= {"node": "666" }
 
-    @test(groups=['lookups_api2.tests', 'api2_check-lookups-query'], depends_on_groups=['nodes_api2.tests'])
+    @test(groups=['lookups_api2.tests', 'api2_check-lookups'], depends_on_groups=['obm_api2.tests'])
+    def check_lookups(self):
+        """ Testing GET:/lookups """
+        Api().lookups_get()
+        rsp = self.__client.last_response
+        LOG.info("\nLookup list: {}\n".format(rsp.data, json=True))
+        assert_equal(200, rsp.status, message=rsp.reason)
+        assert_not_equal(0, len(rsp.data))
+
+    @test(groups=['api2_check-lookups-query'], depends_on_groups=['api2_check-lookups'])
     def check_lookups_query(self):
         """ Testing GET:/lookups?q=term """
         Api().nodes_get_all()
@@ -35,11 +44,14 @@ class LookupsTests(object):
         assert_not_equal(0, len(nodes), message='Node list was empty!')
         Api().obms_get()
         obms = loads(self.__client.last_response.data)
+        LOG.info("OBM get data: {}".format(obms, json=True))
         hosts = []
         for o in obms:
             hosts.append(o.get('config').get('host'))
         assert_not_equal(0, len(hosts), message='No OBM hosts were found!')
+        LOG.info("Hosts {}".format(hosts, json=True))
         for host in hosts:
+            LOG.info("Looking up host: {}".format(host))
             Api().lookups_get(q=host)
             rsp = self.__client.last_response
             assert_equal(200, rsp.status, message=rsp.reason)

--- a/test/tests/api/v2_0/nodes_tests.py
+++ b/test/tests/api/v2_0/nodes_tests.py
@@ -1,4 +1,3 @@
-from config.api1_1_config import config as config_old   #TODO remove when 2.0 worklfow API is implemented
 from config.api2_0_config import config
 from config.amqp import *
 from modules.logger import Log
@@ -25,7 +24,6 @@ LOG = Log(__name__)
 class NodesTests(object):
 
     def __init__(self):
-        self.__client_old = config_old.api_client
         self.__client = config.api_client
         self.__worker = None
         self.__discovery_duration = None

--- a/test/tests/api/v2_0/obm_settings.py
+++ b/test/tests/api/v2_0/obm_settings.py
@@ -84,7 +84,7 @@ class obmSettings(object):
             node_type = n.get('type')
             uid = n.get('id')
             if uuid is None or uuid == uid:
-                if node_type != 'enclosure':
+                if node_type not in ['enclosure', 'switch', 'pdu']:
                     obm_obj = []
                     Api().obms_get()
                     all_obms = loads(self.__client.last_response.data)

--- a/test/tests/api/v2_0/sel_alert_poller_tests.py
+++ b/test/tests/api/v2_0/sel_alert_poller_tests.py
@@ -149,6 +149,11 @@ class SELPollerAlertTests(object):
                 assert_equal(self.__amqp_alert["data"]["alert"]['reading']["Sensor Type Code"], "07")
                 self.__amqp_alert = {}
 
+                # Clean up SEL log when done.
+                # TO DO: injected SEL entries are causing issue with later tests, if we assert above, no cleanup occurs
+                self.run_ipmitool_command(n['node_ip'], "sel clear")
+                self.verify_empty_sel(n['node_ip'])
+
     @test(groups=['SEL_alert_poller_api2.tests', 'sel_overflow_simulation'], depends_on_groups=['inject_single_error'])
     def test_sel_overflow(self):
         """Test: SEL overflow simulation """
@@ -180,7 +185,12 @@ class SELPollerAlertTests(object):
 
             assert_equal(new_first_SEL_entry,initial_first_SEL_entry + 1)
 
-    @test(groups=['SEL_alert_poller_api2.tests', 'inject_full_sel'],depends_on_groups=['inject_single_error'])
+            # Clean up SEL log when done.
+            # TO DO: injected SEL entries are causing issue with later tests, if we assert above, no cleanup occurs
+            self.run_ipmitool_command(n['node_ip'], "sel clear")
+            self.verify_empty_sel(n['node_ip'])
+
+    @test(groups=['SEL_alert_poller_api2.tests', 'inject_full_sel'], depends_on_groups=['sel_overflow_simulation'])
     def test_full_sel(self):
         """Test: Full sel log"""
         #Validate the poller can digest data from a full sel log all at once
@@ -208,6 +218,13 @@ class SELPollerAlertTests(object):
             assert_false(self.__task.timeout, \
                     message='timeout waiting for task {0}'.format(self.__task.id))
             assert_equal(self.__event_count, n["available_sel_entries"])
+
+            # Clean up SEL log when done.
+            # TO DO: injected SEL entries are causing issue with later tests, if we assert above, no cleanup occurs
+            self.run_ipmitool_command(n['node_ip'], "sel clear")
+            self.verify_empty_sel(n['node_ip'])
+            # wait one poll cycle to allow the sel pollers on the node time to refresh for subsequent testing. fix me.
+            time.sleep(60)
 
     def run_ipmitool_command(self, ip ,command):
         ipmitool_command = "ipmitool -I lanplus -H " + ip +" -U " + self.__bmc_credentials[0] +" -P " + self.__bmc_credentials[1] + " " + command


### PR DESCRIPTION
As part of the disabling of the RackHD 1.1 API, we need to turn off the tests for the 1.1 API in CIT and FIT.
This PR will remove the tests from the CIT CI smoke-tests group.  additional PRs coming for FIT and on-build-config.
- removed the on-http 1.1 api from requirements.txt - so won't be build in the library
- removed api1.1 group from run.py
- updated node_tests.py to remove an outdated call to 1.1

Tested running against physical hardware and vagrant. 
Tested smoke-tests, api-redfish-1.0, and api-v2_0 groups. 
@tannoa2 @johren @panpan0000 @BillyAbildgaard @keedya @gpaulos 