### PR TITLE
Rac 4234 obsolete fit common routines

### DIFF
--- a/test/util/display_SYSINFO_settings.py
+++ b/test/util/display_SYSINFO_settings.py
@@ -17,15 +17,15 @@ import test_api_utils
 class display_sysinfo(fit_common.unittest.TestCase):
     def test_01_get_product_info(self):
         print "============== Displaying Product Info"
-        nodes = test_api_utils.monorail_get_node_list(fit_common.fitargs()['ora'])
+        nodes = fit_common.node_select()
         if len(nodes) == 0:
-            print "No Nodes found on Onrack server "+ fit_common.fitargs()['ora']
+            print "No Nodes found on RackHD server "
         else:
             inode=0
             while inode<len(nodes):
                 nn=nodes[inode]
                 print "Node: "+nn
-                monurl = "/api/1.1/nodes/"+nn+"/catalogs/dmi"
+                monurl = "/api/2.0/nodes/"+nn+"/catalogs/dmi"
                 mondata = fit_common.rackhdapi(monurl)
                 catalog = mondata['json']
                 result = mondata['status']
@@ -42,9 +42,9 @@ class display_sysinfo(fit_common.unittest.TestCase):
 
     def test_02_get_catalog_source(self):
         print "============== Displaying Catalog Sources"
-        nodes = test_api_utils.monorail_get_node_list(fit_common.fitargs()['ora'])
+        nodes = fit_common.node_select()
         if len(nodes) == 0:
-            print "No Nodes found on Onrack server "+ fit_common.fitargs()['ora']
+            print "No Nodes found on RackHD server "
         else:
             inode=0
             while inode<len(nodes):
@@ -52,7 +52,7 @@ class display_sysinfo(fit_common.unittest.TestCase):
                 nn=nodes[inode]
                 print "Node: "+nn
 
-                monurl = "/api/1.1/nodes/"+nn+"/catalogs"
+                monurl = "/api/2.0/nodes/"+nn+"/catalogs"
                 mondata = fit_common.rackhdapi(monurl)
                 catalog = mondata['json']
                 result = mondata['status']

--- a/test/util/display_SYSINFO_settings.py
+++ b/test/util/display_SYSINFO_settings.py
@@ -8,7 +8,7 @@ Purpose:
 import fit_path  # NOQA: unused import
 import fit_common
 
-fit_common.VERBOSIY = 1
+fit_common.VERBOSIY = 1  # this is needed for suppressing debug messages to make reports readable
 
 
 class display_sysinfo(fit_common.unittest.TestCase):

--- a/test/util/display_SYSINFO_settings.py
+++ b/test/util/display_SYSINFO_settings.py
@@ -1,17 +1,14 @@
-# Copyright 2016, EMC, Inc.
+'''
+Copyright 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 
-"""
-  Purpose:
-  This script will generate a list of discovered nodes and display the system information for the nodes 
-"""
+Purpose:
+  This script will generate a list of discovered nodes and display the system information for the nodes
+'''
 
 import fit_path  # NOQA: unused import
-import os
-import sys
-import subprocess
-
 import fit_common
-import test_api_utils
+
+fit_common.VERBOSIY = 1
 
 
 class display_sysinfo(fit_common.unittest.TestCase):
@@ -21,11 +18,11 @@ class display_sysinfo(fit_common.unittest.TestCase):
         if len(nodes) == 0:
             print "No Nodes found on RackHD server "
         else:
-            inode=0
-            while inode<len(nodes):
-                nn=nodes[inode]
-                print "Node: "+nn
-                monurl = "/api/2.0/nodes/"+nn+"/catalogs/dmi"
+            inode = 0
+            while inode < len(nodes):
+                nn = nodes[inode]
+                print "Node: " + nn
+                monurl = "/api/2.0/nodes/" + nn + "/catalogs/dmi"
                 mondata = fit_common.rackhdapi(monurl)
                 catalog = mondata['json']
                 result = mondata['status']
@@ -34,11 +31,11 @@ class display_sysinfo(fit_common.unittest.TestCase):
                     print "Error on catalog/dmi command"
                 else:
                     # Check BMC IP vs OBM IP setting
-                    print " ID: "+catalog["id"]
-                    print " Product Name : "+catalog["data"]["System Information"]["Product Name"]
-                    print " Serial Number: "+catalog["data"]["System Information"]["Serial Number"]
-                    print " UUID         : "+catalog["data"]["System Information"]["UUID"]
-                inode +=1
+                    print " ID: " + catalog["id"]
+                    print " Product Name : " + catalog["data"]["System Information"]["Product Name"]
+                    print " Serial Number: " + catalog["data"]["System Information"]["Serial Number"]
+                    print " UUID         : " + catalog["data"]["System Information"]["UUID"]
+                inode += 1
 
     def test_02_get_catalog_source(self):
         print "============== Displaying Catalog Sources"
@@ -46,13 +43,13 @@ class display_sysinfo(fit_common.unittest.TestCase):
         if len(nodes) == 0:
             print "No Nodes found on RackHD server "
         else:
-            inode=0
-            while inode<len(nodes):
+            inode = 0
+            while inode < len(nodes):
                 print("")
-                nn=nodes[inode]
-                print "Node: "+nn
+                nn = nodes[inode]
+                print "Node: " + nn
 
-                monurl = "/api/2.0/nodes/"+nn+"/catalogs"
+                monurl = "/api/2.0/nodes/" + nn + "/catalogs"
                 mondata = fit_common.rackhdapi(monurl)
                 catalog = mondata['json']
                 result = mondata['status']
