### PR TITLE
RAC-4182 - Staging the CIT redfish_1_0 test scripts into temp directory

### DIFF
--- a/test/tests/api/tmp_fit_staging/redfish_1_0/account_service_tests.py
+++ b/test/tests/api/tmp_fit_staging/redfish_1_0/account_service_tests.py
@@ -1,0 +1,140 @@
+from config.redfish1_0_config import *
+from modules.logger import Log
+from modules.redfish_auth import Auth
+from on_http_redfish_1_0 import RedfishvApi as redfish
+from on_http_redfish_1_0 import rest
+from datetime import datetime
+from proboscis.asserts import assert_equal
+from proboscis.asserts import assert_false
+from proboscis.asserts import assert_raises
+from proboscis.asserts import assert_not_equal
+from proboscis.asserts import assert_true
+from proboscis.asserts import fail
+from proboscis import SkipTest
+from proboscis import test
+from json import loads,dumps
+from proboscis import before_class
+from proboscis import after_class
+
+
+LOG = Log(__name__)
+
+@test(groups=['redfish.account_service.tests'], depends_on_groups=['obm.tests'])
+class AccountServiceTests(object):
+
+    def __init__(self):
+        self.__client = config.api_client
+        self.__accounts = None
+        self.__roles = None
+
+    @before_class()
+    def setup(self):
+        """setup test environment"""
+        Auth.enable()
+
+    @after_class(always_run=True)
+    def teardown(self):
+        """ restore test environment """
+        Auth.disable()
+
+    def __get_data(self):
+        return loads(self.__client.last_response.data)
+
+    @test(groups=['redfish.get_account_service'])
+    def test_get_account_service(self):
+        """ Testing GET /AccountService """
+        redfish().get_account_service()
+        service = self.__get_data()
+        LOG.debug(service,json=True)
+        id = service.get('Id')
+        assert_equal('AccountService', id, message='unexpected id {0}, expected {1}'.format(id,'AccountService'))
+        accounts = service.get('Accounts')
+        roles = service.get('Roles')
+        assert_not_equal(None, accounts, message='Failed to get accounts')
+        assert_not_equal(None, roles, message='Failed to get roles')
+
+    @test(groups=['redfish.list_roles'], depends_on_groups=['redfish.get_account_service'])
+    def test_list_roles(self):
+        """ Testing GET /AcountService/Roles """
+        redfish().list_roles()
+        roles = self.__get_data()
+        LOG.debug(roles,json=True)
+        self.__roles = roles.get('Members')
+        assert_equal(len(self.__roles), 3, message='expected role length to be 3')
+        for member in self.__roles:
+            dataId = member.get('@odata.id')
+            assert_not_equal(None,dataId)
+            dataId = dataId.split('/redfish/v1/AccountService/Roles/')[1]
+            redfish().get_role(dataId)
+            role = self.__get_data()
+            LOG.debug(role,json=True)
+            name = role.get('Name')
+            assert_equal(dataId, name, message='unexpected name {0}, expected {1}'.format(name,dataId))
+
+    @test(groups=['redfish.get_accounts'], depends_on_groups=['redfish.get_account_service'])
+    def test_get_accounts(self):
+        """ Testing GET /AcountService/Accounts """
+        redfish().get_accounts()
+        accounts = self.__get_data()
+        LOG.debug(accounts,json=True)
+        self.__accounts = accounts.get('Members')
+        for member in self.__accounts:
+            dataId = member.get('@odata.id')
+            assert_not_equal(None,dataId)
+            dataId = dataId.split('/redfish/v1/AccountService/Accounts/')[1]
+            redfish().get_account(dataId)
+            account = self.__get_data()
+            LOG.debug(account,json=True)
+            username = account.get('UserName')
+            assert_equal(dataId, username, message='unexpected username {0}, expected {1}'.format(username,dataId))
+
+    @test(groups=['redfish.create_account'], depends_on_groups=['redfish.get_accounts'])
+    def test_create_account(self):
+        """ Testing POST /AcountService/Accounts """
+        body = {
+            'UserName': 'funtest-name',
+            'Password': 'funtest123',
+            'RoleId': 'Administrator'
+        }
+        redfish().create_account(payload=body)
+        self.test_get_accounts()
+        found = False
+        for member in self.__accounts:
+            dataId = member.get('@odata.id')
+            assert_not_equal(None,dataId)
+            dataId = dataId.split('/redfish/v1/AccountService/Accounts/')[1]
+            if dataId == 'funtest-name':
+                found = True
+                redfish().get_account(dataId)
+                account = self.__get_data()
+                assert_equal(account.get('RoleId'), 'Administrator', message='unexpected RoleId')
+                break
+        if not found:
+            fail(message='newly created user was not found')
+
+    @test(groups=['redfish.modify_account'], depends_on_groups=['redfish.create_account'])
+    def test_modify_account(self):
+        """ Testing PATCH /AcountService/Accounts/{name} """
+        body = {
+            'Password': 'funtest456',
+            'RoleId': 'ReadOnly'
+        }
+        redfish().modify_account('funtest-name', payload=body)
+        redfish().get_account('funtest-name')
+        account = self.__get_data()
+        assert_equal(account.get('RoleId'), 'ReadOnly', message='unexpected RoleId')
+
+    @test(groups=['redfish.remove_account'], depends_on_groups=['redfish.create_account'])
+    def test_remove_account(self):
+        redfish().remove_account('funtest-name')
+        self.test_get_accounts()
+        found = False
+        for member in self.__accounts:
+            dataId = member.get('@odata.id')
+            assert_not_equal(None,dataId)
+            dataId = dataId.split('/redfish/v1/AccountService/Accounts/')[1]
+            if dataId == 'funtest-name':
+                fail(message='failed to delete account')
+
+
+

