### PR TITLE
RAC-4588 amqp stream monitor groundwork PR

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,6 +1,7 @@
 amqp==1.4.8
 ansible==1.8.4
 anyjson==0.3.3
+docker-py==1.10.6
 flake8==3.2.1
 gevent==1.1.2
 greenlet==0.4.10

--- a/test/stream-monitor/flogging/logger_sets.py
+++ b/test/stream-monitor/flogging/logger_sets.py
@@ -22,7 +22,7 @@ class _LoggerSet(object):
         if hasattr(self.trl, key):
             return getattr(self.trl, key)
 
-        m = "'{0}' object has no attribute '{1}'".format(self.__name__, key)
+        m = "'{0}' object has no attribute '{1}'".format(self.__class__, key)
         raise AttributeError(m)
 
 

--- a/test/stream-monitor/requirements.txt
+++ b/test/stream-monitor/requirements.txt
@@ -1,3 +1,5 @@
 gevent==1.1.2
 greenlet==0.4.10
 nose==1.3.7
+docker-py==1.10.6
+kombu==4.0.2

--- a/test/stream-monitor/sm_plugin/__init__.py
+++ b/test/stream-monitor/sm_plugin/__init__.py
@@ -3,4 +3,14 @@ Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 """
 from stream_monitor import StreamMonitorPlugin, smp_get_stream_monitor, smp_get_stream_monitor_plugin
 
-__all__ = [StreamMonitorPlugin, smp_get_stream_monitor_plugin, smp_get_stream_monitor]
+
+def AMQPStreamMonitor():
+    """
+    This makes the plugin-based-singleton look more like a normal
+    import.
+    """
+    return smp_get_stream_monitor('amqp')
+
+
+__all__ = [StreamMonitorPlugin, smp_get_stream_monitor_plugin, smp_get_stream_monitor,
+           AMQPStreamMonitor]

--- a/test/stream-monitor/stream_sources/__init__.py
+++ b/test/stream-monitor/stream_sources/__init__.py
@@ -3,5 +3,6 @@ Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 """
 from log_type import LoggingMarker
 from self_test_source import SelfTestStreamMonitor
+from amqp_source import AMQPStreamMonitor
 
-__all__ = [LoggingMarker, SelfTestStreamMonitor]
+__all__ = [LoggingMarker, SelfTestStreamMonitor, AMQPStreamMonitor]

--- a/test/stream-monitor/stream_sources/amqp_od/__init__.py
+++ b/test/stream-monitor/stream_sources/amqp_od/__init__.py
@@ -1,0 +1,6 @@
+"""
+Copyright (c) 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+"""
+from rackhd_amqp_od import RackHDAMQPOnDemand
+
+__all__ = [RackHDAMQPOnDemand]