@@ -61,10 +58,11 @@ class display_sysinfo(fit_common.unittest.TestCase):
                     print "Error: failed catalog request"
                 else:
                     i = 0
-                    while i<len(catalog):
-                        print "Source: "+catalog[i]["source"]
-                        i +=1
-                inode +=1
+                    while i < len(catalog):
+                        print "Source: " + catalog[i]["source"]
+                        i += 1
+                inode += 1
+
 
 if __name__ == '__main__':
     fit_common.unittest.main()

--- a/test/util/display_node_FIRMWARE_versions.py
+++ b/test/util/display_node_FIRMWARE_versions.py
@@ -17,7 +17,7 @@ NODELIST = fit_common.node_select()
 if NODELIST == []:
     print "No nodes found on stack"
     exit
-fit_common.VERBOSITY = 1
+fit_common.VERBOSITY = 1  # this is needed for suppressing debug messages to make reports readable
 
 
 def mon_get_ip_info(node):

--- a/test/util/display_node_FIRMWARE_versions.py
+++ b/test/util/display_node_FIRMWARE_versions.py
@@ -1,17 +1,13 @@
-# Copyright 2016, EMC, Inc.
-
-
 '''
-This is a utility to  display variuos node firmware and manufacturer info.
+Copyright 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+Purpose:
+   This is a utility to  display variuos node firmware and manufacturer info.
 '''
 
 import fit_path  # NOQA: unused import
-import os
-import sys
-import subprocess
 import json
 import pprint
-
 import fit_common
 import test_api_utils
 
@@ -20,11 +16,11 @@ import test_api_utils
 NODELIST = fit_common.node_select()
 if NODELIST == []:
     print "No nodes found on stack"
-    exit;
+    exit
+fit_common.VERBOSITY = 1
 
 
-# routine to grab BMC and RMM info
-def mon_get_ip_info( node ):
+def mon_get_ip_info(node):
     '''
     This routine will grab the IP information from the compute node
     '''
@@ -34,7 +30,7 @@ def mon_get_ip_info( node ):
     nodeinfo = nodedata['json']
     result = nodedata['status']
     if result != 200:
-        print "Error on node command ",  nodeurl
+        print "Error on node command ", nodeurl
         fit_common.TEST_CASE["test_error"] += 1
         return
 
@@ -46,20 +42,22 @@ def mon_get_ip_info( node ):
     if result != 200:
         print "Error on catalog/bmc command ", monurl
     else:
-        print " BMC MAC Address: "+catalog["data"]["MAC Address"]
+        print " BMC MAC Address: " + catalog["data"]["MAC Address"]
         bmc_ip_value = catalog["data"].get("IP Address")
-        print " Shared NIC BMC IP Address: "+ bmc_ip_value
-        print " Shared NIC BMC IP Address Source: "+catalog["data"]["IP Address Source"]
-            
+        print " Shared NIC BMC IP Address: " + bmc_ip_value
+        print " Shared NIC BMC IP Address Source: " + catalog["data"]["IP Address Source"]
+
         # Check BMC IP vs OBM IP setting
-        try: obmlist = nodeinfo["obmSettings"]
+        try:
+            obmlist = nodeinfo["obmSettings"]
         except:
             print "ERROR: Node has no OBM settings configured"
         else:
             if fit_common.VERBOSITY >= 3:
                 print " OBM Settings:"
                 print fit_common.json.dumps(obmlist, indent=4)
-            try: obmhost = obmlist[0]["config"]["host"]
+            try:
+                obmlist[0]["config"]["host"]
             except:
                 print "ERROR: Invalid or empty OBM setting"
 
@@ -71,9 +69,9 @@ def mon_get_ip_info( node ):
     if result != 200:
         print "\nNo RMM catalog for node"
     else:
-        print " RMM MAC Address: "+catalog["data"].get("MAC Address")
-        print " RMM IP Address: "+catalog["data"].get("IP Address")
-        print " RMM IP Address Source: "+catalog["data"].get("IP Address Source")
+        print " RMM MAC Address: " + catalog["data"].get("MAC Address")
+        print " RMM IP Address: " + catalog["data"].get("IP Address")
+        print " RMM IP Address Source: " + catalog["data"].get("IP Address Source")
 
 
 def redfish_simple_storage_members(node_id):
