### PR TITLE
[skip ci]packer ansible: add rackhd install log and version check

### DIFF
--- a/packer/ansible/roles/rackhd-builds/tasks/aptitude_install_rackhd.yml
+++ b/packer/ansible/roles/rackhd-builds/tasks/aptitude_install_rackhd.yml
@@ -22,3 +22,7 @@
     exit [lindex $result 3]
   args:
     executable: /usr/bin/expect
+  register: install_rackhd
+
+- name: RackHD Installation Log
+  debug: msg="{{ install_rackhd.stdout }}"

--- a/packer/ansible/roles/rackhd-builds/tasks/main.yml
+++ b/packer/ansible/roles/rackhd-builds/tasks/main.yml
@@ -30,3 +30,13 @@
     package: rackhd={{ rackhd_version }}
   sudo: yes
   when: (rackhd_version is not undefined) and rackhd_version
+
+- name: Check Installed RackHD version
+  shell: |
+    installed_version=`apt-cache policy rackhd | grep Installed | awk '{print $2}'`
+    echo "[Debug] installed_version=$installed_version"
+    if [ "$installed_version" != "{{ rackhd_version }}" ]; then
+      echo "Installed wrong rackhd version $installed_version"
+      exit 1
+    fi
+  when: (rackhd_version is not undefined) and rackhd_version


### PR DESCRIPTION
This PR is for:
* Put the version check ahead of time (right after aptitude install)
* Ansible log is not enough. Should increase a bit

@panpan0000 @PengTian0 