--- a/test/stream-monitor/stream_sources/amqp_od/amqp_on_demand.py
+++ b/test/stream-monitor/stream_sources/amqp_od/amqp_on_demand.py
@@ -1,0 +1,120 @@
+import os
+import os.path
+import re
+from docker import Client
+
+
+class _VCheckedClient(Client):
+    _REQUIRED_DOCKER_VERSION='1.12'
+
+    def __init__(self, *args, **kwargs):
+        super(_VCheckedClient, self).__init__(*args, **kwargs)
+        client_vinfo = self.version()
+        assert '1.12' in client_vinfo['Version'], \
+            'Need a 1.12ish docker version, found {0}'.format(client_vinfo['Version'])
+
+
+class AMQPOnDemand(object):
+    _RABBITMQ_REPO_NAME = 'rabbitmq'
+    _RABBITMQ_TAG = 'management'
+    _RABBITMQ_IMAGE_NAME = '{0}:{1}'.format(_RABBITMQ_REPO_NAME, _RABBITMQ_TAG)
+
+    def __init__(self):
+        self.__main_client = _VCheckedClient(timeout=600)
+
+        # make a name that is unique by directory.
+        base_name = "rabbitmq-for-{0}".format(os.getcwd())
+        # make it docker-name safe (todo: this isn't complete yet)
+        safe_name = re.sub(r'''\s|/''', '-', base_name)
+
+        existing = self.__assure_running(safe_name)
+        assert existing is not None, \
+            'failed to find or create test rabbitmq server'
+
+        self.__rabbit = existing
+
+    def __assure_running(self, safe_name):
+        running = False
+        while not running:
+            existing = self.__find_by_name(safe_name)
+            if existing is None:
+                self.__start_rabbitmq(safe_name)
+            else:
+                state = existing["State"]
+                if state == 'running':
+                    running = True
+                elif state == 'exited':
+                    response = self.__main_client.start(container=existing.get('Id'))
+                    # todo: log
+                    print response
+                else:
+                    raise Exception("state = {0}".format(state))
+        return existing
+
+    def __find_by_name(self, safe_name):
+        containers = self.__main_client.containers(
+            all=True, filters={'name': safe_name})
+        if len(containers) == 0:
+            return None
+        assert len(containers) == 1, \
+            'impossible-result: docker names are unique, but found multiple for {0} ({1}}'.format(
+                safe_name, containers)
+        # todo: log
+        # print "containters"* 30
+        # import pprint
+        # pprint.pprint(containers[0]['Ports'])
+        return containers[0]
+
+    def __start_rabbitmq(self, safe_name):
+        # Make sure we have the image...
+        pull_output = self.__main_client.pull(
+            self._RABBITMQ_REPO_NAME, tag=self._RABBITMQ_TAG, stream=True)
+
+        # todo: log
+        for line in pull_output:
+            pass
+
+        # todo: hashify or randomize port ids so more than one of these can
+        #  run at once.
+        host_config = self.__main_client.create_host_config(
+            port_bindings={
+                4369: ('127.0.0.1',),
+                5671: ('127.0.0.1',),
+                5672: ('127.0.0.1',),
+                15671: ('127.0.0.1',),
+                15672: ('127.0.0.1',),
+                25672: ('127.0.0.1',)
+            })
+        dockproc = self.__main_client.create_container(
+            image=self._RABBITMQ_IMAGE_NAME, name=safe_name, tty=True,
+            host_config=host_config)
+
+        # todo: see if we need 'command="--insecure-registry=mubmle' as param to above.
+
+        response = self.__main_client.start(container=dockproc.get('Id'))
+        # todo: log
+        # print response
+        return dockproc
+
+    @property
+    def host(self):
+        return '127.0.0.1'
+
+    @property
+    def ssl_port(self):
+        return self.__find_port_for(5672)
+
+    @property
+    def port(self):
+        return self.__find_port_for(5671)
+
+    def __find_port_for(self, base_port):
+        for port in self.__rabbit['Ports']:
+            # It MUST have a private port (what is bound inside the proc)
+            # TODO: fix private-only actually MEANS private only!!!
+            if port['PrivatePort'] == base_port:
+                # It MAY have a public one, if it is mapped. Otherwise it
+                # will be bound to the same as the private one.
+                return port.get('PublicPort', base_port)
+
+        return None

--- a/test/stream-monitor/stream_sources/amqp_od/amqp_on_demand.py
+++ b/test/stream-monitor/stream_sources/amqp_od/amqp_on_demand.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import os.path
 import re
@@ -5,7 +6,7 @@ from docker import Client
 
 
 class _VCheckedClient(Client):
-    _REQUIRED_DOCKER_VERSION='1.12'
+    _REQUIRED_DOCKER_VERSION = '1.12'
 
     def __init__(self, *args, **kwargs):
         super(_VCheckedClient, self).__init__(*args, **kwargs)
@@ -46,7 +47,7 @@ class AMQPOnDemand(object):
                 elif state == 'exited':
                     response = self.__main_client.start(container=existing.get('Id'))
                     # todo: log
-                    print response
+                    print(response)
                 else:
                     raise Exception("state = {0}".format(state))
         return existing
@@ -91,7 +92,8 @@ class AMQPOnDemand(object):
 
         # todo: see if we need 'command="--insecure-registry=mubmle' as param to above.
 
-        response = self.__main_client.start(container=dockproc.get('Id'))
+        # response = self.__main_client.start(container=dockproc.get('Id'))
+        self.__main_client.start(container=dockproc.get('Id'))
         # todo: log
         # print response
         return dockproc