@@ -82,7 +80,7 @@ def redfish_simple_storage_members(node_id):
     :param nodeid:   node id
     """
 
-    on_url = "/redfish/v1/Systems/"+str(node_id)+'/SimpleStorage'
+    on_url = "/redfish/v1/Systems/" + str(node_id) + '/SimpleStorage'
     on_data = fit_common.rackhdapi(url_cmd=on_url)
 
     # To get a list of devices
@@ -99,15 +97,13 @@ def redfish_simple_storage_members(node_id):
 
     return dev_ids
 
-class display_node_firmware(fit_common.unittest.TestCase):
 
-    # This test displays the BMC and BIOS firmware versions from the 
+class display_node_firmware(fit_common.unittest.TestCase):
+    # This test displays the BMC and BIOS firmware versions from the
     # RackHD catalog data and the onrack redfish calls
     # No asserts are used in this test, avoiding early exit on errors
-
     def test_display_bmc_bios(self):
         ora_name = ""
-        mon_name = ""
         inode = 1
         for node in NODELIST:
             print "==== Displaying BMC BIOS ===="
@@ -121,7 +117,7 @@ class display_node_firmware(fit_common.unittest.TestCase):
                 sysdata = on_data['json']
                 ora_name = sysdata.get("Name", "")
                 print "Name: ", ora_name
-                print "AssetTag: ",  sysdata.get("AssetTag", "")
+                print "AssetTag: ", sysdata.get("AssetTag", "")
                 print "SKU: ", sysdata.get("SKU", "")
                 print "BiosVersion: ", sysdata.get("BiosVersion", "")
                 print "PowerState: ", sysdata.get("PowerState", "")
@@ -140,9 +136,8 @@ class display_node_firmware(fit_common.unittest.TestCase):
             if result != 200:
                 print "Error on catalog/dmi command"
             else:
-                print " ID: "+catalog["id"]
+                print " ID: " + catalog["id"]
                 print " Product Name : ", catalog["data"]["System Information"].get("Product Name", "")
-                mon_name = catalog["data"]["System Information"].get("Product Name", "")
                 print " Serial Number: ", catalog["data"]["System Information"].get("Serial Number", "")
                 print " UUID         : ", catalog["data"]["System Information"].get("UUID", "")
                 print " BMC FW Revision : ", catalog["data"]["BIOS Information"].get("Firmware Revision", "")
@@ -151,22 +146,19 @@ class display_node_firmware(fit_common.unittest.TestCase):
                 print " BIOS Vendor     : ", catalog["data"]["BIOS Information"].get("Vendor", "")
             print "ORA Name      : ", ora_name
             print "\nIP Info:"
-            mon_get_ip_info( node )
+            mon_get_ip_info(node)
             inode += 1
         print "=========================================================\n"
 
-
-    # This test displays the BMC MC info from the compute node via
-    # IPMI call ipmitool mc info
-    # No asserts are used in this test, avoiding early exit on errors
-
     def test_display_bmc_mc_info(self):
-
+        # This test displays the BMC MC info from the compute node via
+        # IPMI call ipmitool mc info
+        # No asserts are used in this test, avoiding early exit on errors
         inode = 1
         for node in NODELIST:
             print "==== Displaying BMC MC info ===="
             nodetype = test_api_utils.get_rackhd_nodetype(node)
-            print "\nNode " + str(inode) + ": "+node
+            print "\nNode " + str(inode) + ": " + node
             print "Type: ", nodetype
             if nodetype != "unknown" and nodetype != "Unmanaged":
                 nodeurl = "/api/2.0/nodes/" + node
@@ -174,40 +166,38 @@ class display_node_firmware(fit_common.unittest.TestCase):
                 nodeinfo = nodedata['json']
                 result = nodedata['status']
                 if result != 200:
-                    print "Error on node command"+nodeurl
+                    print "Error on node command" + nodeurl
                 else:
-                    try: obmlist = nodeinfo["obmSettings"]
+                    try:
+                        obmlist = nodeinfo["obmSettings"]
                     except:
                         print "ERROR: Node has no OBM settings configured"
                     else:
                         if obmlist:
                             bmc_ip = test_api_utils.get_compute_bmc_ip(node)
-                            if bmc_ip in [1,2]:
+                            if bmc_ip in [1, 2]:
                                 print "No BMC IP found"
                             elif bmc_ip.startswith('192.168'):
                                 print "ERROR: BAD BMC Value: ", bmc_ip
                             else:
                                 user_cred = test_api_utils.get_compute_node_username(node)
-                                if user_cred in [1,2,3,4]:
+                                if user_cred in [1, 2, 3, 4]:
                                     print "Unable to get user credetials for node_id", node
                                 else:
                                     mc_data = test_api_utils.run_ipmi_command(bmc_ip, 'mc info', user_cred)
-                                    if mc_data ['exitcode'] == 0:
+                                    if mc_data['exitcode'] == 0:
                                         print "MC Data: "
-                                        print mc_data ['stdout']
+                                        print mc_data['stdout']
                         else:
                             print "ERROR: Node has no OBM settings configured"
                 inode += 1
         print "=========================================================\n"
 
-    
-    # This test displays the MegaRaid controller firmware data from the compute
-    # node if it exists.  It then displays the controller info contained in the
-    # RackHD redfish managed system data
-    # No asserts are used in this test, avoiding early exit on errors
-
     def test_display_raid_controller_firmware(self):
-
+        # This test displays the MegaRaid controller firmware data from the compute
+        # node if it exists.  It then displays the controller info contained in the
+        # RackHD redfish managed system data
+        # No asserts are used in this test, avoiding early exit on errors
         inode = 1
         for node in NODELIST:
             print "==== Displaying MegaRAID and Controller info ===="
@@ -223,20 +213,20 @@ class display_node_firmware(fit_common.unittest.TestCase):
                 if result != 200:
                     print "ERROR: failed catalog request"
                 else:
-                    source_set = test_api_utils.get_node_source_id_list( node )
+                    source_set = test_api_utils.get_node_source_id_list(node)
                     if 'megaraid-controllers' in source_set:
                         print "Source: megaraid-controllers\n"
-                        raidurl = "/api/2.0/nodes/"+node+"/catalogs/megaraid-controllers"
+                        raidurl = "/api/2.0/nodes/" + node + "/catalogs/megaraid-controllers"
                         raiddata = fit_common.rackhdapi(raidurl, action="get")
                         catalog = raiddata['json']
                         result = raiddata['status']
-                        print " Basics: ",catalog["data"]["Controllers"][0]["Command Status"]
+                        print " Basics: ", catalog["data"]["Controllers"][0]["Command Status"]
                         print " Version: ",
                         pprint.pprint(catalog["data"]["Controllers"][0]["Response Data"]["Version"])
                     else:
                         print "Info: monorail catalog did not contain megraid-controllers source"
                     # display controller data if available, no firmware revs are present in the output
-                    device_ids = redfish_simple_storage_members( node )
+                    device_ids = redfish_simple_storage_members(node)
                     for dev_id in device_ids:
                         devurl = "/redfish/v1/Systems/" + node + "/SimpleStorage/" + dev_id
                         devdata = fit_common.rackhdapi(url_cmd=devurl)
@@ -245,10 +235,10 @@ class display_node_firmware(fit_common.unittest.TestCase):
                         if result == 200:
                             controller = devdata['json']
                             print "Controller: " + str(dev_id) + " Name: " + str(controller.get('Name', ""))
-                            print "Description: ", json.dumps( controller.get('Description', ""), indent=4)
+                            print "Description: ", json.dumps(controller.get('Description', ""), indent=4)
             inode += 1
         print "========================================================="
 
+
 if __name__ == '__main__':
     fit_common.unittest.main()
-    

--- a/test/util/display_node_FIRMWARE_versions.py
+++ b/test/util/display_node_FIRMWARE_versions.py
@@ -29,7 +29,7 @@ def mon_get_ip_info( node ):
     This routine will grab the IP information from the compute node
     '''
     # Get RackHD node info
-    nodeurl = "/api/1.1/nodes/" + node
+    nodeurl = "/api/2.0/nodes/" + node
     nodedata = fit_common.rackhdapi(nodeurl, action="get")
     nodeinfo = nodedata['json']
     result = nodedata['status']
@@ -39,7 +39,7 @@ def mon_get_ip_info( node ):
         return
 
     # get RackHD BMC info
-    monurl = "/api/1.1/nodes/" + node + "/catalogs/bmc"
+    monurl = "/api/2.0/nodes/" + node + "/catalogs/bmc"
     mondata = fit_common.rackhdapi(monurl, action="get")
     catalog = mondata['json']
     result = mondata['status']
@@ -64,7 +64,7 @@ def mon_get_ip_info( node ):
                 print "ERROR: Invalid or empty OBM setting"
 
     # Get RackHD RMM info
-    monurl = "/api/1.1/nodes/" + node + "/catalogs/rmm"
+    monurl = "/api/2.0/nodes/" + node + "/catalogs/rmm"
     mondata = fit_common.rackhdapi(monurl, action="get")
     catalog = mondata['json']
     result = mondata['status']
@@ -132,7 +132,7 @@ class display_node_firmware(fit_common.unittest.TestCase):
 
             # Print the related system info from RackHD
             print "\nRackHD System Info from DMI:"
-            monurl = "/api/1.1/nodes/" + node + "/catalogs/dmi"
+            monurl = "/api/2.0/nodes/" + node + "/catalogs/dmi"
             mondata = fit_common.rackhdapi(monurl, action="get")
             catalog = mondata['json']
             result = mondata['status']
@@ -169,7 +169,7 @@ class display_node_firmware(fit_common.unittest.TestCase):
             print "\nNode " + str(inode) + ": "+node
             print "Type: ", nodetype
             if nodetype != "unknown" and nodetype != "Unmanaged":
-                nodeurl = "/api/1.1/nodes/" + node
+                nodeurl = "/api/2.0/nodes/" + node
                 nodedata = fit_common.rackhdapi(nodeurl, action="get")
                 nodeinfo = nodedata['json']
                 result = nodedata['status']
@@ -216,7 +216,7 @@ class display_node_firmware(fit_common.unittest.TestCase):
             print "\nNode " + str(inode) + ": " + node
             print "Type: ", nodetype
             if nodetype != "unknown" and nodetype != "Unmanaged":
-                monurl = "/api/1.1/nodes/" + node + "/catalogs"
+                monurl = "/api/2.0/nodes/" + node + "/catalogs"
                 mondata = fit_common.rackhdapi(monurl, action="get")
                 catalog = mondata['json']
                 result = mondata['status']
@@ -226,7 +226,7 @@ class display_node_firmware(fit_common.unittest.TestCase):
                     source_set = test_api_utils.get_node_source_id_list( node )
                     if 'megaraid-controllers' in source_set:
                         print "Source: megaraid-controllers\n"
-                        raidurl = "/api/1.1/nodes/"+node+"/catalogs/megaraid-controllers"
+                        raidurl = "/api/2.0/nodes/"+node+"/catalogs/megaraid-controllers"
                         raiddata = fit_common.rackhdapi(raidurl, action="get")
                         catalog = raiddata['json']
                         result = raiddata['status']

--- a/test/util/display_node_firmware_versions.py
+++ b/test/util/display_node_firmware_versions.py
@@ -1,0 +1,244 @@
+'''
+Copyright 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+Purpose:
+   This is a utility to  display variuos node firmware and manufacturer info.
+'''
+
+import fit_path  # NOQA: unused import
+import json
+import pprint
+import fit_common
+import test_api_utils
+
+# Globals
+
+NODELIST = fit_common.node_select()
+if NODELIST == []:
+    print "No nodes found on stack"
+    exit
+fit_common.VERBOSITY = 1  # this is needed for suppressing debug messages to make reports readable
+
+
+def mon_get_ip_info(node):
+    '''
+    This routine will grab the IP information from the compute node
+    '''
+    # Get RackHD node info
+    nodeurl = "/api/2.0/nodes/" + node
+    nodedata = fit_common.rackhdapi(nodeurl, action="get")
+    nodeinfo = nodedata['json']
+    result = nodedata['status']
+    if result != 200:
+        print "Error on node command ", nodeurl
+        fit_common.TEST_CASE["test_error"] += 1
+        return
+
+    # get RackHD BMC info
+    monurl = "/api/2.0/nodes/" + node + "/catalogs/bmc"
+    mondata = fit_common.rackhdapi(monurl, action="get")
+    catalog = mondata['json']
+    result = mondata['status']
+    if result != 200:
+        print "Error on catalog/bmc command ", monurl
+    else:
+        print " BMC MAC Address: " + catalog["data"]["MAC Address"]
+        bmc_ip_value = catalog["data"].get("IP Address")
+        print " Shared NIC BMC IP Address: " + bmc_ip_value
+        print " Shared NIC BMC IP Address Source: " + catalog["data"]["IP Address Source"]
+
+        # Check BMC IP vs OBM IP setting
+        try:
+            obmlist = nodeinfo["obmSettings"]
+        except:
+            print "ERROR: Node has no OBM settings configured"
+        else:
+            if fit_common.VERBOSITY >= 3:
+                print " OBM Settings:"
+                print fit_common.json.dumps(obmlist, indent=4)
+            try:
+                obmlist[0]["config"]["host"]
+            except:
+                print "ERROR: Invalid or empty OBM setting"
+
+    # Get RackHD RMM info
+    monurl = "/api/2.0/nodes/" + node + "/catalogs/rmm"
+    mondata = fit_common.rackhdapi(monurl, action="get")
+    catalog = mondata['json']
+    result = mondata['status']
+    if result != 200:
+        print "\nNo RMM catalog for node"
+    else:
+        print " RMM MAC Address: " + catalog["data"].get("MAC Address")
+        print " RMM IP Address: " + catalog["data"].get("IP Address")
+        print " RMM IP Address Source: " + catalog["data"].get("IP Address Source")
+
+
+def redfish_simple_storage_members(node_id):
+    """
+    To get the device ids from simple storage for a given node_id
+    :param nodeid:   node id
+    """
+
+    on_url = "/redfish/v1/Systems/" + str(node_id) + '/SimpleStorage'
+    on_data = fit_common.rackhdapi(url_cmd=on_url)
+
+    # To get a list of devices
+    dev_ids = []
+    try:
+        members = on_data['json']["Members"]
+    except KeyError:
+        members = []
+
+    for member in members:
+        href_id = member["@odata.id"]
+        dev_id = href_id.split('/')[-1]
+        dev_ids.append(dev_id)
+
+    return dev_ids
+
+
+class display_node_firmware(fit_common.unittest.TestCase):
+    # This test displays the BMC and BIOS firmware versions from the
+    # RackHD catalog data and the onrack redfish calls
+    # No asserts are used in this test, avoiding early exit on errors
+    def test_display_bmc_bios(self):
+        ora_name = ""
+        inode = 1
+        for node in NODELIST:
+            print "==== Displaying BMC BIOS ===="
+            # Print the SKU info from onrack
+            print "\nNode " + str(inode) + ": " + node
+            print "Redfish SKU data:"
+            # Redfish 1.0
+            on_url = "/redfish/v1/Systems/" + node
+            on_data = fit_common.rackhdapi(url_cmd=on_url)
+            if on_data['status'] == 200:
+                sysdata = on_data['json']
+                ora_name = sysdata.get("Name", "")
+                print "Name: ", ora_name
+                print "AssetTag: ", sysdata.get("AssetTag", "")
+                print "SKU: ", sysdata.get("SKU", "")
+                print "BiosVersion: ", sysdata.get("BiosVersion", "")
+                print "PowerState: ", sysdata.get("PowerState", "")
+                print "SerialNumber: ", sysdata.get("SerialNumber", "")
+                print " Model: ", sysdata.get("Model", "")
+            else:
+                print "Status: ", on_data['status']
+
+            # Print the related system info from RackHD
+            print "\nRackHD System Info from DMI:"
+            monurl = "/api/2.0/nodes/" + node + "/catalogs/dmi"
+            mondata = fit_common.rackhdapi(monurl, action="get")
+            catalog = mondata['json']
+            result = mondata['status']
+            # increment the error counter, but don't exit with an assert if no DMI catalog
+            if result != 200:
+                print "Error on catalog/dmi command"
+            else:
+                print " ID: " + catalog["id"]
+                print " Product Name : ", catalog["data"]["System Information"].get("Product Name", "")
+                print " Serial Number: ", catalog["data"]["System Information"].get("Serial Number", "")
+                print " UUID         : ", catalog["data"]["System Information"].get("UUID", "")
+                print " BMC FW Revision : ", catalog["data"]["BIOS Information"].get("Firmware Revision", "")
+                print " Release Date    : ", catalog["data"]["BIOS Information"].get("Release Date", "")
+                print " BIOS FW Package : ", catalog["data"]["BIOS Information"].get("Version", "")
+                print " BIOS Vendor     : ", catalog["data"]["BIOS Information"].get("Vendor", "")
+            print "ORA Name      : ", ora_name
+            print "\nIP Info:"
+            mon_get_ip_info(node)
+            inode += 1
+        print "=========================================================\n"
+
+    def test_display_bmc_mc_info(self):
+        # This test displays the BMC MC info from the compute node via
+        # IPMI call ipmitool mc info
+        # No asserts are used in this test, avoiding early exit on errors
+        inode = 1
+        for node in NODELIST:
+            print "==== Displaying BMC MC info ===="
+            nodetype = test_api_utils.get_rackhd_nodetype(node)
+            print "\nNode " + str(inode) + ": " + node
+            print "Type: ", nodetype
+            if nodetype != "unknown" and nodetype != "Unmanaged":
+                nodeurl = "/api/2.0/nodes/" + node
+                nodedata = fit_common.rackhdapi(nodeurl, action="get")
+                nodeinfo = nodedata['json']
+                result = nodedata['status']
+                if result != 200:
+                    print "Error on node command" + nodeurl
+                else:
+                    try:
+                        obmlist = nodeinfo["obmSettings"]
+                    except:
+                        print "ERROR: Node has no OBM settings configured"
+                    else:
+                        if obmlist:
+                            bmc_ip = test_api_utils.get_compute_bmc_ip(node)
+                            if bmc_ip in [1, 2]:
+                                print "No BMC IP found"
+                            elif bmc_ip.startswith('192.168'):
+                                print "ERROR: BAD BMC Value: ", bmc_ip
+                            else:
+                                user_cred = test_api_utils.get_compute_node_username(node)
+                                if user_cred in [1, 2, 3, 4]:
+                                    print "Unable to get user credetials for node_id", node
+                                else:
+                                    mc_data = test_api_utils.run_ipmi_command(bmc_ip, 'mc info', user_cred)
+                                    if mc_data['exitcode'] == 0:
+                                        print "MC Data: "
+                                        print mc_data['stdout']
+                        else:
+                            print "ERROR: Node has no OBM settings configured"
+                inode += 1
+        print "=========================================================\n"
+
+    def test_display_raid_controller_firmware(self):
+        # This test displays the MegaRaid controller firmware data from the compute
+        # node if it exists.  It then displays the controller info contained in the
+        # RackHD redfish managed system data
+        # No asserts are used in this test, avoiding early exit on errors
+        inode = 1
+        for node in NODELIST:
+            print "==== Displaying MegaRAID and Controller info ===="
+            source_set = []
+            nodetype = test_api_utils.get_rackhd_nodetype(node)
+            print "\nNode " + str(inode) + ": " + node
+            print "Type: ", nodetype
+            if nodetype != "unknown" and nodetype != "Unmanaged":
+                monurl = "/api/2.0/nodes/" + node + "/catalogs"
+                mondata = fit_common.rackhdapi(monurl, action="get")
+                catalog = mondata['json']
+                result = mondata['status']
+                if result != 200:
+                    print "ERROR: failed catalog request"
+                else:
+                    source_set = test_api_utils.get_node_source_id_list(node)
+                    if 'megaraid-controllers' in source_set:
+                        print "Source: megaraid-controllers\n"
+                        raidurl = "/api/2.0/nodes/" + node + "/catalogs/megaraid-controllers"
+                        raiddata = fit_common.rackhdapi(raidurl, action="get")
+                        catalog = raiddata['json']
+                        result = raiddata['status']
+                        print " Basics: ", catalog["data"]["Controllers"][0]["Command Status"]
+                        print " Version: ",
+                        pprint.pprint(catalog["data"]["Controllers"][0]["Response Data"]["Version"])
+                    else:
+                        print "Info: monorail catalog did not contain megraid-controllers source"
+                    # display controller data if available, no firmware revs are present in the output
+                    device_ids = redfish_simple_storage_members(node)
+                    for dev_id in device_ids:
+                        devurl = "/redfish/v1/Systems/" + node + "/SimpleStorage/" + dev_id
+                        devdata = fit_common.rackhdapi(url_cmd=devurl)
+                        controller = devdata['json']
+                        result = devdata['status']
+                        if result == 200:
+                            controller = devdata['json']
+                            print "Controller: " + str(dev_id) + " Name: " + str(controller.get('Name', ""))
+                            print "Description: ", json.dumps(controller.get('Description', ""), indent=4)
+            inode += 1
+        print "========================================================="
+
+
+if __name__ == '__main__':
+    fit_common.unittest.main()

--- a/test/util/display_rackhd_nodes.py
+++ b/test/util/display_rackhd_nodes.py
@@ -12,7 +12,7 @@ from nosedep import depends
 import fit_common
 import test_api_utils
 
-fit_common.VERBOSITY = 1
+fit_common.VERBOSITY = 1  # this is needed for suppressing debug messages to make reports readable
 
 
 class display_rackhd_node_list(fit_common.unittest.TestCase):

--- a/test/util/display_rackhd_nodes.py
+++ b/test/util/display_rackhd_nodes.py
@@ -21,7 +21,7 @@ import test_api_utils
 class display_rackhd_node_list(fit_common.unittest.TestCase):
     def test_display_node_list(self):
         # This test displays a list of the nodes, type and name
-        mondata = fit_common.rackhdapi("/api/1.1/nodes")
+        mondata = fit_common.rackhdapi("/api/2.0/nodes")
         nodes = mondata['json']
         result = mondata['status']
         if result == 200:
@@ -41,7 +41,7 @@ class display_rackhd_node_list(fit_common.unittest.TestCase):
     def test_display_node_list_discovery_data(self):
         # This test displays a list of the nodes along with 
         # the associated BMC, RMM, and OBM settings for the discovered compute nodes 
-        mondata = fit_common.rackhdapi("/api/1.1/nodes")
+        mondata = fit_common.rackhdapi("/api/2.0/nodes")
         nodes = mondata['json']
         result = mondata['status']
 
@@ -76,7 +76,7 @@ class display_rackhd_node_list(fit_common.unittest.TestCase):
                     else:
                         print "Not associated with a monorail enclosure"
                     # try to get the BMC info from the catalog
-                    monurl = "/api/1.1/nodes/"+nn+"/catalogs/bmc"
+                    monurl = "/api/2.0/nodes/"+nn+"/catalogs/bmc"
                     mondata = fit_common.rackhdapi(monurl, action="get")
                     catalog = mondata['json']
                     bmcresult = mondata['status']
@@ -95,7 +95,7 @@ class display_rackhd_node_list(fit_common.unittest.TestCase):
                         print "\t" + catalog["data"]["IP Address"],
                         print "\t" + catalog["data"]["IP Address Source"],
                     # Get RMM info from the catalog, if present
-                    rmmurl = "/api/1.1/nodes/"+nn+"/catalogs/rmm"
+                    rmmurl = "/api/2.0/nodes/"+nn+"/catalogs/rmm"
                     rmmdata = fit_common.rackhdapi(rmmurl, action="get")
                     rmmcatalog = rmmdata['json']
                     rmmresult = rmmdata['status']
@@ -106,7 +106,7 @@ class display_rackhd_node_list(fit_common.unittest.TestCase):
                         print "\t" + rmmcatalog["data"].get("IP Address", "-"),
                         print "\t" + rmmcatalog["data"].get("IP Address Source", "-") + "\t",
 
-                    nodeurl = "/api/1.1/nodes/"+nn
+                    nodeurl = "/api/2.0/nodes/"+nn
                     nodedata = fit_common.rackhdapi(nodeurl, action="get")
                     nodeinfo = nodedata['json']
                     result = nodedata['status']

--- a/test/util/display_rackhd_nodes.py
+++ b/test/util/display_rackhd_nodes.py
@@ -1,22 +1,19 @@
-# Copyright 2016, EMC, Inc.
+'''
+Copyright 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 
-"""
-  Purpose:
+Purpose:
   This script will generate a list of discovered nodes and identifiers
   using the RackHD API calls.