--- a/test/tests/api/tmp_fit_staging/redfish_1_0/chassis_tests.py
+++ b/test/tests/api/tmp_fit_staging/redfish_1_0/chassis_tests.py
@@ -1,0 +1,88 @@
+from config.redfish1_0_config import *
+from modules.logger import Log
+from on_http_redfish_1_0 import RedfishvApi as redfish
+from datetime import datetime
+from proboscis.asserts import assert_equal
+from proboscis.asserts import assert_false
+from proboscis.asserts import assert_raises
+from proboscis.asserts import assert_not_equal
+from proboscis.asserts import assert_true
+from proboscis.asserts import fail
+from proboscis import SkipTest
+from proboscis import test
+from json import loads,dumps
+
+LOG = Log(__name__)
+
+@test(groups=['redfish.chassis.tests'], \
+    depends_on_groups=['obm.tests', 'amqp.tests'])
+class ChassisTests(object):
+
+    def __init__(self):
+        self.__client = config.api_client
+        self.__chassisList = None
+        self.__membersList = None
+
+    def __get_data(self):
+        return loads(self.__client.last_response.data)
+
+    @test(groups=['redfish.list_chassis'])
+    def test_list_chassis(self):
+        """ Testing GET /Chassis """
+        redfish().list_chassis()
+        chassis = self.__get_data()
+        LOG.debug(chassis,json=True)
+        assert_not_equal(0, len(chassis), message='Chassis list was empty!')
+        self.__chassisList = chassis
+    
+    @test(groups=['redfish.get_chassis'], depends_on_groups=['redfish.list_chassis'])
+    def test_get_chassis(self):
+        """ Testing GET /Chassis/{identifier} """
+        self.__membersList = self.__chassisList.get('Members')
+        assert_not_equal(None, self.__membersList)
+        for member in self.__membersList:
+            dataId = member.get('@odata.id')
+            assert_not_equal(None,dataId)
+            dataId = dataId.split('/redfish/v1/Chassis/')[1]
+            LOG.info(dataId)
+            redfish().get_chassis(dataId)
+            chassis = self.__get_data()
+            LOG.debug(chassis,json=True)
+            id = chassis.get('Id')
+            assert_equal(dataId, id, message='unexpected id {0}, expected {1}'.format(id,dataId))
+
+    @test(groups=['redfish.get_chassis_thermal'], depends_on_groups=['redfish.get_chassis'])
+    def test_get_chassis_thermal(self):
+        """ Testing GET /Chassis/{identifier}/Thermal """
+        for member in self.__membersList:
+            dataId = member.get('@odata.id')
+            assert_not_equal(None,dataId)
+            dataId = dataId.split('/redfish/v1/Chassis/')[1]
+            redfish().get_thermal(dataId)
+            thermal = self.__get_data()
+            LOG.debug(thermal,json=True)
+            assert_not_equal({}, thermal, message='thermal object undefined!')
+            name = thermal.get('Name')
+            assert_not_equal('', name, message='empty thermal name!')
+            temperature = thermal.get('Temperatures')
+            assert_not_equal(0, len(temperature), message='temperature list was empty!')
+            fans = thermal.get('Fans')
+            assert_not_equal(0, len(fans), message='fans list was empty!')
+            
+            
+    @test(groups=['redfish.get_chassis_power'], depends_on_groups=['redfish.get_chassis'])
+    def test_get_chassis_power(self):
+        """ Testing GET /Chassis/{identifier}/Power """
+        for member in self.__membersList:
+            dataId = member.get('@odata.id')
+            assert_not_equal(None,dataId)
+            dataId = dataId.split('/redfish/v1/Chassis/')[1]
+            redfish().get_power(dataId)
+            power = self.__get_data()
+            LOG.debug(power,json=True)
+            assert_not_equal({}, power, message='power object undefined!')
+            name = power.get('Name')
+            assert_not_equal('', name, message='empty power name!')
+            voltages = power.get('Voltages')
+            assert_not_equal(0, len(power), message='voltages list was empty!')
+            

--- a/test/tests/api/tmp_fit_staging/redfish_1_0/event_service_tests.py
+++ b/test/tests/api/tmp_fit_staging/redfish_1_0/event_service_tests.py
@@ -1,0 +1,129 @@
+from config.redfish1_0_config import *
+from config.settings import *
+from on_http_redfish_1_0 import RedfishvApi as redfish
+from modules.httpd import Httpd, BaseHandler, open_ssh_forward
+from modules.logger import Log
+from modules.worker import WorkerThread, WorkerTasks
+from proboscis.asserts import assert_equal
+from proboscis.asserts import assert_false
+from proboscis.asserts import assert_raises
+from proboscis.asserts import assert_not_equal
+from proboscis.asserts import assert_true
+from proboscis.asserts import assert_is_not_none
+from proboscis.asserts import fail
+from proboscis import SkipTest
+from proboscis import test
+from json import loads
+import thread
+
+LOG = Log(__name__)
+
+@test(groups=['redfish.event_service.tests'])
+class EventServiceTests(object):
+    def __init__(self):
+        self.__client = config.api_client
+        self.__httpd_port = 9995
+        
+    def __get_data(self):
+        return loads(self.__client.last_response.data)
+
+    def __httpd_start(self,worker,id):
+        worker.start()
+
+    class EventServiceHandler(BaseHandler):
+        def do_POST(self):
+            self._set_headers()
+            content_length = int(self.headers.getheader('content-length'),0)
+            body = loads(self.rfile.read(content_length))
+            LOG.info(body,json=True)
+            def shutdown(task):
+                task.worker.stop()
+                task.running = False
+            thread.start_new_thread(shutdown, (task,)) # spawn thread to avoid deadlock
+            assert_equal(subscription.get('Id'), body.get('MemberId'))
+    
+    @test(groups=['redfish.event_service_root'])
+    def test_event_service_root(self):
+        """ Testing GET /EventService """
+        redfish().event_service_root()
+        data = self.__get_data()
+        status = self.__client.last_response.status
+        assert_equal(200, status, message='unexpected status')
+    
+    @test(groups=['redfish.create_subscription'], \
+          depends_on_groups=['redfish.event_service_root'])
+    def test_create_event_subscription(self):
+        """ Testing POST /EventService/Subscription  """
+        global subscription 
+        payload = {
+            'Id': '12345',
+            'Name': 'Alert 1',
+            'Destination': 'http://localhost:{0}'.format(self.__httpd_port), 
+            'EventTypes': ['Alert'], 
+            'Context': 'Client Alerting', 
+            'Protocol': 'Redfish' 
+        }
+        redfish().create_subscription(payload)
+        subscription = self.__get_data()
+        assert_is_not_none(subscription)
+        LOG.info(subscription,json=True)
+        status = self.__client.last_response.status
+        assert_equal(201, status, message='unexpected status on create')
+        
+    @test(groups=['redfish.subscriptions_collection'], \
+          depends_on_groups=['redfish.create_subscription'])
+    def test_get_event_subscription(self):
+        """ Testing GET /EventService/Subscription/:id  """
+        redfish().get_event(subscription.get('Id'))
+        data = self.__get_data()
+        status = self.__client.last_response.status
+        assert_equal(200, status, message='unexpected status')
+        assert_equal(subscription.get('Id'), data.get('Id'), \
+            message='subscription id not found')
+        
+    @test(groups=['redfish.submit_test_event'], \
+          depends_on_groups=['redfish.create_subscription'])
+    def test_submit_test_event(self):
+        """ Testing POST /EventService/SubmitTestEvent  """
+        global task
+        server = Httpd(port=int(HTTPD_PORT), handler_class=self.EventServiceHandler)
+        task = WorkerThread(server,'httpd')
+        worker = WorkerTasks(tasks=[task], func=self.__httpd_start)
+        worker.run()
+        
+        # forward port for services running on a guest host
+        session = open_ssh_forward(self.__httpd_port) 
+        
+        redfish().test_event(body={})
+        worker.wait_for_completion(timeout_sec=60)
+        session.logout()
+        assert_false(task.timeout, message='timeout waiting for task {0}'.format(task.id))
+   
+    @test(groups=['redfish.subscriptions_collection'], \
+          depends_on_groups=['redfish.submit_test_event'])
+    def test_subscription_collection(self):
+        """ Testing GET /EventService/Subscription  """
+        redfish().get_events_collection()
+        data = self.__get_data()
+        status = self.__client.last_response.status
+        assert_equal(200, status, message='unexpected status on GET')
+        ids = []
+        for member in data.get('Members'):
+            ids.append(member.get('@odata.id') \
+                .split('/redfish/v1/EventService/Subscriptions/')[1])
+        assert_true(subscription.get('Id') in ids, message='subscription id not found')
+        
+    @test(groups=['redfish.delete_subscriptions'], \
+          depends_on_groups=['redfish.subscriptions_collection'])
+    def test_delete_subscriptions(self):
+        """ Testing DELETE /EventService/Subscription  """
+        redfish().get_events_collection()
+        data = self.__get_data()
+        for member in data.get('Members'):
+            id = member.get('@odata.id').split('/redfish/v1/EventService/Subscriptions/')[1]
+            redfish().delete_event(id)
+            status = self.__client.last_response.status
+            assert_equal(204, status, message='unexpected status on DELETE')
+        redfish().get_events_collection()
+        data = self.__get_data()
+        assert_equal(len(data.get('Members')), 0, message='unexpected subscription size, expected zero')