--- a/test/stream-monitor/stream_sources/amqp_od/rackhd_amqp_od.py
+++ b/test/stream-monitor/stream_sources/amqp_od/rackhd_amqp_od.py
@@ -1,0 +1,39 @@
+from amqp_on_demand import AMQPOnDemand
+from kombu import Exchange, Connection, Queue
+
+
+class RackHDAMQPOnDemand(AMQPOnDemand):
+    def __init__(self):
+        super(RackHDAMQPOnDemand, self).__init__()
+
+        self.__setup_rackhd_style_amqp()
+
+    def __setup_rackhd_style_amqp(self):
+        """
+        Need to make exchanges and named queus to make this
+        look like a RackHD instance amqp.
+        """
+        con = Connection(hostname=self.host, port=self.ssl_port, ssl=False)
+        on_task = self.__assure_exchange(con, 'on.task', 'topic')
+        self.__assure_named_queue(con, on_task, 'ipmi.command.sel.result')
+        self.__assure_named_queue(con, on_task, 'ipmi.command.sdr.result')
+        self.__assure_named_queue(con, on_task, 'ipmi.command.chassis.result')
+
+        on_events = self.__assure_exchange(con, 'on.events', 'topic')
+        self.__assure_named_queue(con, on_events, 'graph.finished')
+        self.__assure_named_queue(con, on_events, 'polleralert.sel.updated', '#')
+
+        self.__assure_exchange(con, 'on.heartbeat', 'topic')
+
+    def __assure_exchange(self, connection, exchange_name, exchange_type):
+        exchange = Exchange(exchange_name, type=exchange_type)
+        bound_exchange = exchange(connection)
+        bound_exchange.declare()
+
+    def __assure_named_queue(self, connection, exchange, queue_name, routing_key_extension='*'):
+        routing_key = '{}.{}'.format(queue_name, routing_key_extension)
+        queue = Queue(queue_name, exchange, routing_key, connection)
+        queue.declare()
+
+    def get_url(self):
+        return 'amqp://{}:{}'.format(self.host, self.ssl_port)