-"""
+'''
 
-#pylint: disable=relative-import
 
 import fit_path  # NOQA: unused import
-import os
-import sys
-import subprocess
-import json
-import pprint
 from nosedep import depends
 import fit_common
 import test_api_utils
+
+fit_common.VERBOSITY = 1
+
 
 class display_rackhd_node_list(fit_common.unittest.TestCase):
     def test_display_node_list(self):
@@ -39,16 +36,16 @@ class display_rackhd_node_list(fit_common.unittest.TestCase):
 
     @depends(after='test_display_node_list')
     def test_display_node_list_discovery_data(self):
-        # This test displays a list of the nodes along with 
-        # the associated BMC, RMM, and OBM settings for the discovered compute nodes 
+        # This test displays a list of the nodes along with
+        # the associated BMC, RMM, and OBM settings for the discovered compute nodes
         mondata = fit_common.rackhdapi("/api/2.0/nodes")
         nodes = mondata['json']
         result = mondata['status']
 
         if result == 200:
-            #print "result" + str(result)
+            # print "result" + str(result)
             # Display node info
-            print "\nNumber of nodes found: "+str(len(nodes))+"\n"
+            print "\nNumber of nodes found: " + str(len(nodes)) + "\n"
             i = 0
             for node in nodes:
                 i += 1
@@ -76,7 +73,7 @@ class display_rackhd_node_list(fit_common.unittest.TestCase):
                     else:
                         print "Not associated with a monorail enclosure"
                     # try to get the BMC info from the catalog
-                    monurl = "/api/2.0/nodes/"+nn+"/catalogs/bmc"
+                    monurl = "/api/2.0/nodes/" + nn + "/catalogs/bmc"
                     mondata = fit_common.rackhdapi(monurl, action="get")
                     catalog = mondata['json']
                     bmcresult = mondata['status']
@@ -95,7 +92,7 @@ class display_rackhd_node_list(fit_common.unittest.TestCase):
                         print "\t" + catalog["data"]["IP Address"],
                         print "\t" + catalog["data"]["IP Address Source"],
                     # Get RMM info from the catalog, if present
-                    rmmurl = "/api/2.0/nodes/"+nn+"/catalogs/rmm"
+                    rmmurl = "/api/2.0/nodes/" + nn + "/catalogs/rmm"
                     rmmdata = fit_common.rackhdapi(rmmurl, action="get")
                     rmmcatalog = rmmdata['json']
                     rmmresult = rmmdata['status']
@@ -106,7 +103,7 @@ class display_rackhd_node_list(fit_common.unittest.TestCase):
                         print "\t" + rmmcatalog["data"].get("IP Address", "-"),
                         print "\t" + rmmcatalog["data"].get("IP Address Source", "-") + "\t",
 
-                    nodeurl = "/api/2.0/nodes/"+nn
+                    nodeurl = "/api/2.0/nodes/" + nn
                     nodedata = fit_common.rackhdapi(nodeurl, action="get")
                     nodeinfo = nodedata['json']
                     result = nodedata['status']
@@ -125,9 +122,10 @@ class display_rackhd_node_list(fit_common.unittest.TestCase):
                                 print "Invalid or empty OBM setting"
                             else:
                                 print obmhost,
-                                print "\t" + obmlist[0]["config"].get("user","Error: No User defined!")
+                                print "\t" + obmlist[0]["config"].get("user", "Error: No User defined!")
         else:
             print "Cannot get RackHD nodes from stack, http response code: ", result
+
 
 if __name__ == '__main__':
     fit_common.unittest.main()

--- a/test/util/display_sysinfo_settings.py
+++ b/test/util/display_sysinfo_settings.py
@@ -1,0 +1,68 @@
+'''
+Copyright 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+Purpose:
+  This script will generate a list of discovered nodes and display the system information for the nodes
+'''
+
+import fit_path  # NOQA: unused import
+import fit_common
+
+fit_common.VERBOSIY = 1  # this is needed for suppressing debug messages to make reports readable
+
+
+class display_sysinfo(fit_common.unittest.TestCase):
+    def test_01_get_product_info(self):
+        print "============== Displaying Product Info"
+        nodes = fit_common.node_select()
+        if len(nodes) == 0:
+            print "No Nodes found on RackHD server "
+        else:
+            inode = 0
+            while inode < len(nodes):
+                nn = nodes[inode]
+                print "Node: " + nn
+                monurl = "/api/2.0/nodes/" + nn + "/catalogs/dmi"
+                mondata = fit_common.rackhdapi(monurl)
+                catalog = mondata['json']
+                result = mondata['status']
+
+                if result != 200:
+                    print "Error on catalog/dmi command"
+                else:
+                    # Check BMC IP vs OBM IP setting
+                    print " ID: " + catalog["id"]
+                    print " Product Name : " + catalog["data"]["System Information"]["Product Name"]
+                    print " Serial Number: " + catalog["data"]["System Information"]["Serial Number"]
+                    print " UUID         : " + catalog["data"]["System Information"]["UUID"]
+                inode += 1
+
+    def test_02_get_catalog_source(self):
+        print "============== Displaying Catalog Sources"
+        nodes = fit_common.node_select()
+        if len(nodes) == 0:
+            print "No Nodes found on RackHD server "
+        else:
+            inode = 0
+            while inode < len(nodes):
+                print("")
+                nn = nodes[inode]
+                print "Node: " + nn
+
+                monurl = "/api/2.0/nodes/" + nn + "/catalogs"
+                mondata = fit_common.rackhdapi(monurl)
+                catalog = mondata['json']
+                result = mondata['status']
+
+                if result != 200:
+                    print "Error: failed catalog request"
+                else:
+                    i = 0
+                    while i < len(catalog):
+                        print "Source: " + catalog[i]["source"]
+                        i += 1
+                inode += 1
+
+
+if __name__ == '__main__':
+    fit_common.unittest.main()

--- a/test/util/node_list.py
+++ b/test/util/node_list.py
@@ -11,7 +11,7 @@ import fit_common
 
 class test_list_nodes(fit_common.unittest.TestCase):
     def test_node_list(self):
-        fit_common.VERBOSITY = 1
+        fit_common.VERBOSITY = 1  # this is needed for suppressing debug messages to make reports readable
         print "\nNode List:"
         print "----------------------------------------------------------------------"
         skulist = fit_common.rackhdapi("/api/2.0/skus")['json']

--- a/test/util/node_list.py
+++ b/test/util/node_list.py
@@ -1,17 +1,11 @@
 '''
-Copyright 2016, EMC, Inc
+Copyright 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 
-This utility lists the number and type of compute nodes in a stack.
-
-Author(s):
-George Paulos
+Purpose:
+  This utility lists the number and type of compute nodes in a stack.
 '''
 
 import fit_path  # NOQA: unused import
-import os
-import sys
-import subprocess
-import argparse
 import fit_common
 
 
@@ -35,6 +29,6 @@ class test_list_nodes(fit_common.unittest.TestCase):
                     print "    " + node['id'] + " - Type: " + node['type']
         print
 
+
 if __name__ == '__main__':
     fit_common.unittest.main()
-

--- a/test/util/node_list.py
+++ b/test/util/node_list.py
@@ -20,14 +20,14 @@ class test_list_nodes(fit_common.unittest.TestCase):
         fit_common.VERBOSITY = 1
         print "\nNode List:"
         print "----------------------------------------------------------------------"
-        skulist = fit_common.rackhdapi("/api/1.1/skus")['json']
-        nodelist = fit_common.rackhdapi("/api/1.1/nodes")['json']
+        skulist = fit_common.rackhdapi("/api/2.0/skus")['json']
+        nodelist = fit_common.rackhdapi("/api/2.0/nodes")['json']
         for sku in skulist:
             nodecount = fit_common.json.dumps(nodelist).count(sku['id'])
             if nodecount > 0:
                 print sku['name'] + ": " + str(nodecount)
             for node in nodelist:
-                if 'sku' in node and  node['sku'] == sku['id']:
+                if 'sku' in node and str(sku['id']) in str(node['sku']):
                     print "    " + node['id'] + " - Type: " + node['type']
         print "Unknown:"
         for node in nodelist:


### PR DESCRIPTION
This PR fixes some technical debt in fit_common.py:

- removed obsolete function appliance_reset() which used BMC to reset the appliance in the old MN lab. No longer relevant, because it doesn't work with Vagrant or with ESXi stacks. Can just use remote_shell('reboot') for a reset.

- removed obsolete function apply_obm_settings_seq(), apply_obm_settings() is the current supported version

- fixed mongo_reset() which was set up for OnRack configuration and broken for current, Now works with RackHD source and package installations.

@hohene @larry-dean @jimturnquist @stuart-stanley @johren