--- a/test/tests/api/tmp_fit_staging/redfish_1_0/managers_tests.py
+++ b/test/tests/api/tmp_fit_staging/redfish_1_0/managers_tests.py
@@ -1,0 +1,113 @@
+from config.redfish1_0_config import *
+from modules.logger import Log
+from on_http_redfish_1_0 import RedfishvApi as redfish
+from on_http_redfish_1_0 import rest
+from datetime import datetime
+from proboscis.asserts import assert_equal
+from proboscis.asserts import assert_false
+from proboscis.asserts import assert_raises
+from proboscis.asserts import assert_not_equal
+from proboscis.asserts import assert_true
+from proboscis.asserts import assert_is
+from proboscis.asserts import assert_is_not_none
+from proboscis.asserts import fail
+from proboscis import SkipTest
+from proboscis import test
+from json import loads,dumps
+import re, time
+
+LOG = Log(__name__)
+
+@test(groups=['redfish.managers.tests'], depends_on_groups=['redfish.systems.tests'])
+class ManagersTests(object):
+
+    def __init__(self):
+        self.__client = config.api_client
+        self.__managersList = None
+
+    def __get_data(self):
+        return loads(self.__client.last_response.data)
+
+    @test(groups=['redfish.list_managers'])
+    def test_list_managers(self):
+        """ Testing GET /Managers """
+        redfish().list_managers()
+        manager = self.__get_data()
+        LOG.debug(manager,json=True)
+        assert_not_equal(0, len(manager), message='managers list was empty!')
+        self.__managersList = manager.get('Members')
+        assert_is_not_none(self.__managersList)
+
+    @test(groups=['redfish.get_manager'], depends_on_groups=['redfish.list_managers'])
+    def test_get_manager(self):
+        """ Testing GET /Managers/{identifier} """
+        for member in self.__managersList:
+            dataId = member.get('@odata.id')
+            assert_is_not_none(dataId)
+            dataId = dataId.split('/redfish/v1/Managers/')[1]
+            redfish().get_manager(dataId)
+            manager = self.__get_data()
+            LOG.debug(manager,json=True)
+            id = manager.get('Id')
+            assert_equal(dataId, id, message='unexpected id {0}, expected {1}'.format(id,dataId))
+
+    @test(groups=['redfish.get_manager_invalid'], depends_on_groups=['redfish.list_managers'])
+    def test_get_manager_invalid(self):
+        """ Testing GET /Managers/{identifier} 404s properly """
+        for member in self.__managersList:
+            dataId = member.get('@odata.id')
+            assert_is_not_none(dataId)
+            dataId = dataId.split('/redfish/v1/Managers/')[1]
+            try:
+                redfish().get_manager(dataId + '1')
+                fail(message='did not raise exception')
+            except rest.ApiException as e:
+                assert_equal(404, e.status, message='unexpected response {0}, expected 404'.format(e.status))
+
+    @test(groups=['redfish.list_manager_ethernet_interfaces'], depends_on_groups=['redfish.list_managers'])
+    def test_list_manager_ethernet_interfaces(self):
+        """ Testing GET /Managers/{identifier}/EthernetInterfaces """
+        for member in self.__managersList:
+            dataId = member.get('@odata.id')
+            assert_is_not_none(dataId)
+            dataId = dataId.split('/redfish/v1/Managers/')[1]
+            redfish().list_manager_ethernet_interfaces(dataId)
+            interface = self.__get_data()
+            LOG.debug(interface,json=True)
+            count = interface.get('Members@odata.count')
+            assert_true(count >= 1, message='expected count to be >= 1')
+
+    @test(groups=['redfish.list_manager_ethernet_interfaces_invalid'], depends_on_groups=['redfish.list_managers'])
+    def test_list_manager_ethernet_interfaces_invalid(self):
+        """ Testing GET /Managers/{identifier}/EthernetInterfaces 404s properly """
+        for member in self.__managersList:
+            dataId = member.get('@odata.id')
+            assert_is_not_none(dataId)
+            dataId = dataId.split('/redfish/v1/Managers/')[1]
+            try:
+                redfish().list_manager_ethernet_interfaces(dataId + '1')
+                fail(message='did not raise exception')
+            except rest.ApiException as e:
+                assert_equal(404, e.status, message='unexpected response {0}, expected 404'.format(e.status))
+
+    @test(groups=['redfish.get_manager_ethernet_interface'], depends_on_groups=['redfish.list_manager_ethernet_interfaces'])
+    def test_get_manager_ethernet_interface(self):
+        """ Testing GET /Managers/{identifier}/EthernetInterfaces/{id} """
+        for member in self.__managersList:
+            dataId = member.get('@odata.id')
+            assert_is_not_none(dataId)
+            dataId = dataId.split('/redfish/v1/Managers/')[1]
+            redfish().list_manager_ethernet_interfaces(dataId)
+            managers = self.__get_data();
+            for manager in managers.get('Members'):
+                odata_id = manager.get('@odata.id')
+                req_id = odata_id.split('/redfish/v1/Managers/'+dataId+'/EthernetInterfaces/')[1]
+                redfish().get_manager_ethernet_interface(dataId, req_id)
+                interface = self.__get_data()
+                LOG.debug(interface,json=True)
+                id = interface.get('Id')
+                assert_equal(req_id, id, message='unexpected id {0}, expected {1}'.format(id,dataId))
+                ipv4 = interface.get('IPv4Addresses')
+                assert_is_not_none(ipv4)
+                assert_not_equal(0, len(ipv4), message='ipv4 list was empty!')
+

