### PR TITLE
Rac-4236 Rac-4325 fix technical debt in RackHD installers

### DIFF
--- a/test/common/network_lib.py
+++ b/test/common/network_lib.py
@@ -1,0 +1,90 @@
+'''
+Copyright 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+Author(s):
+George Paulos
+
+This is a FIT common library containing network helper routines to perform
+commonly-used network-related functions
+'''
+
+import fit_path  # NOQA: unused import
+import fit_common
+import flogging
+log = flogging.get_loggers()
+
+
+def get_host_nics(host=fit_common.fitargs()['rackhd_host']):
+    # this routine returns an array of valid network ports on the specified host, default rackhd_host
+    # collect nic names
+    getifs = fit_common.remote_shell("ifconfig -s -a |tail -n +2 |grep -v -e Iface -e lo -e docker", host)
+    # split into array
+    splitifs = getifs['stdout'].split('\n')
+    niclist = []  # array of valid network ports
+    # clean out login artifacts
+    for item in splitifs:
+        if "assword" not in item and item.split(" ")[0]:
+            niclist.append(item.split(" ")[0])
+    return niclist
+
+
+def nic_config_file(iface=None, ipaddress=None, netmask="255.255.255.0", gateway=None):
+    """
+    this routine creates a NIC config file string from the specified NIC port, IP address, netmask, etc.
+    """
+    config_string = ""
+    if iface:
+        config_string = "auto " + iface + "\n" + \
+                        "iface " + iface + " inet static\n"
+    else:
+        return None  # return None if no iface specified
+    if ipaddress:
+        config_string = config_string + "ipaddress " + ipaddress + "\n"
+        config_string = config_string + "netmask " + netmask + "\n"
+    else:
+        config_string = "auto " + iface + "\n" + \
+                        "iface " + iface + " inet dhcp\n"
+        return config_string  # return DHCP if no ipaddress specified
+    if gateway:
+        config_string = config_string + "gateway " + gateway + "\n"
+    return config_string
+
+
+def dhcp_config_file(ipaddress=None, netmask="255.255.255.0", default_lease_time=600, max_lease_time=7200):
+    # this routine returns a DHCP config file string from the DHCP server IP address and netmask
+    if not ipaddress or not split_ipv4(ipaddress) or not split_ipv4(netmask):
+        return None  # return None if ipaddress is missing
+    ipsplit = split_ipv4(ipaddress)
+    ip_prefix = ipsplit[0] + '.' + ipsplit[1] + '.' + ipsplit[2] + '.'
+    masksplit = split_ipv4(netmask)
+    dhcp_high = \
+        str(int(ipsplit[0]) + (255 - int(masksplit[0]))) + '.' + \
+        str(int(ipsplit[1]) + (255 - int(masksplit[1]))) + '.' + \
+        str(int(ipsplit[2]) + (255 - int(masksplit[2]))) + '.' + '254'
+    dhcp_low = ip_prefix + str(int(ipsplit[3]) + 2)
+    config_string = 'ddns-update-style none;\n' \
+                    'option domain-name "example.org";\n' \
+                    'option domain-name-servers ns1.example.org, ns2.example.org;\n' \
+                    'default-lease-time ' + str(default_lease_time) + ';\n' \
+                    'max-lease-time ' + str(max_lease_time) + ';\n' \
+                    'log-facility local7;\n' \
+                    'deny duplicates;\n' \
+                    'ignore-client-uids true;\n' \
+                    'subnet ' + ip_prefix + '0 netmask ' + fit_common.fitrackhd()['dhcpSubnetMask'] + ' {\n' \
+                    '  range ' + dhcp_low + ' ' + dhcp_high + ';\n' \
+                    '  option vendor-class-identifier "PXEClient";\n' \
+                    '}\n'
+    return config_string
+
+
+def split_ipv4(ipaddress):
+    # this routine splits a valid IPv4 address or netmask into decimal octets and returns an array
+    iparray = ipaddress.split(".")
+    if len(iparray) != 4:
+        log.error("Invalid IP address: " + ipaddress)
+        return None
+    for octet in iparray:
+        if int(octet) < 0 or int(octet) > 255:
+            log.error("Invalid IP address: " + ipaddress)
+            return None
+    return iparray