--- a/test/stream-monitor/stream_sources/amqp_source.py
+++ b/test/stream-monitor/stream_sources/amqp_source.py
@@ -1,0 +1,206 @@
+"""
+Copyright (c) 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+A set of super-simple matchers to use to self-test the matching framework.
+"""
+import sys
+import time
+import optparse
+import uuid
+import gevent
+import gevent.queue
+from .monitor_abc import StreamMonitorBaseClass
+from .stream_matchers_base import StreamMatchBase
+from .amqp_od import RackHDAMQPOnDemand
+from kombu import Connection, Producer, Queue, Exchange, Consumer
+
+
+class _AMQPServerWrapper(object):
+    def __init__(self, amqp_url):
+        self.__connection = Connection(amqp_url)
+        self.__connection.connect()
+        self.__monitors = {}
+        self.__running = True
+        self.__consumer = Consumer(self.__connection, on_message=self.__on_message)
+        self.__consumer_gl = gevent.spawn(self.__consumer_greenlet_main)
+
+    def __consumer_greenlet_main(self):
+        gevent.sleep(0)
+        while self.__running:
+            self.__consumer.consume()
+            try:
+                self.__connection.drain_events(timeout=0.1)
+            except Exception as ex:
+                # print("was woken because {}".format(ex))
+                pass
+            gevent.sleep(0)
+            # print("---loop")
+
+    def __on_message(self, msg):
+        ct = msg.delivery_info['consumer_tag']
+        assert ct in self.__monitors, \
+            "Message from consumer '{}', but we are not monitoring that (list={})".format(
+                msg.delivery_info['consumer_tag'], self.__monitors.keys())
+        mon = self.__monitors[ct]
+        mon['event_cb'](msg, msg.body)
+
+    @property
+    def connected(self):
+        return self.__connection.connected
+
+    def create_add_monitor(self, exchange, routing_key, event_cb, queue_name=None):
+        mname = "ex={} rk={} qn={}".format(exchange, routing_key, queue_name)
+        if mname in self.__monitors:
+            mon = self.__monitors[mname]
+            mon["event_cb"] = event_cb
+        else:
+            if queue_name is None:
+                queue_name = ''
+                exclusive = True
+            else:
+                exclusive = False
+            ex = Exchange(exchange, 'topic')
+            queue = Queue(exchange=ex, routing_key=routing_key, exclusive=exclusive)
+            bound_queue = queue.bind(self.__connection)
+            self.__consumer.add_queue(bound_queue)
+            bound_queue.consume(mname, self.__on_message)
+            mon = {
+                "event_cb": event_cb,
+                "exchange": ex
+                }
+            self.__monitors[mname] = mon
+        return mon['exchange']
+
+    def inject(self, exchange, routing_key, payload):
+        prod = Producer(self.__connection, exchange=exchange, routing_key=routing_key)
+        prod.publish(payload)
+
+    def test_helper_sync_send_msg(self, exchange, ex_rk, send_rk, payload):
+        ex = Exchange(exchange, 'topic')
+        queue = Queue(exchange=ex, routing_key=ex_rk + '.*', exclusive=True, channel=self.__connection)
+        queue.declare()
+        prod = Producer(self.__connection, exchange=ex, routing_key=send_rk)
+        prod.publish(payload)
+        return queue
+
+    def test_helper_sync_recv_msg(self, queue):
+        for tick in range(10):
+            msg = queue.get()
+            if msg is not None:
+                break
+            time.sleep(1)
+        return msg
+
+
+class _AMQPMatcher(StreamMatchBase):
+    """
+    Implementation of a StreamMatchBase matcher.
+    """
+    def __init__(self, match_tbd, description, min=1, max=1):
+        self.__match_tbd = match_tbd
+        super(_AMQPMatcher, self).__init__(description, min=min, max=max)
+
+    def _match(self, other_event):
+        return bool(other_event)
+
+    def dump(self, ofile=sys.stdout, indent=0):
+        super(_AMQPMatcher, self).dump(ofile=ofile, indent=indent)
+        ins = ' ' * indent
+        print >>ofile, "{0} match_tbd='{1}'".format(ins, self.__match_tbd)
+
+
+class _AMQPQueueMonitor(StreamMonitorBaseClass):
+    def __init__(self, amqp_server, exchange, routing_key, queue_name=None):
+        super(_AMQPQueueMonitor, self).__init__()
+        # let base class catch up with us statewise (we get created from
+        # inside the entire amqp-stream-monitor after begin). We do this here
+        # so that nothing can wander in as the queues are set up, etc.
+        self.handle_begin()
+        self.__server = amqp_server
+        self.__routing_key = routing_key
+        self.__saved_messages = gevent.queue.Queue()
+
+        ex = self.__server.create_add_monitor(exchange, routing_key, self.__got_one_cb)
+        self.__exchange = ex
+
+    def __got_one_cb(self, msg, body):
+        self.__saved_messages.put([msg, body])
+
+    def inject_test(self):
+        payload = {'test_uuid': str(uuid.uuid4())}
+        self.__server.inject(self.__exchange, self.__routing_key, payload)
+        what_sent = {'route_key': self.__routing_key, 'payload': payload}
+        return what_sent
+
+    def wait_for_one_message(self, timeout=5):
+        sleep_till = time.time() + timeout
+        found = False
+        tries = 0
+        while time.time() < sleep_till:
+            try:
+                tries += 1
+                msg, body = self.__saved_messages.get(block=False)
+                found = True
+            except gevent.queue.Empty:
+                pass
+            if found:
+                return msg, body
+            gevent.sleep(0)
+        return None, None
+
+
+class AMQPStreamMonitor(StreamMonitorBaseClass):
+    """
+    Implementation of a StreamMonitorBaseClass that handles working with AMQP.
+
+    Needs to be able to:
+    * Create an AMQP-on-demand server if asked
+    * Spin up an AMQP receiver greenlet to on-demand
+    """
+    def handle_begin(self):
+        """
+        Handles plugin 'begin' event. This means spinning up
+        a greenlet to monitor the AMQP server.
+        """
+        super(AMQPStreamMonitor, self).handle_begin()
+        self.__monitors = []
+        sm_amqp_url = getattr(self.__options, 'sm_amqp_url', None)
+        if sm_amqp_url is None:
+            self.__amqp_on_demand = RackHDAMQPOnDemand()
+            sm_amqp_url = self.__amqp_on_demand.get_url()
+        else:
+            self.__amqp_on_demand = None
+        self.__amqp_server = _AMQPServerWrapper(sm_amqp_url)
+
+    def test_helper_is_amqp_running(self):
+        return self.__amqp_server.connected
+
+    def test_helper_sync_send_msg(self, exchange, ex_rk, send_rk, payload):
+        return self.__amqp_server.test_helper_sync_send_msg(
+            exchange, ex_rk, send_rk, payload)
+
+    def test_helper_sync_recv_msg(self, queue):
+        return self.__amqp_server.test_helper_sync_recv_msg(queue)
+
+    def get_queue_monitor(self, exchange, routing_key, queue_name=None):
+        assert queue_name is None, \
+            'named queues coming in another story. param is for api definition only currently'
+        monitor = _AMQPQueueMonitor(self.__amqp_server, exchange, routing_key)
+        self.__monitors.append(monitor)
+
+        return monitor
+
+    @classmethod
+    def enabled_for_nose(true):
+        return True
+
+    def set_options(self, options):
+        self.__options = options
+
+    @classmethod
+    def add_nose_parser_opts(self, parser):
+        amqp_group = optparse.OptionGroup(parser, 'AMQP options')
+        parser.add_option_group(amqp_group)
+        amqp_group.add_option(
+            '--sm-amqp-url', dest='sm_amqp_url', default=None,
+            help="set the AMQP url to use. If not set, a docker based server will be setup and used")