--- a/test/tests/api/tmp_fit_staging/redfish_1_0/registry_tests.py
+++ b/test/tests/api/tmp_fit_staging/redfish_1_0/registry_tests.py
@@ -1,0 +1,98 @@
+from config.redfish1_0_config import *
+from modules.logger import Log
+from on_http_redfish_1_0 import RedfishvApi as redfish
+from on_http_redfish_1_0 import rest
+from datetime import datetime
+from proboscis.asserts import assert_equal
+from proboscis.asserts import assert_false
+from proboscis.asserts import assert_raises
+from proboscis.asserts import assert_not_equal
+from proboscis.asserts import assert_true
+from proboscis.asserts import fail
+from proboscis import SkipTest
+from proboscis import test
+from json import loads,dumps
+
+LOG = Log(__name__)
+
+@test(groups=['redfish.registry.tests'], depends_on_groups=['obm.tests'])
+class RegistryTests(object):
+
+    def __init__(self):
+        self.__client = config.api_client
+        self.__registryList = None
+        self.__membersList = None
+        self.__locationUri = []
+
+    def __get_data(self):
+        return loads(self.__client.last_response.data)
+
+    @test(groups=['redfish.list_registry'])
+    def test_list_registry(self):
+        """ Testing GET /Registries """
+        redfish().list_registry()
+        registry = self.__get_data()
+        LOG.debug(registry,json=True)
+        assert_not_equal(0, len(registry), message='Registry list was empty!')
+        self.__registryList = registry
+
+    @test(groups=['redfish.get_registry_file'], depends_on_groups=['redfish.list_registry'])
+    def test_get_registry_file(self):
+        """ Testing GET /Registries/{identifier} """
+        self.__membersList = self.__registryList.get('Members')
+        assert_not_equal(None, self.__membersList)
+        for member in self.__membersList:
+            dataId = member.get('@odata.id')
+            assert_not_equal(None,dataId)
+            dataId = dataId.split('/redfish/v1/Registries/')[1]
+            redfish().get_registry_file(dataId)
+            registry_file = self.__get_data()
+            LOG.debug(registry_file,json=True)
+            id = registry_file.get('Id')
+            assert_equal(dataId, id, message='unexpected id {0}, expected {1}'.format(id,dataId))
+            assert_equal(type(registry_file.get('Location')), list, message='expected list not found')
+            location = registry_file.get('Location')[0]
+            assert_equal(type(location.get('Uri')), unicode, message='expected uri string not found')
+            self.__locationUri.append(location.get('Uri'))
+
+    @test(groups=['redfish.get_registry_file_invalid'], depends_on_groups=['redfish.list_registry'])
+    def test_get_registry_file_invalid(self):
+        """ Testing GET /Registries/{identifier} 404s properly """
+        self.__membersList = self.__registryList.get('Members')
+        assert_not_equal(None, self.__membersList)
+        for member in self.__membersList:
+            dataId = member.get('@odata.id')
+            assert_not_equal(None,dataId)
+            dataId = dataId.split('/redfish/v1/Registries/')[1]
+            try:
+                redfish().get_registry_file(dataId + '-invalid')
+                fail(message='did not raise exception')
+            except rest.ApiException as e:
+                assert_equal(404, e.status, message='unexpected response {0}, expected 404'.format(e.status))
+
+    @test(groups=['redfish.get_registry_file_contents'], depends_on_groups=['redfish.get_registry_file'])
+    def test_get_registry_file_contents(self):
+        """ Testing GET /Registries/en/{identifier} """
+        assert_not_equal([], self.__locationUri)
+        for member in self.__locationUri:
+            assert_not_equal(None,member)
+            dataId = member.split('/redfish/v1/Registries/en/')[1]
+            redfish().get_registry_file_contents(dataId)
+            registry_file_contents = self.__get_data()
+            LOG.debug(registry_file_contents,json=True)
+            id = registry_file_contents.get('Id')
+            assert_equal(dataId, id, message='unexpected id {0}, expected {1}'.format(id,dataId))
+
+    @test(groups=['redfish.get_registry_file_contents_invalid'], depends_on_groups=['redfish.get_registry_file'])
+    def test_get_registry_file_contents_invalid(self):
+        """ Testing GET /Registries/en/{identifier} 404s properly """
+        assert_not_equal([], self.__locationUri)
+        for member in self.__locationUri:
+            assert_not_equal(None,member)
+            dataId = member.split('/redfish/v1/Registries/en/')[1]
+            try:
+                redfish().get_registry_file_contents(dataId + '-invalid')
+                fail(message='did not raise exception')
+            except rest.ApiException as e:
+                assert_equal(404, e.status, message='unexpected response {0}, expected 404'.format(e.status))
+