--- a/test/common/network_lib.py
+++ b/test/common/network_lib.py
@@ -19,15 +19,15 @@ def get_host_nics(host=fit_common.fitargs()['rackhd_host']):
     This routine returns an array of valid network ports on the specified host, default rackhd_host
     """
     # collect nic names
-    getifs = fit_common.remote_shell("ip -o addr |grep -v -e lo -e docker", host)
+    getifs = fit_common.remote_shell("ifconfig -s -a |tail -n +2 |grep -v -e Iface -e lo -e docker", host)
     # split into array
     splitifs = getifs['stdout'].split('\n')
     niclist = []  # array of valid network ports
     # clean out login artifacts and verify ports
     for item in splitifs:
-        if "assword" not in item and "inet" in item and item.split(" ")[1]:
-            if fit_common.remote_shell("ip -o addr show " + item.split(" ")[1])['exitcode'] == 0:
-                niclist.append(item.split(" ")[1])
+        if "assword" not in item and item.split(" ")[0]:
+            if fit_common.remote_shell("ifconfig -s " + item.split(" ")[0])['exitcode'] == 0:
+                niclist.append(item.split(" ")[0])
     return niclist
 
 

--- a/test/common/network_lib.py
+++ b/test/common/network_lib.py
@@ -82,10 +82,13 @@ def dhcp_config_file(ipaddress=None, netmask="255.255.255.0", default_lease_time
     ipsplit = split_ipv4(ipaddress)
     ip_prefix = ipsplit[0] + '.' + ipsplit[1] + '.' + ipsplit[2] + '.'
     masksplit = split_ipv4(netmask)
-    dhcp_high = \
-        str(int(ipsplit[0]) + (255 - int(masksplit[0]))) + '.' + \
-        str(int(ipsplit[1]) + (255 - int(masksplit[1]))) + '.' + \
-        str(int(ipsplit[2]) + (255 - int(masksplit[2]))) + '.' + '254'
+    masksplit[0] = str(int(ipsplit[0]) + (255 - int(masksplit[0])))
+    masksplit[1] = str(int(ipsplit[1]) + (255 - int(masksplit[1])))
+    masksplit[2] = str(int(ipsplit[2]) + (255 - int(masksplit[2])))
+    for index in range(0, 3):
+        if int(masksplit[index]) > 255:
+            masksplit[index] = '255'
+    dhcp_high = masksplit[0] + '.' + masksplit[1] + '.' + masksplit[2] + '.254'
     dhcp_low = ip_prefix + str(int(ipsplit[3]) + 2)
     config_string = 'ddns-update-style none;\n' \
                     'option domain-name "example.org";\n' \
@@ -98,6 +101,8 @@ def dhcp_config_file(ipaddress=None, netmask="255.255.255.0", default_lease_time
                     'subnet ' + ip_prefix + '0 netmask ' + fit_common.fitrackhd()['dhcpSubnetMask'] + ' {\n' \
                     '  range ' + dhcp_low + ' ' + dhcp_high + ';\n' \
                     '  option vendor-class-identifier "PXEClient";\n' \
+                    '  option routers ' + ipaddress + ';\n' \
+                    '  option domain-name-servers ' + ipaddress + ';\n' \
                     '}\n'
     return config_string
 

--- a/test/deploy/rackhd_package_install.py
+++ b/test/deploy/rackhd_package_install.py
@@ -1,10 +1,10 @@
 '''
-Copyright 2016, EMC, Inc.
+Copyright 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 
 Author(s):
 George Paulos
 
-This script installs RackHD from BIntray packages onto blank Ubuntu 14 or 16 OS via Ansible installer.
+This script installs RackHD from Bintray packages onto blank Ubuntu 14 or 16 OS via Ansible installer.
 If test bed is behind proxy wall, make sure to enter proxy URL in config/install_default.json
 This script performs the following functions:
     - loads prerequisite packages git, ansible, etc.
@@ -12,18 +12,18 @@ This script performs the following functions:
     - installs using rackhd_package.yml playbook
     - set up networking
     - load configuration files
-    - startup and verify operations
+    - startup and verify services
 
 usage:
     python run_tests.py -stack <stack ID> -test deploy/rackhd_package_install.py
 '''
 
 import fit_path  # NOQA: unused import
-
 import os
-import sys
-import subprocess
 import fit_common
+import network_lib
+import flogging
+log = flogging.get_loggers()
 
 # set proxy if required
 PROXYVARS = ''
@@ -32,126 +32,119 @@ if fit_common.fitproxy()['host'] != '':
     PROXYVARS = "export http_proxy=http://" + fit_common.fitproxy()['host'] + ":" + fit_common.fitproxy()['port'] + ";" + \
                 "export https_proxy=http://" + fit_common.fitproxy()['host'] + ":" + fit_common.fitproxy()['port'] + ";"
 
+
 class rackhd_package_install(fit_common.unittest.TestCase):
     def test01_install_rackhd_dependencies(self):
-        print "**** Installing RackHD dependencies."
         # update sudoers to preserve proxy environment
         sudoersproxy = open("sudoersproxy", 'w')
         sudoersproxy.write('Defaults env_keep="HOME no_proxy http_proxy https_proxy"\n')
         sudoersproxy.close()
         fit_common.remote_shell('pwd')
-        fit_common.scp_file_to_ora("sudoersproxy")
-        self.assertEqual(fit_common.remote_shell('cp sudoersproxy /etc/sudoers.d/'
-                                                  )['exitcode'], 0, "sudoersproxy config failure.")
+        fit_common.scp_file_to_host("sudoersproxy")
+        self.assertEqual(fit_common.remote_shell('cp sudoersproxy /etc/sudoers.d/')
+                         ['exitcode'], 0, "sudoersproxy config failure.")
         os.remove('sudoersproxy')
         # install git
-        self.assertEqual(fit_common.remote_shell(PROXYVARS + "apt-get -y install git")['exitcode'], 0, "Git install failure.")
-        self.assertEqual(fit_common.remote_shell("git config --global http.sslverify false")['exitcode'], 0, "Git config failure.")
+        self.assertEqual(fit_common.remote_shell(PROXYVARS + "apt-get -y install git")
+                         ['exitcode'], 0, "Git install failure.")
+        self.assertEqual(fit_common.remote_shell("git config --global http.sslverify false")
+                         ['exitcode'], 0, "Git config failure.")
         if fit_common.fitproxy()['host'] != '':
-            self.assertEqual(fit_common.remote_shell("git config --global http.proxy http://" + fit_common.fitproxy()['host'] + ':' + fit_common.fitproxy()['port']
-                                                  )['exitcode'], 0, "Git proxy config failure.")
+            self.assertEqual(fit_common.remote_shell("git config --global http.proxy http://" +
+                             fit_common.fitproxy()['host'] + ':' +
+                             fit_common.fitproxy()['port'])
+                             ['exitcode'], 0, "Git proxy config failure.")
         # install Ansible
-        self.assertEqual(fit_common.remote_shell(PROXYVARS + "apt-get -y update")['exitcode'], 0, "Update failure.")
-        self.assertEqual(fit_common.remote_shell(PROXYVARS + "cd ~;apt-get -y install ansible")['exitcode'], 0, "Ansible Install failure.")
+        self.assertEqual(fit_common.remote_shell(PROXYVARS + "apt-get -y update")
+                         ['exitcode'], 0, "Update failure.")
+        self.assertEqual(fit_common.remote_shell(PROXYVARS + "cd ~;apt-get -y install ansible")
+                         ['exitcode'], 0, "Ansible Install failure.")
         # create startup files
         self.assertEqual(fit_common.remote_shell(
-            "touch /etc/default/on-dhcp-proxy /etc/default/on-http /etc/default/on-tftp /etc/default/on-syslog /etc/default/on-taskgraph"
-            )['exitcode'], 0, "Startup files failure.")
+                         "touch /etc/default/on-dhcp-proxy /etc/default/on-http "
+                         "/etc/default/on-tftp /etc/default/on-syslog /etc/default/on-taskgraph")
+                         ['exitcode'], 0, "Startup files failure.")
 
     def test02_clone_rackhd_source(self):
-        print "**** Cloning RackHD repo."
         # clone base repo
         fit_common.remote_shell('rm -rf ~/rackhd')
-        self.assertEqual(fit_common.remote_shell(PROXYVARS + "git clone "
-                                                + fit_common.fitinstall()['rackhd']['repo']
-                                                + " ~/rackhd"
-                                                )['exitcode'], 0, "RackHD git clone failure.")
+        self.assertEqual(fit_common.remote_shell(PROXYVARS + "git clone " +
+                         fit_common.fitinstall()['rackhd']['repo'] + " ~/rackhd")
+                         ['exitcode'], 0, "RackHD git clone failure.")
 
     def test03_run_ansible_installer(self):
-        print "**** Run RackHD Ansible installer."
-        self.assertEqual(fit_common.remote_shell(PROXYVARS +
-                                                 "cd ~/rackhd/packer/ansible/;"
-                                                 "ansible-playbook -i 'local,' -c local rackhd_package.yml",
-                                                 timeout=800,
-                                                 )['exitcode'], 0, "RackHD Install failure.")
+        self.assertEqual(fit_common.remote_shell(PROXYVARS + "cd ~/rackhd/packer/ansible/;"
+                         "ansible-playbook -i 'local,' -c local rackhd_package.yml", timeout=800,)
+                         ['exitcode'], 0, "RackHD Install failure.")
 
     def test04_install_network_config(self):
-        print "**** Installing RackHD network config."
-        # collect nic names
-        getifs = fit_common.remote_shell("ifconfig -s -a |tail -n +2 |grep -v -e Iface -e lo -e docker")
-        # clean out login stuff
-        splitifs = getifs['stdout'].split('\n')
-        ifslist = [] # array of valid eth ports
-        for item in splitifs:
-            if "assword" not in item and item.split(" ")[0]:
-                ifslist.append(item.split(" ")[0])
+        # collect nic names from RackHD host
+        ifslist = network_lib.get_host_nics()
 
         # install control network config
         control_cfg = open('control.cfg', 'w')
-        control_cfg.write(
-                            'auto ' + ifslist[1] + '\n'
-                            'iface ' + ifslist[1] + ' inet static\n'
-                            'address 172.31.128.1\n'
-                            'netmask 255.255.252.0\n'
-                        )
+        control_cfg.write(network_lib.nic_config_file(
+                          iface=ifslist[1],
+                          ipaddress=fit_common.fitrackhd()['dhcpGateway'],
+                          netmask=fit_common.fitrackhd()['dhcpSubnetMask']))
         control_cfg.close()
-        # copy file to ORA
-        fit_common.scp_file_to_ora('control.cfg')
-        self.assertEqual(fit_common.remote_shell('cp control.cfg /etc/network/interfaces.d/')['exitcode'], 0, "Control network config failure.")
+        # copy file to host
+        fit_common.scp_file_to_host('control.cfg')
+        self.assertEqual(fit_common.remote_shell('cp control.cfg /etc/network/interfaces.d/')
+                         ['exitcode'], 0, "Control network config failure.")
         os.remove('control.cfg')
         # startup NIC
-        fit_common.remote_shell('ip addr add 172.31.128.1/22 dev ' + ifslist[1])
+        fit_common.remote_shell('ip addr add ' + fit_common.fitrackhd()['dhcpGateway'] +
+                                '/' + fit_common.fitrackhd()['dhcpSubnetMask'] + ' dev ' + ifslist[1])
         fit_common.remote_shell('ip link set ' + ifslist[1] + ' up')
-        self.assertEqual(fit_common.remote_shell('ping -c 1 -w 5 172.31.128.1')['exitcode'], 0, 'Control NIC failure.')
+        self.assertEqual(fit_common.remote_shell('ping -c 1 -w 5 ' + fit_common.fitrackhd()['dhcpGateway'])
+                         ['exitcode'], 0, 'Control NIC failure.')
 
         # If PDU network adapter is present, configure
         try:
             ifslist[2]
         except IndexError:
-            print "**** No PDU network will be configured"
+            log.info_5("**** No PDU interface available, PDU will not be configured")
         else:
-            pdudirect_cfg = open('pdudirect.cfg', 'w')
-            pdudirect_cfg.write(
-                                'auto ' + ifslist[2] + '\n'
-                                'iface ' + ifslist[2] + ' inet static\n'
-                                'address 192.168.1.1\n'
-                                'netmask 255.255.255.0\n'
-                                )
-            pdudirect_cfg.close()
-            # copy file to ORA
-            fit_common.scp_file_to_ora('pdudirect.cfg')
-            self.assertEqual(fit_common.remote_shell('cp pdudirect.cfg /etc/network/interfaces.d/')['exitcode'], 0, "DHCP Config failure.")
-            os.remove('pdudirect.cfg')
-            # startup NIC
-            fit_common.remote_shell('ip addr add 192.168.1.1/24 dev ' + ifslist[2])
-            fit_common.remote_shell('ip link set ' + ifslist[2] + ' up')
-            self.assertEqual(fit_common.remote_shell('ping -c 1 -w 5 192.168.1.1')['exitcode'], 0, 'PDU NIC failure.')
+            # if 'pdu' is specified in stack, then configure PDU network
+            if 'pdu' in fit_common.fitcfg():
+                # process PDU IP configuration
+                pdusplit = fit_common.fitcfg()['pdu'].split(".")
+                pdu_prefix = pdusplit[0] + '.' + pdusplit[1] + '.' + pdusplit[2] + '.'
+                # build interface config file
+                pdudirect_cfg = open('pdudirect.cfg', 'w')
+                pdudirect_cfg.write(network_lib.nic_config_file(
+                                    iface=ifslist[2],
+                                    ipaddress=pdu_prefix + "1",
+                                    netmask="255.255.255.0"))
+                pdudirect_cfg.close()
+                # copy file to Host
+                fit_common.scp_file_to_host('pdudirect.cfg')
+                self.assertEqual(fit_common.remote_shell('cp pdudirect.cfg /etc/network/interfaces.d/')
+                                 ['exitcode'], 0, "DHCP Config failure.")
+                os.remove('pdudirect.cfg')
+                # startup NIC
+                fit_common.remote_shell('ip addr add ' + pdu_prefix + '1/24 dev ' + ifslist[2])
+                fit_common.remote_shell('ip link set ' + ifslist[2] + ' up')
+                self.assertEqual(fit_common.remote_shell('ping -c 1 -w 5 ' + pdu_prefix + '1')
+                                 ['exitcode'], 0, 'PDU NIC failure.')
+            else:
+                log.info_5("**** No PDU specified for this stack")
 
-        #create DHCP config
+        # create DHCP interface config file
         fit_common.remote_shell('echo INTERFACES=' + ifslist[1] + ' > /etc/default/isc-dhcp-server')
+        # build DHCP config file
         dhcp_conf = open('dhcpd.conf', 'w')
-        dhcp_conf.write(
-                        'ddns-update-style none;\n'
-                        'option domain-name "example.org";\n'
-                        'option domain-name-servers ns1.example.org, ns2.example.org;\n'
-                        'default-lease-time 600;\n'
-                        'max-lease-time 7200;\n'
-                        'log-facility local7;\n'
-                        'deny duplicates;\n'
-                        'ignore-client-uids true;\n'
-                        'subnet 172.31.128.0 netmask 255.255.252.0 {\n'
-                        '  range 172.31.128.2 172.31.131.254;\n'
-                        '  option vendor-class-identifier "PXEClient";\n'
-                        '}\n'
-                         )
+        dhcp_conf.write(network_lib.dhcp_config_file(ipaddress=fit_common.fitrackhd()['dhcpGateway'],
+                                                     netmask=fit_common.fitrackhd()['dhcpSubnetMask']))
         dhcp_conf.close()
-        # copy file to ORA
-        fit_common.scp_file_to_ora('dhcpd.conf')
-        self.assertEqual(fit_common.remote_shell('cp dhcpd.conf /etc/dhcp/')['exitcode'], 0, "DHCP Config failure.")
+        # copy file to Host
+        fit_common.scp_file_to_host('dhcpd.conf')
+        self.assertEqual(fit_common.remote_shell('cp dhcpd.conf /etc/dhcp/')
+                         ['exitcode'], 0, "DHCP Config failure.")
         os.remove('dhcpd.conf')
 
     def test05_install_rackhd_config_files(self):
-        print "**** Installing RackHD config files."
         # create RackHD config
         hdconfig = fit_common.fitcfg()['rackhd-config']
         config_json = open('config.json', 'w')
@@ -159,25 +152,33 @@ class rackhd_package_install(fit_common.unittest.TestCase):
         config_json.close()
         # AMQP config files
         rabbitmq_config = open('rabbitmq.config', 'w')
-        rabbitmq_config.write('[{rabbit,[{tcp_listeners, [5672]},{loopback_users, []}]},{rabbitmq_management,[{listener, [{port,  15672},{ip,"127.0.0.1"}]}]}].')
+        rabbitmq_config.write('[{rabbit,[{tcp_listeners, [5672]},{loopback_users, []}]},'
+                              '{rabbitmq_management,[{listener, [{port,  15672},{ip,"127.0.0.1"}]}]}].')
         rabbitmq_config.close()
-        # copy files to ORA
-        fit_common.scp_file_to_ora('config.json')
-        fit_common.scp_file_to_ora('rabbitmq.config')
-        self.assertEqual(fit_common.remote_shell('cp config.json /opt/monorail/')['exitcode'], 0, "RackHD Config file failure.")
-        self.assertEqual(fit_common.remote_shell('cp rabbitmq.config /etc/rabbitmq/')['exitcode'], 0, "AMQP Config file failure.")
+        # copy files to host
+        fit_common.scp_file_to_host('config.json')
+        fit_common.scp_file_to_host('rabbitmq.config')
+        self.assertEqual(fit_common.remote_shell('cp config.json /opt/monorail/')
+                         ['exitcode'], 0, "RackHD Config file failure.")
+        self.assertEqual(fit_common.remote_shell('cp rabbitmq.config /etc/rabbitmq/')
+                         ['exitcode'], 0, "AMQP Config file failure.")
         os.remove('config.json')
         os.remove('rabbitmq.config')
 
     def test06_startup(self):
-        print "Restart services."
-        self.assertEqual(fit_common.remote_shell("service isc-dhcp-server restart")['exitcode'], 0, "isc-dhcp-server failure.")
-        self.assertEqual(fit_common.remote_shell("service on-http restart")['exitcode'], 0, "on-http failure.")
-        self.assertEqual(fit_common.remote_shell("service on-dhcp-proxy restart")['exitcode'], 0, "on-dhcp-proxy failure.")
-        self.assertEqual(fit_common.remote_shell("service on-syslog restart")['exitcode'], 0, "on-syslog failure.")
-        self.assertEqual(fit_common.remote_shell("service on-taskgraph restart")['exitcode'], 0, "on-taskgraph failure.")
-        self.assertEqual(fit_common.remote_shell("service on-tftp restart")['exitcode'], 0, "on-tftp failure.")
-        print "**** Check installation."
+        self.assertEqual(fit_common.remote_shell("service isc-dhcp-server restart")
+                         ['exitcode'], 0, "isc-dhcp-server failure.")
+        self.assertEqual(fit_common.remote_shell("service on-http restart")
+                         ['exitcode'], 0, "on-http failure.")
+        self.assertEqual(fit_common.remote_shell("service on-dhcp-proxy restart")
+                         ['exitcode'], 0, "on-dhcp-proxy failure.")
+        self.assertEqual(fit_common.remote_shell("service on-syslog restart")
+                         ['exitcode'], 0, "on-syslog failure.")
+        self.assertEqual(fit_common.remote_shell("service on-taskgraph restart")
+                         ['exitcode'], 0, "on-taskgraph failure.")
+        self.assertEqual(fit_common.remote_shell("service on-tftp restart")
+                         ['exitcode'], 0, "on-tftp failure.")
+        log.info_5("**** Checking installation.")
         for dummy in range(0, 10):
             try:
                 fit_common.rackhdapi("/api/2.0/config")
@@ -187,6 +188,6 @@ class rackhd_package_install(fit_common.unittest.TestCase):
                 break
         self.assertEqual(fit_common.rackhdapi("/api/2.0/config")['status'], 200, "Unable to contact RackHD.")
 
+
 if __name__ == '__main__':
     fit_common.unittest.main()
-    

--- a/test/deploy/rackhd_source_install.py
+++ b/test/deploy/rackhd_source_install.py
@@ -14,7 +14,7 @@ This script performs the following functions:
     - startup and verify services
 
 NOTES:
-       If the host is rebooted, the RackHD must be restarted by typing 'sudo nf start' at console.
+       If the host is rebooted, the RackHD must be restarted by typing 'pm2 restart' at console.
 
 usage:
     python run_tests.py -stack <stack ID> -test deploy/rackhd_source_install.py

--- a/test/deploy/rackhd_source_install.py
+++ b/test/deploy/rackhd_source_install.py
@@ -1,5 +1,5 @@
 '''
-Copyright 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+Copyright 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 
 Author(s):
 George Paulos
@@ -22,6 +22,7 @@ usage:
 
 import fit_path  # NOQA: unused import
 import os
+import sys
 import fit_common
 import network_lib
 import flogging
@@ -55,6 +56,14 @@ if fit_common.fitproxy()['host'] != '':
     fit_common.scp_file_to_host('settings.xml')
     fit_common.remote_shell('mkdir -p ~/.m2;cp settings.xml ~/.m2;mkdir -p /root/.m2;cp settings.xml /root/.m2')
     os.remove('settings.xml')
+
+# verify IP addresses and netmasks in config files are valid
+if not network_lib.verify_rackhd_network_config():
+    log.error("Invalid network configuration in rackhd_default.json.")
+    sys.exit(255)
+if 'pdu' in fit_common.fitcfg() and not network_lib.split_ipv4(fit_common.fitcfg()['pdu']):
+    log.error("Invalid PDU IP address in stack_config.json: " + fit_common.fitcfg()['pdu'])
+    sys.exit(255)
 
 
 class rackhd_source_install(fit_common.unittest.TestCase):
@@ -127,23 +136,28 @@ class rackhd_source_install(fit_common.unittest.TestCase):
         ifslist = network_lib.get_host_nics()
 
         # install control network config
-        control_cfg = open('control.cfg', 'w')
-        control_cfg.write(network_lib.nic_config_file(
-                          iface=ifslist[1],
-                          ipaddress=fit_common.fitrackhd()['dhcpGateway'],
-                          netmask=fit_common.fitrackhd()['dhcpSubnetMask']))
-        control_cfg.close()
-        # copy file to Host
-        fit_common.scp_file_to_host('control.cfg')
-        self.assertEqual(fit_common.remote_shell('cp control.cfg /etc/network/interfaces.d/')
-                         ['exitcode'], 0, "Control network config failure.")
-        os.remove('control.cfg')
-        # startup NIC
-        fit_common.remote_shell('ip addr add ' + fit_common.fitrackhd()['dhcpGateway'] +
-                                '/' + fit_common.fitrackhd()['dhcpSubnetMask'] + ' dev ' + ifslist[1])
-        fit_common.remote_shell('ip link set ' + ifslist[1] + ' up')
-        self.assertEqual(fit_common.remote_shell('ping -c 1 -w 5 ' + fit_common.fitrackhd()['dhcpGateway'])
-                         ['exitcode'], 0, 'Control NIC config failure.')
+        try:
+            ifslist[1]
+        except IndexError:
+            self.fail("****ERROR No Control interface available, Control LAN will not be configured")
+        else:
+            control_cfg = open('control.cfg', 'w')
+            control_cfg.write(network_lib.nic_config_file(
+                              iface=ifslist[1],
+                              ipaddress=fit_common.fitrackhd()['dhcpGateway'],
+                              netmask=fit_common.fitrackhd()['dhcpSubnetMask']))
+            control_cfg.close()
+            # copy file to host
+            fit_common.scp_file_to_host('control.cfg')
+            self.assertEqual(fit_common.remote_shell('cp control.cfg /etc/network/interfaces.d/')
+                             ['exitcode'], 0, "Control network config failure.")
+            os.remove('control.cfg')
+            # startup NIC
+            fit_common.remote_shell('ip addr add ' + fit_common.fitrackhd()['dhcpGateway'] +
+                                    '/' + fit_common.fitrackhd()['dhcpSubnetMask'] + ' dev ' + ifslist[1])
+            fit_common.remote_shell('ip link set ' + ifslist[1] + ' up')
+            self.assertEqual(fit_common.remote_shell('ping -c 1 -w 5 ' + fit_common.fitrackhd()['dhcpGateway'])
+                             ['exitcode'], 0, 'Control NIC failure.')
 
         # If PDU network adapter is present, configure
         try:

--- a/test/deploy/rackhd_source_install.py
+++ b/test/deploy/rackhd_source_install.py
@@ -1,5 +1,5 @@
 '''
-Copyright 2016, EMC, Inc.
+Copyright 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 
 Author(s):
 George Paulos
@@ -11,7 +11,7 @@ This script performs the following functions:
     - installs using rackhd_local.yml playbook
     - set up networking
     - load configuration files
-    - startup and verify operations
+    - startup and verify services
 
 NOTES:
        If the host is rebooted, the RackHD must be restarted by typing 'sudo nf start' at console.
@@ -22,9 +22,10 @@ usage:
 
 import fit_path  # NOQA: unused import
 import os
-import sys
-import subprocess
 import fit_common
+import network_lib
+import flogging
+log = flogging.get_loggers()
 
 # set proxy if required
 PROXYVARS = ''
@@ -34,82 +35,87 @@ if fit_common.fitproxy()['host'] != '':
                 "export https_proxy=http://" + fit_common.fitproxy()['host'] + ":" + fit_common.fitproxy()['port'] + ";"
     # maven proxy settings
     maven_proxy = open('settings.xml', 'w')
-    maven_proxy.write(
-      '<settings '
-      'xmlns="http://maven.apache.org/SETTINGS/1.0.0" '
-      'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
-      'xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 '
-      'http://maven.apache.org/xsd/settings-1.0.0.xsd">'
-          '<proxies>'
-              '<proxy>'
-              '<id>mavenproxy</id>'
-              '<active>true</active>'
-              '<protocol>https</protocol>'
-              '<host>' + fit_common.fitproxy()['host'] + '</host>'
-              '<port>' + fit_common.fitproxy()['port'] + '</port>'
-              '<nonProxyHosts>localhost</nonProxyHosts>'
-            '</proxy>'
-          '</proxies>'
-      '</settings>')
+    maven_proxy.write('<settings '
+                      'xmlns="http://maven.apache.org/SETTINGS/1.0.0" '
+                      'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
+                      'xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 '
+                      'http://maven.apache.org/xsd/settings-1.0.0.xsd">'
+                      '<proxies>'
+                      '<proxy>'
+                      '<id>mavenproxy</id>'
+                      '<active>true</active>'
+                      '<protocol>https</protocol>'
+                      '<host>' + fit_common.fitproxy()['host'] + '</host>'
+                      '<port>' + fit_common.fitproxy()['port'] + '</port>'
+                      '<nonProxyHosts>localhost</nonProxyHosts>'
+                      '</proxy>'
+                      '</proxies>'
+                      '</settings>')
     maven_proxy.close()
-    fit_common.scp_file_to_ora('settings.xml')
+    fit_common.scp_file_to_host('settings.xml')
     fit_common.remote_shell('mkdir -p ~/.m2;cp settings.xml ~/.m2;mkdir -p /root/.m2;cp settings.xml /root/.m2')
     os.remove('settings.xml')
 
+
 class rackhd_source_install(fit_common.unittest.TestCase):
     def test01_install_rackhd_dependencies(self):
-        print "**** Installing RackHD dependencies."
         # update sudoers to preserve proxy environment
         sudoersproxy = open("sudoersproxy", 'w')
         sudoersproxy.write('Defaults env_keep="HOME no_proxy http_proxy https_proxy"\n')
         sudoersproxy.close()
         fit_common.remote_shell('pwd')
-        fit_common.scp_file_to_ora("sudoersproxy")
-        self.assertEqual(fit_common.remote_shell('cp sudoersproxy /etc/sudoers.d/'
-                                                  )['exitcode'], 0, "sudoersproxy config failure.")
+        fit_common.scp_file_to_host("sudoersproxy")
+        self.assertEqual(fit_common.remote_shell('cp sudoersproxy /etc/sudoers.d/')
+                         ['exitcode'], 0, "sudoersproxy failure.")
         os.remove('sudoersproxy')
         # install git
-        self.assertEqual(fit_common.remote_shell(PROXYVARS + "apt-get -y install git")['exitcode'], 0, "Git install failure.")
-        self.assertEqual(fit_common.remote_shell("git config --global http.sslverify false")['exitcode'], 0, "Git config failure.")
+        self.assertEqual(fit_common.remote_shell(PROXYVARS + "apt-get -y install git")
+                         ['exitcode'], 0, "Git install failure.")
+        self.assertEqual(fit_common.remote_shell("git config --global http.sslverify false")
+                         ['exitcode'], 0, "Git config failure.")
         if fit_common.fitproxy()['host'] != '':
-            self.assertEqual(fit_common.remote_shell("git config --global http.proxy http://" + fit_common.fitproxy()['host'] + ':' + fit_common.fitproxy()['port']
-                                                  )['exitcode'], 0, "Git proxy config failure.")
+            self.assertEqual(fit_common.remote_shell("git config --global http.proxy http://" +
+                             fit_common.fitproxy()['host'] + ':' +
+                             fit_common.fitproxy()['port'])
+                             ['exitcode'], 0, "Git proxy config failure.")
         # install Ansible
-        self.assertEqual(fit_common.remote_shell(PROXYVARS + "apt-get -y update")['exitcode'], 0, "Update failure.")
-        self.assertEqual(fit_common.remote_shell(PROXYVARS + "cd ~;apt-get -y install ansible")['exitcode'], 0, "Ansible Install failure.")
+        self.assertEqual(fit_common.remote_shell(PROXYVARS + "apt-get -y update")
+                         ['exitcode'], 0, "Update failure.")
+        self.assertEqual(fit_common.remote_shell(PROXYVARS + "cd ~;apt-get -y install ansible")
+                         ['exitcode'], 0, "Ansible Install failure.")
         # create startup files
         self.assertEqual(fit_common.remote_shell(
-            "touch /etc/default/on-dhcp-proxy /etc/default/on-http /etc/default/on-tftp /etc/default/on-syslog /etc/default/on-taskgraph"
-            )['exitcode'], 0, "Startup files failure.")
+                         "touch /etc/default/on-dhcp-proxy /etc/default/on-http "
+                         "/etc/default/on-tftp /etc/default/on-syslog /etc/default/on-taskgraph"
+                         )['exitcode'], 0, "Startup files failure.")
 
     def test02_clone_rackhd_source(self):
-        print "**** Cloning RackHD source."
-        # clone base repo
+        # remove previous installation
         fit_common.remote_shell('rm -rf ~/rackhd')
-        self.assertEqual(fit_common.remote_shell(PROXYVARS + "git clone "
-                                                + fit_common.fitinstall()['rackhd']['repo']
-                                                + " ~/rackhd"
-                                                )['exitcode'], 0, "RackHD git clone failure.")
-        self.assertEqual(fit_common.remote_shell("cd ~/rackhd/" + ";git checkout "
-                                                 + fit_common.fitinstall()['rackhd']['branch']
+        # clone base repo
+        self.assertEqual(fit_common.remote_shell(PROXYVARS + "git clone " +
+                         fit_common.fitinstall()['rackhd']['repo'] + " ~/rackhd")
+                         ['exitcode'], 0, "RackHD git clone failure.")
+        self.assertEqual(fit_common.remote_shell("cd ~/rackhd/" + ";git checkout " +
+                                                 fit_common.fitinstall()['rackhd']['branch']
                                                  )['exitcode'], 0, "Branch not found on RackHD repo.")
         '''
-        # this section is for future use
+        # this section is for future use when repo selection is enabled
         # clone modules
         for repo in fit_common.fitinstall().keys():
-            self.assertEqual(fit_common.remote_shell(PROXYVARS
-                                                    + "rm -rf ~/rackhd/" + repo + ";"
-                                                    + "git clone "
-                                                    + fit_common.fitinstall()[repo]['repo']
-                                                    + " ~/rackhd/" + repo
-                                                     )['exitcode'], 0, "RackHD git clone module failure:" + repo)
-            self.assertEqual(fit_common.remote_shell("cd ~/rackhd/" + repo + ";git checkout "
-                                                     + fit_common.fitinstall()[repo]['branch']
-                                                     )['exitcode'], 0, "Branch not found on module:" + repo)
+            self.assertEqual(fit_common.remote_shell(PROXYVARS +
+                             "rm -rf ~/rackhd/" + repo + ";" + "git clone " +
+                             fit_common.fitinstall()[repo]['repo'] + " ~/rackhd/" + repo)
+                             ['exitcode'], 0, "RackHD git clone module failure:" + repo)
+            self.assertEqual(fit_common.remote_shell("cd ~/rackhd/" + repo + ";git checkout " +
+                             fit_common.fitinstall()[repo]['branch'])
+                             ['exitcode'], 0, "Branch not found on module:" + repo)
         '''
 
     def test03_run_ansible_installer(self):
-        print "**** Run RackHD Ansible installer."
+        # remove previous installation
+        fit_common.remote_shell('rm -rf ~/src')
+        # run Ansible source installer
         self.assertEqual(fit_common.remote_shell(PROXYVARS +
                                                  "cd ~/rackhd/packer/ansible/;"
                                                  "ansible-playbook -i 'local,' -c local rackhd_local.yml",
@@ -117,82 +123,72 @@ class rackhd_source_install(fit_common.unittest.TestCase):
                                                  )['exitcode'], 0, "RackHD Install failure.")
 
     def test04_install_network_config(self):
-        print "**** Installing RackHD network config."
-        # collect nic names
-        getifs = fit_common.remote_shell("ifconfig -s -a |tail -n +2 |grep -v -e Iface -e lo -e docker")
-        # clean out login stuff
-        splitifs = getifs['stdout'].split('\n')
-        ifslit = [] # array of valid eth ports
-        for item in splitifs:
-            if "assword" not in item and item.split(" ")[0]:
-                ifslit.append(item.split(" ")[0])
+        # collect nic names from RackHD host
+        ifslist = network_lib.get_host_nics()
 
         # install control network config
         control_cfg = open('control.cfg', 'w')
-        control_cfg.write(
-                            'auto ' + ifslit[1] + '\n'
-                            'iface ' + ifslit[1] + ' inet static\n'
-                            'address 172.31.128.1\n'
-                            'netmask 255.255.252.0\n'
-                        )
+        control_cfg.write(network_lib.nic_config_file(
+                          iface=ifslist[1],
+                          ipaddress=fit_common.fitrackhd()['dhcpGateway'],
+                          netmask=fit_common.fitrackhd()['dhcpSubnetMask']))
         control_cfg.close()
-        # copy file to ORA
-        fit_common.scp_file_to_ora('control.cfg')
-        self.assertEqual(fit_common.remote_shell('cp control.cfg /etc/network/interfaces.d/')['exitcode'], 0, "Control network config failure.")
+        # copy file to Host
+        fit_common.scp_file_to_host('control.cfg')
+        self.assertEqual(fit_common.remote_shell('cp control.cfg /etc/network/interfaces.d/')
+                         ['exitcode'], 0, "Control network config failure.")
         os.remove('control.cfg')
         # startup NIC
-        fit_common.remote_shell('ip addr add 172.31.128.1/22 dev ' + ifslit[1])
-        fit_common.remote_shell('ip link set ' + ifslit[1] + ' up')
-        self.assertEqual(fit_common.remote_shell('ping -c 1 -w 5 172.31.128.1')['exitcode'], 0, 'Control NIC failure.')
+        fit_common.remote_shell('ip addr add ' + fit_common.fitrackhd()['dhcpGateway'] +
+                                '/' + fit_common.fitrackhd()['dhcpSubnetMask'] + ' dev ' + ifslist[1])
+        fit_common.remote_shell('ip link set ' + ifslist[1] + ' up')
+        self.assertEqual(fit_common.remote_shell('ping -c 1 -w 5 ' + fit_common.fitrackhd()['dhcpGateway'])
+                         ['exitcode'], 0, 'Control NIC config failure.')
 
         # If PDU network adapter is present, configure
         try:
-            ifslit[2]
+            ifslist[2]
         except IndexError:
-            print "**** No PDU network will be configured"
+            log.info_5("**** No PDU interface available, PDU will not be configured")
         else:
-            pdudirect_cfg = open('pdudirect.cfg', 'w')
-            pdudirect_cfg.write(
-                                'auto ' + ifslit[2] + '\n'
-                                'iface ' + ifslit[2] + ' inet static\n'
-                                'address 192.168.1.1\n'
-                                'netmask 255.255.255.0\n'
-                                )
-            pdudirect_cfg.close()
-            # copy file to ORA
-            fit_common.scp_file_to_ora('pdudirect.cfg')
-            self.assertEqual(fit_common.remote_shell('cp pdudirect.cfg /etc/network/interfaces.d/')['exitcode'], 0, "DHCP Config failure.")
-            os.remove('pdudirect.cfg')
-            # startup NIC
-            fit_common.remote_shell('ip addr add 192.168.1.1/24 dev ' + ifslit[2])
-            fit_common.remote_shell('ip link set ' + ifslit[2] + ' up')
-            self.assertEqual(fit_common.remote_shell('ping -c 1 -w 5 192.168.1.1')['exitcode'], 0, 'PDU NIC failure.')
+            # if 'pdu' is specified in stack, then configure PDU network
+            if 'pdu' in fit_common.fitcfg():
+                # process PDU IP configuration
+                pdusplit = fit_common.fitcfg()['pdu'].split(".")
+                pdu_prefix = pdusplit[0] + '.' + pdusplit[1] + '.' + pdusplit[2] + '.'
+                # build interface config file
+                pdudirect_cfg = open('pdudirect.cfg', 'w')
+                pdudirect_cfg.write(network_lib.nic_config_file(
+                                    iface=ifslist[2],
+                                    ipaddress=pdu_prefix + "1",
+                                    netmask="255.255.255.0"))
+                pdudirect_cfg.close()
+                # copy file to Host
+                fit_common.scp_file_to_host('pdudirect.cfg')
+                self.assertEqual(fit_common.remote_shell('cp pdudirect.cfg /etc/network/interfaces.d/')
+                                 ['exitcode'], 0, "DHCP config failure.")
+                os.remove('pdudirect.cfg')
+                # startup NIC
+                fit_common.remote_shell('ip addr add ' + pdu_prefix + '1/24 dev ' + ifslist[2])
+                fit_common.remote_shell('ip link set ' + ifslist[2] + ' up')
+                self.assertEqual(fit_common.remote_shell('ping -c 1 -w 5 ' + pdu_prefix + '1')
+                                 ['exitcode'], 0, 'PDU NIC failure.')
+            else:
+                log.info_5("**** No PDU specified for this stack")
 
-        #create DHCP config
-        fit_common.remote_shell('echo INTERFACES=' + ifslit[1] + ' > /etc/default/isc-dhcp-server')
+        # create DHCP interface config file
+        fit_common.remote_shell('echo INTERFACES=' + ifslist[1] + ' > /etc/default/isc-dhcp-server')
+        # build DHCP config file
         dhcp_conf = open('dhcpd.conf', 'w')
-        dhcp_conf.write(
-                        'ddns-update-style none;\n'
-                        'option domain-name "example.org";\n'
-                        'option domain-name-servers ns1.example.org, ns2.example.org;\n'
-                        'default-lease-time 600;\n'
-                        'max-lease-time 7200;\n'
-                        'log-facility local7;\n'
-                        'deny duplicates;\n'
-                        'ignore-client-uids true;\n'
-                        'subnet 172.31.128.0 netmask 255.255.252.0 {\n'
-                        '  range 172.31.128.2 172.31.131.254;\n'
-                        '  option vendor-class-identifier "PXEClient";\n'
-                        '}\n'
-                         )
+        dhcp_conf.write(network_lib.dhcp_config_file(ipaddress=fit_common.fitrackhd()['dhcpGateway'],
+                                                     netmask=fit_common.fitrackhd()['dhcpSubnetMask']))
         dhcp_conf.close()
-        # copy file to ORA
-        fit_common.scp_file_to_ora('dhcpd.conf')
+        # copy file to Host
+        fit_common.scp_file_to_host('dhcpd.conf')
         self.assertEqual(fit_common.remote_shell('cp dhcpd.conf /etc/dhcp/')['exitcode'], 0, "DHCP Config failure.")
         os.remove('dhcpd.conf')
 
     def test05_install_rackhd_config_files(self):
-        print "**** Installing RackHD config files."
         # create RackHD config
         hdconfig = fit_common.fitcfg()['rackhd-config']
         config_json = open('config.json', 'w')
@@ -200,13 +196,16 @@ class rackhd_source_install(fit_common.unittest.TestCase):
         config_json.close()
         # AMQP config files
         rabbitmq_config = open('rabbitmq.config', 'w')
-        rabbitmq_config.write('[{rabbit,[{tcp_listeners, [5672]},{loopback_users, []}]},{rabbitmq_management,[{listener, [{port,  15672},{ip,"127.0.0.1"}]}]}].')
+        rabbitmq_config.write('[{rabbit,[{tcp_listeners, [5672]},{loopback_users, []}]},'
+                              '{rabbitmq_management,[{listener, [{port,  15672},{ip,"127.0.0.1"}]}]}].')
         rabbitmq_config.close()
-        # copy files to ORA
-        fit_common.scp_file_to_ora('config.json')
-        fit_common.scp_file_to_ora('rabbitmq.config')
-        self.assertEqual(fit_common.remote_shell('cp config.json /opt/monorail/')['exitcode'], 0, "RackHD Config file failure.")
-        self.assertEqual(fit_common.remote_shell('cp rabbitmq.config /etc/rabbitmq/')['exitcode'], 0, "AMQP Config file failure.")
+        # copy files to Host
+        fit_common.scp_file_to_host('config.json')
+        fit_common.scp_file_to_host('rabbitmq.config')
+        self.assertEqual(fit_common.remote_shell('cp config.json /opt/monorail/')
+                         ['exitcode'], 0, "RackHD Config file failure.")
+        self.assertEqual(fit_common.remote_shell('cp rabbitmq.config /etc/rabbitmq/')
+                         ['exitcode'], 0, "AMQP Config file failure.")
         os.remove('config.json')
         os.remove('rabbitmq.config')
         self.assertEqual(fit_common.remote_shell(PROXYVARS + "cd ~/src/on-http && ./install-web-ui.sh")['exitcode'],
@@ -215,20 +214,14 @@ class rackhd_source_install(fit_common.unittest.TestCase):
                          0, "swagger-ui install failure.")
 
     def test06_startup(self):
-        print "**** Start services."
-        self.assertEqual(fit_common.remote_shell("/etc/init.d/isc-dhcp-server restart")['exitcode'], 0, "dhcp startup failure.")
-        self.assertEqual(fit_common.remote_shell("cd ~/;pm2 start rackhd-pm2-config.yml > /dev/null 2>&1")['exitcode'], 0, "RackHD startup failure.")
-        print "**** Check installation."
-        fit_common.time.sleep(10)
-        for dummy in range(0, 10):
-            try:
-                fit_common.rackhdapi("/swagger-ui")
-                fit_common.rackhdapi("/api/2.0/config")
-            except:
-                fit_common.time.sleep(10)
-            else:
-                break
+        self.assertEqual(fit_common.remote_shell("/etc/init.d/isc-dhcp-server restart")
+                         ['exitcode'], 0, "DHCP startup failure.")
+        self.assertEqual(fit_common.remote_shell("cd ~/;pm2 restart rackhd-pm2-config.yml > /dev/null 2>&1")
+                         ['exitcode'], 0, "RackHD startup failure.")
+        log.info_5("**** Checking installation.")
+        fit_common.time.sleep(30)
         self.assertEqual(fit_common.rackhdapi("/api/2.0/config")['status'], 200, "Unable to contact RackHD.")
+
 
 if __name__ == '__main__':
     fit_common.unittest.main()


### PR DESCRIPTION
This PR addresses technical debt in deploy/rackhd_package_install.py and deploy/rackhd_source_install.py .

This is a resubmit of RAC-4236 and RAC-4325 to address concerns about invalid configuration entries

- removed all hard-coded IP addresses, harvests all IP addresses and netmasks from rackhd_config
- convert function call scp_file_to_ora > scp_file_to_host
- use FIT logging instead of print statements
- refactored and moved all shared network routines to new common library common/network_lib.py
- added validation to detect invalid or missing network configuration
- fixed Hound violations

@hohene @larry-dean @jimturnquist @stuart-stanley @johren 