--- a/test/stream-monitor/stream_sources/amqp_source.py
+++ b/test/stream-monitor/stream_sources/amqp_source.py
@@ -67,7 +67,7 @@ class _AMQPServerWrapper(object):
             mon = {
                 "event_cb": event_cb,
                 "exchange": ex
-                }
+            }
             self.__monitors[mname] = mon
         return mon['exchange']
 

--- a/test/stream-monitor/stream_sources/amqp_source.py
+++ b/test/stream-monitor/stream_sources/amqp_source.py
@@ -166,11 +166,25 @@ class AMQPStreamMonitor(StreamMonitorBaseClass):
         self.__monitors = []
         sm_amqp_url = getattr(self.__options, 'sm_amqp_url', None)
         if sm_amqp_url is None:
+            sm_amqp_url = None
+        elif sm_amqp_url == 'on-demand':
             self.__amqp_on_demand = RackHDAMQPOnDemand()
             sm_amqp_url = self.__amqp_on_demand.get_url()
         else:
             self.__amqp_on_demand = None
-        self.__amqp_server = _AMQPServerWrapper(sm_amqp_url)
+
+        if sm_amqp_url is None:
+            self.__amqp_server = None
+        else:
+            self.__amqp_server = _AMQPServerWrapper(sm_amqp_url)
+
+    @property
+    def has_amqp_server(self):
+        """
+        method to indicate if an AMQP server was defined or not.
+        This allows callers to Skip() tests if not.
+        """
+        return self.__amqp_server is not None
 
     def test_helper_is_amqp_running(self):
         return self.__amqp_server.connected

--- a/test/stream-monitor/stream_sources/monitor_abc.py
+++ b/test/stream-monitor/stream_sources/monitor_abc.py
@@ -18,7 +18,7 @@ class StreamMonitorBaseClass(object):
         be a stream-monitor plugin so that the methods are called at the proper
         times.
         """
-        self._in_test = False
+        self.__in_test = None
         self.__match_groups = None
         self.__group_stack = None
         self.__seen_before_test = []
@@ -35,7 +35,7 @@ class StreamMonitorBaseClass(object):
         """
         self.__match_groups = StreamGroupsRoot()
         self.__group_stack = [self.__match_groups]