--- a/test/tests/api/tmp_fit_staging/redfish_1_0/schema_tests.py
+++ b/test/tests/api/tmp_fit_staging/redfish_1_0/schema_tests.py
@@ -1,0 +1,97 @@
+from config.redfish1_0_config import *
+from modules.logger import Log
+from on_http_redfish_1_0 import RedfishvApi as redfish
+from on_http_redfish_1_0 import rest
+from datetime import datetime
+from proboscis.asserts import assert_equal
+from proboscis.asserts import assert_false
+from proboscis.asserts import assert_raises
+from proboscis.asserts import assert_not_equal
+from proboscis.asserts import assert_true
+from proboscis.asserts import fail
+from proboscis import SkipTest
+from proboscis import test
+from json import loads,dumps
+
+LOG = Log(__name__)
+
+@test(groups=['redfish.schema.tests'], depends_on_groups=['obm.tests'])
+class SchemaTests(object):
+
+    def __init__(self):
+        self.__client = config.api_client
+        self.__schemaList = None
+        self.__membersList = None
+        self.__locationUri = []
+
+    def __get_data(self):
+        return loads(self.__client.last_response.data)
+
+    @test(groups=['redfish.list_schemas'])
+    def test_list_schemas(self):
+        """ Testing GET /Schemas """
+        redfish().list_schemas()
+        schemas = self.__get_data()
+        LOG.debug(schemas,json=True)
+        assert_not_equal(0, len(schemas), message='Schema list was empty!')
+        self.__schemaList = schemas
+
+    @test(groups=['redfish.get_schema'], depends_on_groups=['redfish.list_schemas'])
+    def test_get_schema(self):
+        """ Testing GET /Schemas/{identifier} """
+        self.__membersList = self.__schemaList.get('Members')
+        assert_not_equal(None, self.__membersList)
+        for member in self.__membersList:
+            dataId = member.get('@odata.id')
+            assert_not_equal(None,dataId)
+            dataId = dataId.split('/redfish/v1/Schemas/')[1]
+            redfish().get_schema(dataId)
+            schema_ref = self.__get_data()
+            LOG.debug(schema_ref,json=True)
+            id = schema_ref.get('Id')
+            assert_equal(dataId, id, message='unexpected id {0}, expected {1}'.format(id,dataId))
+            assert_equal(type(schema_ref.get('Location')), list, message='expected list not found')
+            location = schema_ref.get('Location')[0]
+            assert_equal(type(location.get('Uri')), unicode, message='expected uri string not found')
+            self.__locationUri.append(location.get('Uri'))
+
+    @test(groups=['redfish.get_schema_invalid'], depends_on_groups=['redfish.list_schemas'])
+    def test_get_schema_invalid(self):
+        """ Testing GET /Schemas/{identifier} 404s properly """
+        self.__membersList = self.__schemaList.get('Members')
+        assert_not_equal(None, self.__membersList)
+        for member in self.__membersList:
+            dataId = member.get('@odata.id')
+            assert_not_equal(None,dataId)
+            dataId = dataId.split('/redfish/v1/Schemas/')[1]
+            try:
+                redfish().get_schema(dataId + '-invalid')
+                fail(message='did not raise exception')
+            except rest.ApiException as e:
+                assert_equal(404, e.status, message='unexpected response {0}, expected 404'.format(e.status))
+            break
+
+    @test(groups=['redfish.get_schema_content'], depends_on_groups=['redfish.get_schema'])
+    def test_get_schema_content(self):
+        """ Testing GET /SchemaStore/en/{identifier} """
+        assert_not_equal([], self.__locationUri)
+        for member in self.__locationUri:
+            assert_not_equal(None,member)
+            dataId = member.split('/redfish/v1/SchemaStore/en/')[1]
+            redfish().get_schema_content(dataId)
+            schema_file_contents = self.__get_data()
+
+    @test(groups=['redfish.get_schema_content_invalid'], depends_on_groups=['redfish.get_schema'])
+    def test_get_schema_content_invalid(self):
+        """ Testing GET /Schemas/en/{identifier} 404s properly """
+        assert_not_equal([], self.__locationUri)
+        for member in self.__locationUri:
+            assert_not_equal(None,member)
+            dataId = member.split('/redfish/v1/SchemaStore/en/')[1]
+            try:
+                redfish().get_schema_content(dataId + '-invalid')
+                fail(message='did not raise exception')
+            except rest.ApiException as e:
+                assert_equal(404, e.status, message='unexpected response {0}, expected 404'.format(e.status))
+            break
+

--- a/test/tests/api/tmp_fit_staging/redfish_1_0/session_service_tests.py
+++ b/test/tests/api/tmp_fit_staging/redfish_1_0/session_service_tests.py
@@ -1,0 +1,118 @@
+from config.redfish1_0_config import *
+from modules.logger import Log
+from modules.redfish_auth import Auth
+from on_http_redfish_1_0 import RedfishvApi as redfish
+from on_http_redfish_1_0 import rest
+from datetime import datetime
+from proboscis.asserts import assert_equal
+from proboscis.asserts import assert_false
+from proboscis.asserts import assert_raises
+from proboscis.asserts import assert_not_equal
+from proboscis.asserts import assert_true
+from proboscis.asserts import fail
+from proboscis import SkipTest
+from proboscis import test
+from json import loads,dumps
+from proboscis import before_class
+from proboscis import after_class
+
+
+LOG = Log(__name__)
+
+@test(groups=['redfish.session_service.tests'], depends_on_groups=['obm.tests'])
+class SessionServiceTests(object):
+
+    def __init__(self):
+        self.__client = config.api_client
+        self.__sessionList = None
+        self.__session = None
+
+    @before_class()
+    def setup(self):
+        """setup test environment"""
+        Auth.enable()
+
+    @after_class(always_run=True)
+    def teardown(self):
+        """ restore test environment """
+        Auth.disable()
+
+    def __get_data(self):
+        return loads(self.__client.last_response.data)
+
+    @test(groups=['redfish.get_session_service'])
+    def test_get_session_service(self):
+        """ Testing GET /SessionService """
+        redfish().get_session_service()
+        service = self.__get_data()
+        LOG.debug(service,json=True)
+        id = service.get('Id')
+        assert_equal('SessionService', id, message='unexpected id {0}, expected {1}'.format(id,'SessionService'))
+        sessions = service.get('Sessions')
+        assert_not_equal(None, sessions, message='Failed to get sessions')
+
+    @test(groups=['redfish.post_session'], depends_on_groups=['redfish.get_session_service'])
+    def test_post_session(self):
+        """ Testing POST /SessionService/Sessions """
+        body = {
+            'UserName': 'admin',
+            'Password': 'admin123'
+        }
+        redfish().post_session(payload=body)
+        sessions = self.__get_data()
+        self.__session = sessions.get('Id')
+        assert_not_equal(None, self.__session)
+
+    @test(groups=['redfish.get_sessions'], depends_on_groups=['redfish.post_session'])
+    def test_get_sessions(self):
+        """ Testing GET /SessionService/Sessions """
+        redfish().get_sessions()
+        sessions = self.__get_data()
+        self.__sessionList = sessions.get('Members')
+
+    @test(groups=['redfish.get_session_info'], depends_on_groups=['redfish.get_sessions'])
+    def test_get_session_info(self):
+        """ Testing GET /SessionService/Sessions/{identifier} """
+        assert_not_equal(None, self.__sessionList)
+        for member in self.__sessionList:
+            dataId = member.get('@odata.id')
+            assert_not_equal(None,dataId)
+            dataId = dataId.split('/redfish/v1/SessionService/Sessions/')[1]
+            redfish().get_session_info(dataId)
+            session_ref = self.__get_data()
+            LOG.debug(session_ref,json=True)
+            id = session_ref.get('Id')
+            assert_equal(dataId, id, message='unexpected id {0}, expected {1}'.format(id,dataId))
+
+    @test(groups=['redfish.get_session_info_invalid'], depends_on_groups=['redfish.get_session_info'])
+    def test_get_session_info_invalid(self):
+        """ Testing GET /SessionService/Sessions/{identifier} 404s properly"""
+        assert_not_equal(None, self.__sessionList)
+        for member in self.__sessionList:
+            dataId = member.get('@odata.id')
+            assert_not_equal(None,dataId)
+            dataId = dataId.split('/redfish/v1/SessionService/Sessions/')[1]
+            try:
+                redfish().get_session_info(dataId + 'invalid')
+                fail(message='did not raise exception')
+            except rest.ApiException as e:
+                assert_equal(404, e.status, message='unexpected response {0}, expected 404'.format(e.status))
+            break
+
+    @test(groups=['redfish.do_logout_session'], depends_on_groups=['redfish.get_session_info_invalid'])
+    def test_do_logout_session(self):
+        """ Testing DELETE /SessionService/Sessions/{identifier} """
+        redfish().do_logout_session(self.__session)
+        try:
+            redfish().get_session_info(self.__session)
+            fail(message='did not raise exception')
+        except rest.ApiException as e:
+            assert_equal(404, e.status, message='unexpected response {0}, expected 404'.format(e.status))
+
+        self.test_get_sessions()
+        for member in self.__sessionList:
+            dataId = member.get('@odata.id')
+            dataId = dataId.split('/redfish/v1/SessionService/Sessions/')[1]
+            assert_not_equal(self.__session,dataId)
+
+

