### PR TITLE
RAC-4487 - test_rackhd_api_ucs - Remove api/1.1 reference, change to 2.0

### DIFF
--- a/test/tests/ucs/test_rackhd_api_ucs.py
+++ b/test/tests/ucs/test_rackhd_api_ucs.py
@@ -218,7 +218,7 @@ class rackhd_ucs_api(unittest.TestCase):
         """
         catalog_workflows = []
         for x in range(len(self.UCS_NODES)):
-            postUrl = '/api/1.1/nodes/' + str(self.UCS_NODES[x]["id"]) + "/workflows?name=Graph.Ucs.Catalog"
+            postUrl = '/api/2.0/nodes/' + str(self.UCS_NODES[x]["id"]) + "/workflows?name=Graph.Ucs.Catalog"
             header = {"Content-Type": "application/json"}
             api_data = fit_common.rackhdapi(postUrl, headers=header, action="post")
             self.assertEqual(api_data['status'], 201,

--- a/test/tests/ucs/test_rackhd_api_ucs.py
+++ b/test/tests/ucs/test_rackhd_api_ucs.py
@@ -21,7 +21,7 @@ from nose.plugins.attrib import attr
 logs = flogging.get_loggers()
 
 
-@attr(all=True, regression=True, smoke=True, ucs=True)
+@attr(all=True, regression=True, smoke=False, ucs=True)
 class rackhd_ucs_api(unittest.TestCase):
 
     UCS_IP = fit_common.fitcfg().get("ucs_ip")


### PR DESCRIPTION
Change the /api/1.1/nodes call to /api/2.0/nodes

@tannoa2 @keedya @johren @gpaulos 