-        self.__in_test = False
+        self.__in_test = None
 
     def handle_start_test(self, test):
         """
@@ -45,13 +45,19 @@ class StreamMonitorBaseClass(object):
         self.__match_groups.handle_start_test(test)
         self.__seen_before_test = []
         self.__seen_during_test = []
-        self.__in_test = True
+        self.__in_test = test
 
     def handle_stop_test(self, test):
         """
         called at stream-monitor stop-test.
         """
-        self.__in_test = False
+        pass
+
+    def handle_after_test(self, test):
+        """
+        called at stream-monitor after-test
+        """
+        self.__in_test = None
 
     def _add_matcher(self, matcher):
         """

--- a/test/stream-monitor/test/test_amqp_mon.py
+++ b/test/stream-monitor/test/test_amqp_mon.py
@@ -1,0 +1,181 @@
+"""
+Copyright (c) 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+Self-test of the matcher infrastructure. This is less about individual matchers,
+and more about if the various sequences and groups work (and fail!) as expected.
+"""
+from __future__ import print_function
+import unittest
+import plugin_test_helper
+import inspect
+import traceback
+import uuid
+import json
+from sm_plugin import smp_get_stream_monitor
+
+
+class _InnerResults(object):
+    def __init__(self, results_obj, exception_str=None):
+        self.__exception_str = exception_str
+        self.results = results_obj
+
+    @property
+    def is_exception(self):
+        return isinstance(self.results, Exception)
+
+    def dump_exception(self):
+        if self.__exception_str is not None:
+            for line in self.__exception_str.split('\n'):
+                print(line)
+
+
+class TestAMQPOnDemand(plugin_test_helper.resolve_no_verify_helper_class()):
+    """
+    This is the test-container for the stream-monitor matchers.
+
+    This is a nose-plugin tester based test-container, which means that makeSuite is
+    called once for each "test_xxxx" method in this class and returns a list of
+    test-cases to run. Each of those is run _within_ the context of its own complete
+    nose environment (complete with the plugin(s) we are testing!) , and then the
+    "test_xxxx" method is called.
+
+    This, however, means one normally needs to make a complete class for each test case,
+    since if you don't, all the test-cases from makeSuite get called once for each
+    outer test-case. Also, errors from the makeSuite test cases are not reported
+    directly to the outer-context, which means test counts and such would be off.
+
+    To streamline this a little, makeSuite "peeks" at the outer test-name and only
+    returns a single test-case containing the inner-test-case for the exact same name.
+    It also passes the outer-test-case into the inner own so that it can set its
+    results into TestMatcherGroups.test_suite_result['test_name_xxxx'], allowing the
+    outer tests to do the work of looking at results, while the inner ones just do
+    the sequencing.
+    """
+    test_suite_results = {}
+    longMessage = True   # this turns on printing of arguments for unittest.assert*s
+
+    def __get_inner_results(self):
+        our_frame = inspect.currentframe()
+        # climb looking for the first thing starting with 'test_'. We
+        # could just pop one up, but that would make things like
+        # self.assertRaises() fail.
+        while our_frame is not None and not our_frame.f_code.co_name.startswith('test_'):
+            our_frame = our_frame.f_back
+        assert our_frame is not None, \
+            "alleged impossible situation where no 'test_' was found in stack"
+
+        # get our callers name
+        parent_name = our_frame.f_code.co_name
+
+        # now fetch results put there by the method with the same name
+        # inside a TC from makeSuite() below.
+        iresult = self.test_suite_results[parent_name]
+
+        # if it was an assertion, throw it again (allow self.Raises and such)
+        if iresult.is_exception:
+            # dump the traceback to stdout. If the exception is caught by the
+            # specific test, then it will show up nicely in capture.
+            iresult.dump_exception()
+            raise iresult.results
+        return iresult.results
+
+    def test_connected_to_ondemand_server(self):
+        ires = self.__get_inner_results()
+        self.assertIsInstance(ires, bool, 'return type must be boolean')
+        self.assertTrue(ires, 'was not connected to amqp server')
+
+    def test_send_receive_sync_message(self):
+        ires = self.__get_inner_results()
+        expected = ires['expected']
+        got = ires['got']
+        self.assertIsNotNone(got, "message never received")
+        di = got.delivery_info
+        self.assertEqual(di['routing_key'], expected['route_key'])
+        body = json.loads(got.body)
+        self.assertEqual(body['test_uuid'], expected['payload']['test_uuid'])
+
+    def test_send_receive_async_message(self):
+        ires = self.__get_inner_results()
+        expected = ires['expected']
+        got = ires['got']
+        self.assertIsNotNone(got, "message never received")
+        di = got.delivery_info
+        self.assertEqual(di['routing_key'], expected['route_key'])
+        body = json.loads(got.body)
+        self.assertEqual(body['test_uuid'], expected['payload']['test_uuid'])
+        print("di={}".format(di))
+        print("body={}".format(body))
+
+    def makeSuite(self):
+        class TC(unittest.TestCase):
+            def __init__(self, owner, test_method_name, *args, **kwargs):
+                self.__owner = owner
+                self.__this_method_this_time = test_method_name
+                super(TC, self).__init__(*args, **kwargs)
+
+            def shortDescription(self):
+                return self.__this_method_this_time
+
+            def __str__(self):
+                return '{0} ({1})'.format(
+                    self.__this_method_this_time,
+                    unittest.util.strclass(self.__class__))
+
+            def setUp(self):
+                """
+                """
+                self.__asm = smp_get_stream_monitor('amqp')
+
+            def test_connected_to_ondemand_server(self):
+                results = self.__asm.test_helper_is_amqp_running()
+                return results
+
+            def test_send_receive_sync_message(self):
+                payload = {'test_uuid': str(uuid.uuid4())}
+                queue = self.__asm.test_helper_sync_send_msg(
+                    'on.events', 'on.events', 'on.events.test', payload)
+                data_back = self.__asm.test_helper_sync_recv_msg(queue)
+                return {'expected': {'route_key': 'on.events.test', 'payload': payload},
+                        'got': data_back}
+
+            def test_send_receive_async_message(self):
+                on_tasks = self.__asm.get_queue_monitor('on.events', 'on.events.tests')
+                sent_info = on_tasks.inject_test()
+                msg, body = on_tasks.wait_for_one_message()
+                expected = {
+                    'expected': sent_info,
+                    'got': msg
+                }
+                return expected
+
+            def runTests(self):
+                method_set = inspect.getmembers(self, self.__check_for_usable_test)
+                ran_one = False
+                for method_name, method in method_set:
+                    if method_name == self.__this_method_this_time:
+                        self.__run_test(method_name, method)
+                        ran_one = True
+                        break
+                assert ran_one, \
+                    'Unable to find test-method matching {0}'.format(self.__this_method_this_time)
+
+            def __run_test(self, method_name, method):
+                results = None
+                exception_str = None
+                try:
+                    results = method()
+                except Exception as ex:
+                    results = ex
+                    exception_str = traceback.format_exc()
+
+                results = _InnerResults(results, exception_str)
+
+                self.__owner.test_suite_results[method_name] = results
+
+            def __check_for_usable_test(self, item):
+                if inspect.ismethod(item):
+                    # ok, it's at least a method.
+                    if item.__name__.startswith('test_'):
+                        return True
+                return False
+        return [TC(self, self._testMethodName, 'runTests')]