--- a/test/tests/api/tmp_fit_staging/redfish_1_0/systems_tests.py
+++ b/test/tests/api/tmp_fit_staging/redfish_1_0/systems_tests.py
@@ -1,0 +1,305 @@
+from config.redfish1_0_config import *
+from modules.logger import Log
+from on_http_redfish_1_0 import RedfishvApi as redfish
+from on_http_redfish_1_0 import rest
+from datetime import datetime
+from proboscis.asserts import assert_equal
+from proboscis.asserts import assert_false
+from proboscis.asserts import assert_raises
+from proboscis.asserts import assert_not_equal
+from proboscis.asserts import assert_true
+from proboscis.asserts import assert_is
+from proboscis.asserts import assert_is_not_none
+from proboscis.asserts import fail
+from proboscis import SkipTest
+from proboscis import test
+from json import loads,dumps
+import re, time
+
+LOG = Log(__name__)
+
+@test(groups=['redfish.systems.tests'], depends_on_groups=['redfish.chassis.tests'])
+class SystemsTests(object):
+
+    def __init__(self):
+        self.__client = config.api_client
+        self.__systemsList = None
+        self.__membersList = None
+        self.__systemProcessorsList = None
+        self.__simpleStorageList = None
+        self.__logServicesList = None
+        self.__resetActionTypes = None
+        self.__bootImageTypes = None
+
+    def __get_data(self):
+        return loads(self.__client.last_response.data)
+
+    @test(groups=['redfish.list_systems'])
+    def test_list_systems(self):
+        """ Testing GET /Systems """
+        redfish().list_systems()
+        self.__systemsList = self.__get_data()
+        LOG.debug(self.__systemsList,json=True)
+        assert_not_equal(0, len(self.__systemsList), message='systems list was empty!')
+        
+    @test(groups=['redfish.get_systems'],\
+            depends_on_groups=['redfish.list_systems'])
+    def test_get_systems(self):
+        """ Testing GET /Systems/{identifier} """
+        self.__membersList = self.__systemsList.get('Members')
+        assert_is_not_none(self.__membersList)
+        for member in self.__membersList:
+            dataId = member.get('@odata.id')
+            assert_is_not_none(dataId)
+            dataId = dataId.split('/redfish/v1/Systems/')[1]
+            redfish().get_system(dataId)
+            systems = self.__get_data()
+            LOG.debug(systems,json=True)
+            id = systems.get('Id')
+            assert_equal(dataId, id, message='unexpected id {0}, expected {1}'.format(id,dataId))
+
+    @test(groups=['redfish.list_system_processors'],\
+            depends_on_groups=['redfish.get_systems'])
+    def test_list_system_processors(self):
+        """ Testing GET /Systems/{identifier}/Processors """
+        self.__membersList = self.__systemsList.get('Members')
+        assert_is_not_none(self.__membersList)
+        for member in self.__membersList:
+            dataId = member.get('@odata.id')
+            assert_is_not_none(dataId)
+            dataId = dataId.split('/redfish/v1/Systems/')[1]
+            redfish().list_system_processors(dataId)
+            self.__systemProcessorsList = self.__get_data()
+            LOG.debug(self.__systemProcessorsList,json=True)
+            membersList = self.__systemProcessorsList.get('Members')
+            assert_is_not_none(membersList, message='missing processor members field!')
+            count = self.__systemProcessorsList.get('Members@odata.count')
+            assert_is_not_none(count, message='missing processor member count field!')
+            assert_equal(count,len(membersList))
+
+    @test(groups=['redfish.get_system_processor'],\
+            depends_on_groups=['redfish.list_system_processors'])
+    def test_get_system_processor(self):
+        """ Testing GET /Systems/{identifier}/Processors/{socket} """
+        assert_is_not_none(self.__membersList)
+        membersList = self.__systemProcessorsList.get('Members')
+        assert_is_not_none(membersList, message='missing processor members field!')
+        socket = 0
+        for member in membersList:
+            dataId = member.get('@odata.id')
+            assert_is_not_none(dataId)
+            id = re.compile(r'/Processors/[0-9]+').split(dataId)[0]\
+                    .split('/redfish/v1/Systems/')[1]
+            redfish().get_system_processor(id, socket)
+            processor = self.__get_data()
+            LOG.debug(processor,json=True)
+            procId = processor.get('@odata.id')
+            assert_equal(dataId,procId)
+            socket = socket + 1
+
+    @test(groups=['redfish.list_system_simplestorage'],\
+            depends_on_groups=['redfish.get_systems'])
+    def test_list_simple_storage(self):
+        """ Testing GET /Systems/{identifier}/SimpleStorage """
+        self.__membersList = self.__systemsList.get('Members')
+        assert_is_not_none(self.__membersList)
+        for member in self.__membersList:
+            dataId = member.get('@odata.id')
+            assert_is_not_none(dataId)
+            dataId = dataId.split('/redfish/v1/Systems/')[1]
+            redfish().list_simple_storage(dataId)
+            self.__simpleStorageList = self.__get_data()
+            LOG.debug(self.__simpleStorageList,json=True)
+            membersList = self.__simpleStorageList.get('Members')
+            assert_is_not_none(membersList, message='missing simplestorage members field!')
+            count = self.__simpleStorageList.get('Members@odata.count')
+            assert_is_not_none(count, message='missing simple storage member count field!')
+            assert_equal(count,len(membersList))
+
+    @test(groups=['redfish.get_system_simplestorage'],\
+            depends_on_groups=['redfish.list_system_simplestorage'])
+    def test_get_simple_storage(self):
+        """ Testing GET /Systems/{identifier}/SimpleStorage/{index} """
+        assert_is_not_none(self.__membersList)
+        membersList = self.__simpleStorageList.get('Members')
+        assert_is_not_none(membersList, message='missing simple storage members field!')
+        for member in membersList:
+            dataId = member.get('@odata.id')
+            assert_is_not_none(dataId)
+            index = dataId.split('/SimpleStorage/')[1]
+            id = re.compile(r'/SimpleStorage/[0-9]+').split(dataId)[0]\
+                    .split('/redfish/v1/Systems/')[1]
+            redfish().get_simple_storage(id, index)
+            storage = self.__get_data()
+            LOG.debug(storage,json=True)
+            storageId = storage.get('@odata.id')
+            assert_equal(dataId,storageId)
+
+    @test(groups=['redfish.list_system_log_services'],\
+            depends_on_groups=['redfish.get_systems'])
+    def test_list_log_servives(self):
+        """ Testing GET /Systems/{identifier}/LogServices """
+        self.__membersList = self.__systemsList.get('Members')
+        assert_is_not_none(self.__membersList)
+        for member in self.__membersList:
+            dataId = member.get('@odata.id')
+            assert_is_not_none(dataId)
+            dataId = dataId.split('/redfish/v1/Systems/')[1]
+            redfish().list_log_service(dataId)
+            self.__logServicesList = self.__get_data()
+            LOG.debug(self.__logServicesList,json=True)
+            membersList = self.__logServicesList.get('Members')
+            assert_is_not_none(membersList, message='missing logservices members field!')
+            count = self.__logServicesList.get('Members@odata.count')
+            assert_is_not_none(count, message='missing logservices member count field!')
+            assert_equal(count,len(membersList))
+
+    @test(groups=['redfish.get_sel_log_service'],\
+            depends_on_groups=['redfish.list_system_log_services'])
+    def test_get_sel_log_services(self):
+        """ Testing GET /Systems/{identifier}/LogServices/sel """
+        assert_is_not_none(self.__membersList)
+        membersList = self.__logServicesList.get('Members')
+        assert_is_not_none(membersList, message='missing log services members field!')
+        for member in membersList:
+            dataId = member.get('@odata.id')
+            assert_is_not_none(dataId)
+            id = re.compile(r'/LogServices').split(dataId)[0]\
+                    .split('/redfish/v1/Systems/')[1]
+            redfish().get_sel_log_service(id)
+            sel = self.__get_data()
+            LOG.debug(sel,json=True)
+            selId = sel.get('@odata.id')
+            assert_equal(dataId,selId)
+
+    @test(groups=['redfish.get_sel_log_service_entries'],\
+            depends_on_groups=['redfish.list_system_log_services'])
+    def test_get_sel_log_services_entries(self):
+        """ Testing GET /Systems/{identifier}/LogServices/sel/Entries """
+        assert_is_not_none( self.__membersList)
+        membersList = self.__logServicesList.get('Members')
+        assert_is_not_none(membersList, message='missing log services members field!')
+        for member in membersList:
+            dataId = member.get('@odata.id')
+            assert_is_not_none(dataId)
+            id = re.compile(r'/LogServices').split(dataId)[0]\
+                    .split('/redfish/v1/Systems/')[1]
+            redfish().list_sel_log_service_entries(id)
+            entries = self.__get_data()
+            assert_not_equal({},entries)
+            # Should validate the SEL entries here
+            # Leaving as TODO until a 'add_sel' task is available
+            LOG.debug(entries,json=True)
+
+
+    @test(groups=['redfish.get_sel_log_service_entries_entryid'],\
+            depends_on_groups=['redfish.get_sel_log_service_entries'])
+    def test_get_sel_log_services_entries_entryid(self):
+        """ Testing GET /Systems/{identifier}/LogServices/sel/Entries/{entryId} """
+        # TODO Add more validation when a 'add_sel' task is available
+        assert_is_not_none( self.__membersList)
+        membersList = self.__logServicesList.get('Members')
+        assert_is_not_none(membersList, message='missing log services members field!')
+
+    @test(groups=['redfish.get_systems_actions_reset'],\
+            depends_on_groups=['redfish.get_systems'])
+    def test_get_systems_actions_reset(self):
+        """ Testing GET /Systems/{identifier}/Actions/ComputerSystem.Reset """
+        self.__membersList = self.__systemsList.get('Members')
+        assert_is_not_none( self.__membersList)
+        for member in self.__membersList:
+            dataId = member.get('@odata.id')
+            assert_is_not_none(dataId)
+            dataId = dataId.split('/redfish/v1/Systems/')[1]
+            redfish().list_reset_types(dataId)
+            reset_actions = self.__get_data()
+            LOG.debug(reset_actions,json=True)
+            self.__resetActionTypes = reset_actions.get('reset_type@Redfish.AllowableValues')
+            assert_equal(dumps(self.__resetActionTypes), dumps(['On',\
+                                                                'ForceOff',\
+                                                                'GracefulRestart',\
+                                                                'ForceRestart',\
+                                                                'ForceOn',\
+                                                                'PushPowerButton']))
+
+    # @test(groups=['redfish.post_systems_actions_reset'],\
+    #        depends_on_groups=['redfish.get_systems_actions_reset'])
+    def test_post_systems_actions_reset(self):
+        """ Testing POST /Systems/{identifier}/Actions/ComputerSystem.Reset """
+        self.__membersList = self.__systemsList.get('Members')
+        assert_is_not_none(self.__membersList)
+        assert_is_not_none(self.__resetActionTypes)
+        for member in self.__membersList:
+            actionsCompleted = 0
+            dataId = member.get('@odata.id')
+            assert_not_equal(0,len(dataId))
+            dataId = dataId.split('/redfish/v1/Systems/')[1]
+            for action in self.__resetActionTypes:
+                if action == 'PushPowerButton': # skip manual test
+                    LOG.warning('skipping \"PushPowerButton\" reset action')
+                    continue
+                LOG.info('testing reset action {0}'.format(action))
+                try:
+                    redfish().do_reset(dataId,{'reset_type': action})
+                except rest.ApiException as err:
+                    message = loads(err.body)['message']
+                    if message == 'value not found in map':
+                        LOG.warning('{0} for \"{1}\", skipping..'.format(message,action))
+                        continue
+                    else:
+                        raise(err)
+                task = self.__get_data()
+                taskId = task.get('@odata.id')
+                assert_is_not_none(taskId)
+                taskId = taskId.split('/redfish/v1/TaskService/Tasks/')[1]
+                timeout = 20
+                while timeout > 0:
+                    redfish().get_task(taskId)
+                    taskInfo = self.__get_data()
+                    taskState = taskInfo.get('TaskState')
+                    taskStatus = taskInfo.get('TaskStatus')
+                    assert_is_not_none(taskState)
+                    assert_is_not_none(taskStatus)
+                    if taskState == "Completed" and \
+                       taskStatus == "OK":
+                        actionsCompleted += 1
+                        break
+                    LOG.warning('waiting for reset action {0} (state={1},status={2})' \
+                            .format(action, taskState, taskStatus))
+                    timeout -= 1
+                    time.sleep(1)
+                if timeout == 0:
+                    fail('timed out waiting for reset action {0}'.format(action))
+            if actionsCompleted == 0:
+                fail('no reset actions were completed for id {0}'.format(dataId))
+
+    @test(groups=['redfish.get_systems_actions_bootimage'],\
+            depends_on_groups=['redfish.get_systems'])
+    def test_get_systems_actions_bootimage(self):
+        """ Testing GET /Systems/{identifier}/Actions/RackHD.BootImage """
+        self.__membersList = self.__systemsList.get('Members')
+        assert_is_not_none(self.__membersList)
+        for member in self.__membersList:
+            dataId = member.get('@odata.id')
+            assert_is_not_none(dataId)
+            dataId = dataId.split('/redfish/v1/Systems/')[1]
+            redfish().list_boot_image(dataId)
+            bootImages = self.__get_data()
+            LOG.debug(bootImages,json=True)
+            self.__bootImageTypes = bootImages.get('osNames@Redfish.AllowableValues')
+            assert_is_not_none(self.__bootImageTypes)
+            assert_equal(dumps(self.__bootImageTypes), dumps(['CentOS',\
+                                                              'CentOS+KVM',\
+                                                              'ESXi',\
+                                                              'RHEL',\
+                                                              'RHEL+KVM']))
+
+    @test(groups=['redfish.post_systems_actions_bootimage'],\
+            depends_on_groups=['redfish.get_systems_actions_bootimage'])
+    def test_post_systems_actions_bootimage(self):
+        """ Testing POST /Systems/{identifier}/Actions/RackHD.BootImage """
+        # TODO run some OS installer workflows
+        self.__membersList = self.__systemsList.get('Members')
+        assert_is_not_none(self.__membersList)
+        assert_is_not_none(self.__bootImageTypes)
+

--- a/test/tests/api/tmp_fit_staging/redfish_1_0/task_service_tests.py
+++ b/test/tests/api/tmp_fit_staging/redfish_1_0/task_service_tests.py
@@ -1,0 +1,94 @@
+from config.redfish1_0_config import *
+from modules.logger import Log
+from on_http_redfish_1_0 import RedfishvApi as redfish
+from datetime import datetime
+from proboscis.asserts import assert_equal
+from proboscis.asserts import assert_false
+from proboscis.asserts import assert_raises
+from proboscis.asserts import assert_not_equal
+from proboscis.asserts import assert_true
+from proboscis.asserts import assert_is_not_none
+from proboscis.asserts import fail
+from proboscis import SkipTest
+from proboscis import test
+from json import loads,dumps
+
+LOG = Log(__name__)
+
+@test(groups=['redfish.task_service.tests'], \
+      depends_on_groups=['redfish.systems.tests'])
+class TaskServiceTests(object):
+
+    def __init__(self):
+        self.__client = config.api_client
+        self.__oemServiceList = None
+        self.__taskServiceList = None
+        self.__taskList = None
+
+    def __get_data(self):
+        return loads(self.__client.last_response.data)
+
+    @test(groups=['redfish.get_task_service_root'])
+    def test_get_task_service_root(self):
+        """ Testing GET /TaskService """
+        redfish().task_service_root()
+        taskService = self.__get_data()
+        LOG.debug(taskService,json=True)
+        self.__oemServiceList = taskService.get('Oem')
+        assert_is_not_none(self.__oemServiceList)
+        oemMembers = self.__oemServiceList['RackHD'] \
+                                          ['SystemTaskCollection'].get('Members')
+        assert_is_not_none(oemMembers)
+        assert_not_equal(0, len(oemMembers), message='OEM members list was empty!')
+        self.__taskServiceList = taskService.get('Tasks')
+        assert_is_not_none(self.__taskServiceList)
+        taskMembers = self.__taskServiceList.get('Members')
+        assert_is_not_none(taskMembers)
+        assert_not_equal(0, len(taskMembers), message='Task service members list was empty!')
+
+    @test(groups=['redfish.get_list_tasks'], \
+          depends_on_groups=['redfish.get_task_service_root'])
+    def test_get_list_tasks(self):
+        """ Testing GET /TaskService/Tasks """
+        redfish().list_tasks()
+        self.__taskList = self.__get_data()
+        LOG.debug(self.__taskList,json=True)
+        members = self.__taskList.get('Members')
+        assert_is_not_none(members)
+        assert_not_equal(0, len(members), message='Task members list was empty!')
+
+    @test(groups=['redfish.get_task'], \
+          depends_on_groups=['redfish.get_list_tasks'])
+    def test_get_task(self):
+        """ Testing GET /TaskService/Tasks/{identifier} """
+        assert_is_not_none(self.__taskList)
+        members = self.__taskList.get('Members')
+        for member in members:
+            dataId = member.get('@odata.id')
+            assert_is_not_none(dataId)
+            dataId = dataId.split('/redfish/v1/TaskService/Tasks/')[1]
+            redfish().get_task(dataId)
+            task = self.__get_data()
+            LOG.debug(task,json=True)
+            taskId = task.get('@odata.id')
+            taskId = taskId.split('/redfish/v1/TaskService/Tasks/')[1]
+            assert_equal(dataId,taskId)
+
+    @test(groups=['redfish.get_system_task'], \
+          depends_on_groups=['redfish.get_list_tasks'])
+    def test_get_system_task(self):
+        """ Testing GET /TaskService/Oem/Tasks/{identifier} """
+        assert_is_not_none(self.__oemServiceList)
+        oemMembers = self.__oemServiceList['RackHD'] \
+                                          ['SystemTaskCollection'].get('Members')
+        for member in oemMembers:
+            dataId = member.get('@odata.id')
+            assert_is_not_none(dataId)
+            dataId = dataId.split('/redfish/v1/TaskService/Oem/Tasks/')[1]
+            redfish().get_system_tasks(dataId)
+            task = self.__get_data()
+            LOG.debug(task,json=True)
+            taskId = task.get('@odata.id')
+            taskId = taskId.split('/redfish/v1/TaskService/Oem/Tasks/')[1]
+            assert_equal(dataId,taskId)
+


### PR DESCRIPTION
This PR is for ttaging the CIT redfish_1_0 test scripts into a temp directory for follow on PRs.
This will allow for doing diffs between original and converted scripts, without losing the master.
The scripts in this PR are a copy of the scripts in /test/tests/api/redfish_1_0 only, no updates,
They won't run as part of the CIT or FIT smoke tests in this form.

Plan is:
1. copy the original scripts into this staging area  (this PR)
2. mv the staged script and apply the converted script on top do show the diffs only for review
3. allow the converted script to run in FIT smoke suite.

For this PR. please ignore the hound errors.  This PR is copying existing scripts into a staging directory, and the hound errors will be fixed when we apply the NEW converted scripts.