--- a/test/tests/framework_tsts/test_amqp_stream_monitor.py
+++ b/test/tests/framework_tsts/test_amqp_stream_monitor.py
@@ -1,0 +1,104 @@
+"""
+Copyright (c) 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+Initial test for checking the AMQPStreamMonitor listening capability.
+
+
+Note: this can either be run using an "on-demand" docker based amqp
+server OR using a "real" one.
+For on-demand:
+  python run_tests.py -stack vagrant -test \
+     tests/framework_tsts/test_amqp_stream_monitor.py
+For "real" server:
+   python run_tests.py -stack vagrant -test \
+     tests/framework_tsts/test_amqp_stream_monitor.py \
+     --sm-amqp-url=amqp://user:password@localhost:9091
+
+  The amqp-url has to use ports and credentials that have been setup
+  inside the given amqp server.
+"""
+import fit_path  # NOQA: unused import
+import unittest
+import uuid
+import json
+
+# import nose decorator attr
+from nose.plugins.attrib import attr
+
+# Import the logging feature
+import flogging
+from sm_plugin import AMQPStreamMonitor
+
+# set up the logging
+logs = flogging.get_loggers()
+
+
+@attr(regression=False, smoke=False, amqp_sm_framework=True)
+class test_amqp_stream_monitor_framework(unittest.TestCase):
+    longMessage = True
+
+    def setUp(self):
+        self.__amqp_sm = AMQPStreamMonitor()
+
+    def shortDescription(self):
+        # This removes the docstrings (""") from the unittest test list (collect-only)
+        return None
+
+    def test_amqp_sm_send_receive_sync_message(self):
+        """ Send an amqp message and check it was correctly received """
+        payload = {'test_uuid': str(uuid.uuid4())}
+        queue = self.__amqp_sm.test_helper_sync_send_msg(
+            'on.events', 'on.events', 'on.events.test', payload)
+        got = self.__amqp_sm.test_helper_sync_recv_msg(queue)
+        self.assertIsNotNone(got, "message never received")
+        di = got.delivery_info
+        self.assertEqual(di['routing_key'], 'on.events.test')
+        body = json.loads(got.body)
+        self.assertEqual(body['test_uuid'], payload['test_uuid'])
+
+    def test_amqp_sm_send_receive_async_message(self):
+        """ Send an amqp message and check it was correctly received via greenlet """
+        on_events = self.__amqp_sm.get_queue_monitor('on.events', 'on.events.tests')
+        expected = on_events.inject_test()
+        got, body = on_events.wait_for_one_message()
+        self.assertIsNotNone(got, "message never received")
+        di = got.delivery_info
+        body = json.loads(body)
+        self.assertEqual(di['routing_key'], 'on.events.tests')
+        self.assertEqual(body['test_uuid'], expected['payload']['test_uuid'])
+
+    def test_amqp_sm_display_async_message(self):
+        """ Send, receive, and display an AMQP message """
+        on_events = self.__amqp_sm.get_queue_monitor('on.events', 'on.events.tests')
+        on_events.inject_test()
+        got, body = on_events.wait_for_one_message()
+        self.assertIsNotNone(got, "message never received")
+        di = got.delivery_info
+        body = json.loads(body)
+        logs.data_log.info('delivery_info from message=%s', di)
+        logs.data_log.info('body from message=%s', body)
+
+    def test_amqp_heartbeats(self):
+        on_hb = self.__amqp_sm.get_queue_monitor('on.events', 'heartbeat.#')
+        got, body = on_hb.wait_for_one_message(20)
+        self.assertIsNotNone(got, "message never received")
+        di = got.delivery_info
+        body = json.loads(body)
+        logs.data_log.info('RoutingKey: %s', di['routing_key'])
+        logs.data_log.info('delivery_info from message=%s', di)
+        logs.data_log.info('body from message=%s', body)
+
+    def test_amqp_heartbeats_events(self):
+        on_hb = self.__amqp_sm.get_queue_monitor('on.events', 'heartbeat.#')
+        for x in range(6):
+            got, body = on_hb.wait_for_one_message(20)
+            self.assertIsNotNone(got, "message never received")
+            di = got.delivery_info
+            body = json.loads(body)
+            logs.data_log.info('RoutingKey: %s', di['routing_key'])
+            logs.data_log.info('delivery_info from message=%s', di)
+            logs.data_log.debug('body from message=%s', body)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Added to stream-monitor-plugin:
* AMQP stream source
* On-demand amqp server
* plugin self-tests to:
* * send a msg and synchronously read it back
* * send a msg and let a greenlet receive the message (but then poll the greenlet)
* * send and log a msg
* added --sm-amqp-server option to allow FIT level tests to say where the AMQP server is

Signed-off-by: Erika Hohenstein <Erika.Hohenstein@dell.com>

This was done paired. @RackHD/corecommitters and specifically @johren 

Note: the added ability and self-tests are not "main line" tests yet.