### PR TITLE
RAC-4182 - Converted cit to fit format - redfish api scripts 

### DIFF
--- a/test/tests/api/tmp_fit_staging/redfish_1_0/managers_tests.py
+++ b/test/tests/api/tmp_fit_staging/redfish_1_0/managers_tests.py
@@ -1,113 +1,118 @@
-from config.redfish1_0_config import *
-from modules.logger import Log
+"""
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+"""
+import fit_path  # NOQA: unused import                                                                                          
+import unittest
+import flogging
+
+from config.redfish1_0_config import config
 from on_http_redfish_1_0 import RedfishvApi as redfish
 from on_http_redfish_1_0 import rest
-from datetime import datetime
-from proboscis.asserts import assert_equal
-from proboscis.asserts import assert_false
-from proboscis.asserts import assert_raises
-from proboscis.asserts import assert_not_equal
-from proboscis.asserts import assert_true
-from proboscis.asserts import assert_is
-from proboscis.asserts import assert_is_not_none
-from proboscis.asserts import fail
-from proboscis import SkipTest
-from proboscis import test
-from json import loads,dumps
-import re, time
+from json import loads, dumps
+from nosedep import depends
+from nose.plugins.attrib import attr
 
-LOG = Log(__name__)
+logs = flogging.get_loggers()
 
-@test(groups=['redfish.managers.tests'], depends_on_groups=['redfish.systems.tests'])
-class ManagersTests(object):
 
-    def __init__(self):
-        self.__client = config.api_client
-        self.__managersList = None
+# @test(groups=['redfish.managers.tests'], depends_on_groups=['redfish.systems.tests'])
+@attr(regression=True, smoke=True, managers_rf1_tests=True)
+class ManagersTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.__client = config.api_client
+        cls.__managersList = None
 
     def __get_data(self):
         return loads(self.__client.last_response.data)
 
-    @test(groups=['redfish.list_managers'])
+    # @test(groups=['redfish.list_managers'])
     def test_list_managers(self):
-        """ Testing GET /Managers """
+        # """ Testing GET /Managers """
         redfish().list_managers()
         manager = self.__get_data()
-        LOG.debug(manager,json=True)
-        assert_not_equal(0, len(manager), message='managers list was empty!')
-        self.__managersList = manager.get('Members')
-        assert_is_not_none(self.__managersList)
+        logs.debug(dumps(manager, indent=4))
+        self.assertNotEqual(0, len(manager), msg='managers list was empty!')
+        self.__class__.__managersList = manager.get('Members')
+        self.assertIsNotNone(self.__class__.__managersList, msg='Manager members section was not found')
+        self.assertNotEqual(len(self.__class__.__managersList), 0, msg='Manager members list is empty')
 
-    @test(groups=['redfish.get_manager'], depends_on_groups=['redfish.list_managers'])
+    # @test(groups=['redfish.get_manager'], depends_on_groups=['redfish.list_managers'])
+    @depends(after='test_list_managers')
     def test_get_manager(self):
-        """ Testing GET /Managers/{identifier} """
-        for member in self.__managersList:
+        # """ Testing GET /Managers/{identifier} """
+        for member in self.__class__.__managersList:
             dataId = member.get('@odata.id')
-            assert_is_not_none(dataId)
+            self.assertIsNotNone(dataId)
             dataId = dataId.split('/redfish/v1/Managers/')[1]
             redfish().get_manager(dataId)
             manager = self.__get_data()
-            LOG.debug(manager,json=True)
+            logs.debug(dumps(manager, indent=4))
             id = manager.get('Id')
-            assert_equal(dataId, id, message='unexpected id {0}, expected {1}'.format(id,dataId))
+            self.assertEqual(dataId, id, msg='unexpected id {0}, expected {1}'.format(id, dataId))
 
-    @test(groups=['redfish.get_manager_invalid'], depends_on_groups=['redfish.list_managers'])
+    # @test(groups=['redfish.get_manager_invalid'], depends_on_groups=['redfish.list_managers'])
+    @depends(after='test_list_managers')
     def test_get_manager_invalid(self):
-        """ Testing GET /Managers/{identifier} 404s properly """
-        for member in self.__managersList:
+        # """ Testing GET /Managers/{identifier} 404s properly """
+        for member in self.__class__.__managersList:
             dataId = member.get('@odata.id')
-            assert_is_not_none(dataId)
+            self.assertIsNotNone(dataId)
             dataId = dataId.split('/redfish/v1/Managers/')[1]
             try:
                 redfish().get_manager(dataId + '1')
-                fail(message='did not raise exception')
+                self.fail(msg='did not raise exception')
             except rest.ApiException as e:
-                assert_equal(404, e.status, message='unexpected response {0}, expected 404'.format(e.status))
+                self.assertEqual(404, e.status, msg='unexpected response {0}, expected 404'.format(e.status))
 
-    @test(groups=['redfish.list_manager_ethernet_interfaces'], depends_on_groups=['redfish.list_managers'])
+    # @test(groups=['redfish.list_manager_ethernet_interfaces'], depends_on_groups=['redfish.list_managers'])
+    @depends(after='test_list_managers')
     def test_list_manager_ethernet_interfaces(self):
-        """ Testing GET /Managers/{identifier}/EthernetInterfaces """
-        for member in self.__managersList:
+        # """ Testing GET /Managers/{identifier}/EthernetInterfaces """
+        for member in self.__class__.__managersList:
             dataId = member.get('@odata.id')
-            assert_is_not_none(dataId)
+            self.assertIsNotNone(dataId)
             dataId = dataId.split('/redfish/v1/Managers/')[1]
             redfish().list_manager_ethernet_interfaces(dataId)
             interface = self.__get_data()
-            LOG.debug(interface,json=True)
+            logs.debug(dumps(interface, indent=4))
             count = interface.get('Members@odata.count')
-            assert_true(count >= 1, message='expected count to be >= 1')
+            self.assertTrue(count >= 1, msg='expected count to be >= 1')
 
-    @test(groups=['redfish.list_manager_ethernet_interfaces_invalid'], depends_on_groups=['redfish.list_managers'])
+    # @test(groups=['redfish.list_manager_ethernet_interfaces_invalid'], depends_on_groups=['redfish.list_managers'])
+    @depends(after='test_list_managers')
     def test_list_manager_ethernet_interfaces_invalid(self):
-        """ Testing GET /Managers/{identifier}/EthernetInterfaces 404s properly """
-        for member in self.__managersList:
+        # """ Testing GET /Managers/{identifier}/EthernetInterfaces 404s properly """
+        for member in self.__class__.__managersList:
             dataId = member.get('@odata.id')
-            assert_is_not_none(dataId)
+            self.assertIsNotNone(dataId)
             dataId = dataId.split('/redfish/v1/Managers/')[1]
             try:
                 redfish().list_manager_ethernet_interfaces(dataId + '1')
-                fail(message='did not raise exception')
+                self.fail(msg='did not raise exception')
             except rest.ApiException as e:
-                assert_equal(404, e.status, message='unexpected response {0}, expected 404'.format(e.status))
+                self.assertEqual(404, e.status, msg='unexpected response {0}, expected 404'.format(e.status))
 
-    @test(groups=['redfish.get_manager_ethernet_interface'], depends_on_groups=['redfish.list_manager_ethernet_interfaces'])
+    # @test(groups=['redfish.get_manager_ethernet_interface'], depends_on_groups=['redfish.list_manager_ethernet_interfaces'])
+    @depends(after='test_list_manager_ethernet_interfaces')
     def test_get_manager_ethernet_interface(self):
-        """ Testing GET /Managers/{identifier}/EthernetInterfaces/{id} """
-        for member in self.__managersList:
+        # """ Testing GET /Managers/{identifier}/EthernetInterfaces/{id} """
+        for member in self.__class__.__managersList:
             dataId = member.get('@odata.id')
-            assert_is_not_none(dataId)
+            self.assertIsNotNone(dataId)
             dataId = dataId.split('/redfish/v1/Managers/')[1]
             redfish().list_manager_ethernet_interfaces(dataId)
-            managers = self.__get_data();
+            managers = self.__get_data()
             for manager in managers.get('Members'):
                 odata_id = manager.get('@odata.id')
-                req_id = odata_id.split('/redfish/v1/Managers/'+dataId+'/EthernetInterfaces/')[1]
+                req_id = odata_id.split('/redfish/v1/Managers/' + dataId + '/EthernetInterfaces/')[1]
                 redfish().get_manager_ethernet_interface(dataId, req_id)
                 interface = self.__get_data()
-                LOG.debug(interface,json=True)
+                logs.debug(dumps(interface, indent=4))
                 id = interface.get('Id')
-                assert_equal(req_id, id, message='unexpected id {0}, expected {1}'.format(id,dataId))
+                self.assertEqual(req_id, id, msg='unexpected id {0}, expected {1}'.format(id, dataId))
                 ipv4 = interface.get('IPv4Addresses')
-                assert_is_not_none(ipv4)
-                assert_not_equal(0, len(ipv4), message='ipv4 list was empty!')
-
+                self.assertIsNotNone(ipv4)
+                self.assertNotEqual(0, len(ipv4), msg='ipv4 list was empty!')

--- a/test/tests/api/tmp_fit_staging/redfish_1_0/systems_tests.py
+++ b/test/tests/api/tmp_fit_staging/redfish_1_0/systems_tests.py
@@ -1,256 +1,268 @@
-from config.redfish1_0_config import *
-from modules.logger import Log
+"""
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+"""
+import fit_path  # NOQA: unused import                                                                                          
+import unittest
+import flogging
+import re
+import time
+
+from config.redfish1_0_config import config
 from on_http_redfish_1_0 import RedfishvApi as redfish
 from on_http_redfish_1_0 import rest
-from datetime import datetime
-from proboscis.asserts import assert_equal
-from proboscis.asserts import assert_false
-from proboscis.asserts import assert_raises
-from proboscis.asserts import assert_not_equal
-from proboscis.asserts import assert_true
-from proboscis.asserts import assert_is
-from proboscis.asserts import assert_is_not_none
-from proboscis.asserts import fail
-from proboscis import SkipTest
-from proboscis import test
-from json import loads,dumps
-import re, time
+from json import loads, dumps
+from nosedep import depends
+from nose.plugins.attrib import attr
 
-LOG = Log(__name__)
+logs = flogging.get_loggers()
 
-@test(groups=['redfish.systems.tests'], depends_on_groups=['redfish.chassis.tests'])
-class SystemsTests(object):
 
-    def __init__(self):
-        self.__client = config.api_client
-        self.__systemsList = None
-        self.__membersList = None
-        self.__systemProcessorsList = None
-        self.__simpleStorageList = None
-        self.__logServicesList = None
-        self.__resetActionTypes = None
-        self.__bootImageTypes = None
+# @test(groups=['redfish.systems.tests'], depends_on_groups=['redfish.chassis.tests'])
+@attr(regression=True, smoke=True, system_rf1_tests=True)
+class SystemsTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.__client = config.api_client
+        cls.__systemsList = None
+        cls.__membersList = None
+        cls.__systemProcessorsList = None
+        cls.__simpleStorageList = None
+        cls.__logServicesList = None
+        cls.__resetActionTypes = None
+        cls.__bootImageTypes = None
 
     def __get_data(self):
         return loads(self.__client.last_response.data)
 
-    @test(groups=['redfish.list_systems'])
+    # @test(groups=['redfish.list_systems'])
     def test_list_systems(self):
-        """ Testing GET /Systems """
+        # """ Testing GET /Systems """
         redfish().list_systems()
-        self.__systemsList = self.__get_data()
-        LOG.debug(self.__systemsList,json=True)
-        assert_not_equal(0, len(self.__systemsList), message='systems list was empty!')
-        
-    @test(groups=['redfish.get_systems'],\
-            depends_on_groups=['redfish.list_systems'])
+        self.__class__.__systemsList = self.__get_data()
+        logs.debug(dumps(self.__class__.__systemsList, indent=4))
+        self.assertNotEqual(0, len(self.__class__.__systemsList), msg='systems list was empty!')
+
+    # @test(groups=['redfish.get_systems'],\
+    #        depends_on_groups=['redfish.list_systems'])
+    @depends(after='test_list_systems')
     def test_get_systems(self):
-        """ Testing GET /Systems/{identifier} """
-        self.__membersList = self.__systemsList.get('Members')
-        assert_is_not_none(self.__membersList)
-        for member in self.__membersList:
+        # """ Testing GET /Systems/{identifier} """
+        self.__class__.__membersList = self.__class__.__systemsList.get('Members')
+        self.assertIsNotNone(self.__class__.__membersList)
+        for member in self.__class__.__membersList:
             dataId = member.get('@odata.id')
-            assert_is_not_none(dataId)
+            self.assertIsNotNone(dataId)
             dataId = dataId.split('/redfish/v1/Systems/')[1]
             redfish().get_system(dataId)
             systems = self.__get_data()
-            LOG.debug(systems,json=True)
+            logs.debug(dumps(systems, indent=4))
             id = systems.get('Id')
-            assert_equal(dataId, id, message='unexpected id {0}, expected {1}'.format(id,dataId))
+            self.assertEqual(dataId, id, msg='unexpected id {0}, expected {1}'.format(id, dataId))
 
-    @test(groups=['redfish.list_system_processors'],\
-            depends_on_groups=['redfish.get_systems'])
+    # @test(groups=['redfish.list_system_processors'],\
+    #        depends_on_groups=['redfish.get_systems'])
+    @depends(after='test_get_systems')
     def test_list_system_processors(self):
-        """ Testing GET /Systems/{identifier}/Processors """
-        self.__membersList = self.__systemsList.get('Members')
-        assert_is_not_none(self.__membersList)
-        for member in self.__membersList:
+        # """ Testing GET /Systems/{identifier}/Processors """
+        self.__class__.__membersList = self.__class__.__systemsList.get('Members')
+        self.assertIsNotNone(self.__class__.__membersList)
+        for member in self.__class__.__membersList:
             dataId = member.get('@odata.id')
-            assert_is_not_none(dataId)
+            self.assertIsNotNone(dataId)
             dataId = dataId.split('/redfish/v1/Systems/')[1]
             redfish().list_system_processors(dataId)
-            self.__systemProcessorsList = self.__get_data()
-            LOG.debug(self.__systemProcessorsList,json=True)
-            membersList = self.__systemProcessorsList.get('Members')
-            assert_is_not_none(membersList, message='missing processor members field!')
-            count = self.__systemProcessorsList.get('Members@odata.count')
-            assert_is_not_none(count, message='missing processor member count field!')
-            assert_equal(count,len(membersList))
+            self.__class__.__systemProcessorsList = self.__get_data()
+            logs.debug(dumps(self.__class__.__systemProcessorsList, indent=4))
+            membersList = self.__class__.__systemProcessorsList.get('Members')
+            self.assertIsNotNone(membersList, msg='missing processor members field!')
+            count = self.__class__.__systemProcessorsList.get('Members@odata.count')
+            self.assertIsNotNone(count, msg='missing processor member count field!')
+            self.assertEqual(count, len(membersList))
 
-    @test(groups=['redfish.get_system_processor'],\
-            depends_on_groups=['redfish.list_system_processors'])
+    # @test(groups=['redfish.get_system_processor'],\
+    #        depends_on_groups=['redfish.list_system_processors'])
+    @depends(after='test_list_system_processors')
     def test_get_system_processor(self):
-        """ Testing GET /Systems/{identifier}/Processors/{socket} """
-        assert_is_not_none(self.__membersList)
-        membersList = self.__systemProcessorsList.get('Members')
-        assert_is_not_none(membersList, message='missing processor members field!')
+        # """ Testing GET /Systems/{identifier}/Processors/{socket} """
+        self.assertIsNotNone(self.__class__.__membersList)
+        membersList = self.__class__.__systemProcessorsList.get('Members')
+        self.assertIsNotNone(membersList, msg='missing processor members field!')
         socket = 0
         for member in membersList:
             dataId = member.get('@odata.id')
-            assert_is_not_none(dataId)
-            id = re.compile(r'/Processors/[0-9]+').split(dataId)[0]\
-                    .split('/redfish/v1/Systems/')[1]
+            self.assertIsNotNone(dataId)
+            id = re.compile(r'/Processors/[0-9]+').split(dataId)[0].split('/redfish/v1/Systems/')[1]
             redfish().get_system_processor(id, socket)
             processor = self.__get_data()
-            LOG.debug(processor,json=True)
+            logs.debug(dumps(processor, indent=4))
             procId = processor.get('@odata.id')
-            assert_equal(dataId,procId)
-            socket = socket + 1
+            self.assertEqual(dataId, procId)
+            socket += 1
 
-    @test(groups=['redfish.list_system_simplestorage'],\
-            depends_on_groups=['redfish.get_systems'])
+    # @test(groups=['redfish.list_system_simplestorage'],\
+    #        depends_on_groups=['redfish.get_systems'])
+    @depends(after='test_get_systems')
     def test_list_simple_storage(self):
-        """ Testing GET /Systems/{identifier}/SimpleStorage """
-        self.__membersList = self.__systemsList.get('Members')
-        assert_is_not_none(self.__membersList)
-        for member in self.__membersList:
+        # """ Testing GET /Systems/{identifier}/SimpleStorage """
+        self.__class__.__membersList = self.__class__.__systemsList.get('Members')
+        self.assertIsNotNone(self.__class__.__membersList)
+        for member in self.__class__.__membersList:
             dataId = member.get('@odata.id')
-            assert_is_not_none(dataId)
+            self.assertIsNotNone(dataId)
             dataId = dataId.split('/redfish/v1/Systems/')[1]
             redfish().list_simple_storage(dataId)
-            self.__simpleStorageList = self.__get_data()
-            LOG.debug(self.__simpleStorageList,json=True)
-            membersList = self.__simpleStorageList.get('Members')
-            assert_is_not_none(membersList, message='missing simplestorage members field!')
-            count = self.__simpleStorageList.get('Members@odata.count')
-            assert_is_not_none(count, message='missing simple storage member count field!')
-            assert_equal(count,len(membersList))
+            self.__class__.__simpleStorageList = self.__get_data()
+            logs.debug(dumps(self.__class__.__simpleStorageList, indent=4))
+            membersList = self.__class__.__simpleStorageList.get('Members')
+            self.assertIsNotNone(membersList, msg='missing simplestorage members field!')
+            count = self.__class__.__simpleStorageList.get('Members@odata.count')
+            self.assertIsNotNone(count, msg='missing simple storage member count field!')
+            self.assertEqual(count, len(membersList))
 
-    @test(groups=['redfish.get_system_simplestorage'],\
-            depends_on_groups=['redfish.list_system_simplestorage'])
+    # @test(groups=['redfish.get_system_simplestorage'],\
+    #      depends_on_groups=['redfish.list_system_simplestorage'])
+    @depends(after='test_list_simple_storage')
     def test_get_simple_storage(self):
-        """ Testing GET /Systems/{identifier}/SimpleStorage/{index} """
-        assert_is_not_none(self.__membersList)
-        membersList = self.__simpleStorageList.get('Members')
-        assert_is_not_none(membersList, message='missing simple storage members field!')
+        # """ Testing GET /Systems/{identifier}/SimpleStorage/{index} """
+        self.assertIsNotNone(self.__class__.__membersList)
+        membersList = self.__class__.__simpleStorageList.get('Members')
+        self.assertIsNotNone(membersList, msg='missing simple storage members field!')
         for member in membersList:
             dataId = member.get('@odata.id')
-            assert_is_not_none(dataId)
+            self.assertIsNotNone(dataId)
             index = dataId.split('/SimpleStorage/')[1]
-            id = re.compile(r'/SimpleStorage/[0-9]+').split(dataId)[0]\
-                    .split('/redfish/v1/Systems/')[1]
+            id = re.compile(r'/SimpleStorage/[0-9]+').split(dataId)[0].split('/redfish/v1/Systems/')[1]
             redfish().get_simple_storage(id, index)
             storage = self.__get_data()
-            LOG.debug(storage,json=True)
+            logs.debug(dumps(storage, indent=4))
             storageId = storage.get('@odata.id')
-            assert_equal(dataId,storageId)
+            self.assertEqual(dataId, storageId)
 
-    @test(groups=['redfish.list_system_log_services'],\
-            depends_on_groups=['redfish.get_systems'])
-    def test_list_log_servives(self):
-        """ Testing GET /Systems/{identifier}/LogServices """
-        self.__membersList = self.__systemsList.get('Members')
-        assert_is_not_none(self.__membersList)
-        for member in self.__membersList:
+    # @test(groups=['redfish.list_system_log_services'],\
+    #        depends_on_groups=['redfish.get_systems'])
+    @depends(after='test_get_systems')
+    def test_list_log_services(self):
+        # """ Testing GET /Systems/{identifier}/LogServices """
+        self.__class__.__membersList = self.__class__.__systemsList.get('Members')
+        self.assertIsNotNone(self.__class__.__membersList)
+        for member in self.__class__.__membersList:
             dataId = member.get('@odata.id')
-            assert_is_not_none(dataId)
+            self.assertIsNotNone(dataId)
             dataId = dataId.split('/redfish/v1/Systems/')[1]
             redfish().list_log_service(dataId)
-            self.__logServicesList = self.__get_data()
-            LOG.debug(self.__logServicesList,json=True)
-            membersList = self.__logServicesList.get('Members')
-            assert_is_not_none(membersList, message='missing logservices members field!')
-            count = self.__logServicesList.get('Members@odata.count')
-            assert_is_not_none(count, message='missing logservices member count field!')
-            assert_equal(count,len(membersList))
+            self.__class__.__logServicesList = self.__get_data()
+            logs.debug(dumps(self.__class__.__logServicesList, indent=4))
+            membersList = self.__class__.__logServicesList.get('Members')
+            self.assertIsNotNone(membersList, msg='missing logservices members field!')
+            count = self.__class__.__logServicesList.get('Members@odata.count')
+            self.assertIsNotNone(count, msg='missing logservices member count field!')
+            self.assertEqual(count, len(membersList))
 
-    @test(groups=['redfish.get_sel_log_service'],\
-            depends_on_groups=['redfish.list_system_log_services'])
+    # @test(groups=['redfish.get_sel_log_service'],\
+    #        depends_on_groups=['redfish.list_system_log_services'])
+    @depends(after='test_list_log_services')
     def test_get_sel_log_services(self):
-        """ Testing GET /Systems/{identifier}/LogServices/sel """
-        assert_is_not_none(self.__membersList)
-        membersList = self.__logServicesList.get('Members')
-        assert_is_not_none(membersList, message='missing log services members field!')
+        # """ Testing GET /Systems/{identifier}/LogServices/sel """
+        self.assertIsNotNone(self.__class__.__membersList)
+        membersList = self.__class__.__logServicesList.get('Members')
+        self.assertIsNotNone(membersList, msg='missing log services members field!')
         for member in membersList:
             dataId = member.get('@odata.id')
-            assert_is_not_none(dataId)
-            id = re.compile(r'/LogServices').split(dataId)[0]\
-                    .split('/redfish/v1/Systems/')[1]
+            self.assertIsNotNone(dataId)
+            id = re.compile(r'/LogServices').split(dataId)[0].split('/redfish/v1/Systems/')[1]
+            logs.info("System ID: %s ", id)
             redfish().get_sel_log_service(id)
             sel = self.__get_data()
-            LOG.debug(sel,json=True)
+            logs.debug(dumps(sel, indent=4))
             selId = sel.get('@odata.id')
-            assert_equal(dataId,selId)
+            self.assertEqual(dataId, selId)
 
-    @test(groups=['redfish.get_sel_log_service_entries'],\
-            depends_on_groups=['redfish.list_system_log_services'])
+    # @test(groups=['redfish.get_sel_log_service_entries'],\
+    #        depends_on_groups=['redfish.list_system_log_services'])
+    @depends(after='test_list_log_services')
     def test_get_sel_log_services_entries(self):
-        """ Testing GET /Systems/{identifier}/LogServices/sel/Entries """
-        assert_is_not_none( self.__membersList)
-        membersList = self.__logServicesList.get('Members')
-        assert_is_not_none(membersList, message='missing log services members field!')
+        # """ Testing GET /Systems/{identifier}/LogServices/sel/Entries """
+        self.assertIsNotNone(self.__class__.__membersList)
+        membersList = self.__class__.__logServicesList.get('Members')
+        self.assertIsNotNone(membersList, msg='missing log services members field!')
         for member in membersList:
             dataId = member.get('@odata.id')
-            assert_is_not_none(dataId)
-            id = re.compile(r'/LogServices').split(dataId)[0]\
-                    .split('/redfish/v1/Systems/')[1]
+            self.assertIsNotNone(dataId)
+            id = re.compile(r'/LogServices').split(dataId)[0].split('/redfish/v1/Systems/')[1]
+            logs.info("System ID: %s ", id)
             redfish().list_sel_log_service_entries(id)
             entries = self.__get_data()
-            assert_not_equal({},entries)
+            self.assertNotEqual({}, entries)
             # Should validate the SEL entries here
             # Leaving as TODO until a 'add_sel' task is available
-            LOG.debug(entries,json=True)
+            logs.debug(dumps(entries, indent=4))
 
-
-    @test(groups=['redfish.get_sel_log_service_entries_entryid'],\
-            depends_on_groups=['redfish.get_sel_log_service_entries'])
+    # @test(groups=['redfish.get_sel_log_service_entries_entryid'],\
+    #        depends_on_groups=['redfish.get_sel_log_service_entries'])
+    @depends(after='test_get_sel_log_services_entries')
     def test_get_sel_log_services_entries_entryid(self):
-        """ Testing GET /Systems/{identifier}/LogServices/sel/Entries/{entryId} """
+        # """ Testing GET /Systems/{identifier}/LogServices/sel/Entries/{entryId} """
         # TODO Add more validation when a 'add_sel' task is available
-        assert_is_not_none( self.__membersList)
-        membersList = self.__logServicesList.get('Members')
-        assert_is_not_none(membersList, message='missing log services members field!')
+        self.assertIsNotNone(self.__class__.__membersList)
+        membersList = self.__class__.__logServicesList.get('Members')
+        self.assertIsNotNone(membersList, msg='missing log services members field!')
 
-    @test(groups=['redfish.get_systems_actions_reset'],\
-            depends_on_groups=['redfish.get_systems'])
+    # @test(groups=['redfish.get_systems_actions_reset'],\
+    #        depends_on_groups=['redfish.get_systems'])
+    @depends(after='test_get_systems')
     def test_get_systems_actions_reset(self):
-        """ Testing GET /Systems/{identifier}/Actions/ComputerSystem.Reset """
-        self.__membersList = self.__systemsList.get('Members')
-        assert_is_not_none( self.__membersList)
-        for member in self.__membersList:
+        # """ Testing GET /Systems/{identifier}/Actions/ComputerSystem.Reset """
+        self.__class__.__membersList = self.__class__.__systemsList.get('Members')
+        self.assertIsNotNone(self.__class__.__membersList)
+        for member in self.__class__.__membersList:
             dataId = member.get('@odata.id')
-            assert_is_not_none(dataId)
+            self.assertIsNotNone(dataId)
             dataId = dataId.split('/redfish/v1/Systems/')[1]
+            logs.info("System ID: %s ", dataId)
             redfish().list_reset_types(dataId)
             reset_actions = self.__get_data()
-            LOG.debug(reset_actions,json=True)
-            self.__resetActionTypes = reset_actions.get('reset_type@Redfish.AllowableValues')
-            assert_equal(dumps(self.__resetActionTypes), dumps(['On',\
-                                                                'ForceOff',\
-                                                                'GracefulRestart',\
-                                                                'ForceRestart',\
-                                                                'ForceOn',\
-                                                                'PushPowerButton']))
+            logs.debug(dumps(reset_actions, indent=4))
+            self.__class__.__resetActionTypes = reset_actions.get('reset_type@Redfish.AllowableValues')
+            self.assertEqual(dumps(self.__class__.__resetActionTypes), dumps(['On',
+                                                                              'ForceOff',
+                                                                              'GracefulRestart',
+                                                                              'ForceRestart',
+                                                                              'ForceOn',
+                                                                              'PushPowerButton']))
 
     # @test(groups=['redfish.post_systems_actions_reset'],\
     #        depends_on_groups=['redfish.get_systems_actions_reset'])
+    @depends(after='test_get_systems_actions_reset')
     def test_post_systems_actions_reset(self):
-        """ Testing POST /Systems/{identifier}/Actions/ComputerSystem.Reset """
-        self.__membersList = self.__systemsList.get('Members')
-        assert_is_not_none(self.__membersList)
-        assert_is_not_none(self.__resetActionTypes)
-        for member in self.__membersList:
+        # """ Testing POST /Systems/{identifier}/Actions/ComputerSystem.Reset """
+        self.__class__.__membersList = self.__class__.__systemsList.get('Members')
+        self.assertIsNotNone(self.__class__.__membersList)
+        self.assertIsNotNone(self.__class__.__resetActionTypes)
+        for member in self.__class__.__membersList:
             actionsCompleted = 0
             dataId = member.get('@odata.id')
-            assert_not_equal(0,len(dataId))
+            self.assertNotEqual(0, len(dataId))
             dataId = dataId.split('/redfish/v1/Systems/')[1]
-            for action in self.__resetActionTypes:
-                if action == 'PushPowerButton': # skip manual test
-                    LOG.warning('skipping \"PushPowerButton\" reset action')
+            logs.info("System ID: %s ", dataId)
+            for action in self.__class__.__resetActionTypes:
+                if action == 'PushPowerButton':     # skip manual test
+                    logs.warning('skipping "PushPowerButton" reset action')
                     continue
-                LOG.info('testing reset action {0}'.format(action))
+                logs.info('testing reset action "%s" for %s', action, dataId)
                 try:
-                    redfish().do_reset(dataId,{'reset_type': action})
+                    redfish().do_reset(dataId, {'reset_type': action})
                 except rest.ApiException as err:
                     message = loads(err.body)['message']
                     if message == 'value not found in map':
-                        LOG.warning('{0} for \"{1}\", skipping..'.format(message,action))
+                        logs.warning('%s for "%s", skipping..', message, action)
                         continue
                     else:
                         raise(err)
                 task = self.__get_data()
                 taskId = task.get('@odata.id')
-                assert_is_not_none(taskId)
+                self.assertIsNotNone(taskId)
                 taskId = taskId.split('/redfish/v1/TaskService/Tasks/')[1]
                 timeout = 20
                 while timeout > 0:
@@ -258,48 +270,49 @@ class SystemsTests(object):
                     taskInfo = self.__get_data()
                     taskState = taskInfo.get('TaskState')
                     taskStatus = taskInfo.get('TaskStatus')
-                    assert_is_not_none(taskState)
-                    assert_is_not_none(taskStatus)
-                    if taskState == "Completed" and \
-                       taskStatus == "OK":
+                    self.assertIsNotNone(taskState)
+                    self.assertIsNotNone(taskStatus)
+                    if taskState == "Completed" and taskStatus == "OK":
                         actionsCompleted += 1
                         break
-                    LOG.warning('waiting for reset action {0} (state={1},status={2})' \
-                            .format(action, taskState, taskStatus))
+                    logs.warning('waiting for reset action %s (state=%s, status=%s)',
+                                 action, taskState, taskStatus)
                     timeout -= 1
-                    time.sleep(1)
+                    time.sleep(2)
                 if timeout == 0:
-                    fail('timed out waiting for reset action {0}'.format(action))
+                    self.fail('timed out waiting for reset action {0}'.format(action))
             if actionsCompleted == 0:
-                fail('no reset actions were completed for id {0}'.format(dataId))
+                self.fail('no reset actions were completed for id {0}'.format(dataId))
 
-    @test(groups=['redfish.get_systems_actions_bootimage'],\
-            depends_on_groups=['redfish.get_systems'])
+    # @test(groups=['redfish.get_systems_actions_bootimage'],\
+    #        depends_on_groups=['redfish.get_systems'])
+    @depends(after='test_get_systems')
     def test_get_systems_actions_bootimage(self):
-        """ Testing GET /Systems/{identifier}/Actions/RackHD.BootImage """
-        self.__membersList = self.__systemsList.get('Members')
-        assert_is_not_none(self.__membersList)
-        for member in self.__membersList:
+        # """ Testing GET /Systems/{identifier}/Actions/RackHD.BootImage """
+        self.__class__.__membersList = self.__class__.__systemsList.get('Members')
+        self.assertIsNotNone(self.__class__.__membersList)
+        for member in self.__class__.__membersList:
             dataId = member.get('@odata.id')
-            assert_is_not_none(dataId)
+            self.assertIsNotNone(dataId)
             dataId = dataId.split('/redfish/v1/Systems/')[1]
+            logs.info("System ID: %s ", dataId)
             redfish().list_boot_image(dataId)
             bootImages = self.__get_data()
-            LOG.debug(bootImages,json=True)
-            self.__bootImageTypes = bootImages.get('osNames@Redfish.AllowableValues')
-            assert_is_not_none(self.__bootImageTypes)
-            assert_equal(dumps(self.__bootImageTypes), dumps(['CentOS',\
-                                                              'CentOS+KVM',\
-                                                              'ESXi',\
-                                                              'RHEL',\
-                                                              'RHEL+KVM']))
+            logs.debug(dumps(bootImages, indent=4))
+            self.__class__.__bootImageTypes = bootImages.get('osNames@Redfish.AllowableValues')
+            self.assertIsNotNone(self.__class__.__bootImageTypes)
+            self.assertEqual(dumps(self.__class__.__bootImageTypes), dumps(['CentOS',
+                                                                            'CentOS+KVM',
+                                                                            'ESXi',
+                                                                            'RHEL',
+                                                                            'RHEL+KVM']))
 
-    @test(groups=['redfish.post_systems_actions_bootimage'],\
-            depends_on_groups=['redfish.get_systems_actions_bootimage'])
+    # @test(groups=['redfish.post_systems_actions_bootimage'],\
+    #        depends_on_groups=['redfish.get_systems_actions_bootimage'])
+    @depends(after='test_get_systems_actions_bootimage')
     def test_post_systems_actions_bootimage(self):
-        """ Testing POST /Systems/{identifier}/Actions/RackHD.BootImage """
+        # """ Testing POST /Systems/{identifier}/Actions/RackHD.BootImage """
         # TODO run some OS installer workflows
-        self.__membersList = self.__systemsList.get('Members')
-        assert_is_not_none(self.__membersList)
-        assert_is_not_none(self.__bootImageTypes)
-
+        self.__class__.__membersList = self.__class__.__systemsList.get('Members')
+        self.assertIsNotNone(self.__class__.__membersList)
+        self.assertIsNotNone(self.__class__.__bootImageTypes)


### PR DESCRIPTION
First set of redfish CIT to FIT converted scripts for review.  chassis, system, management.
The tests aren't enabled yet in smoke, but I have 'enabled' and tested outside of this PR against vagrant and physical stacks.

This is part of step 2 in associated PR 673.
Plan is now:
    1. copy the original scripts into this staging area (this PR)
    2. apply the converted script on top do show the diffs only for review
    3. mv the script and allow the converted script to run in FIT smoke suite.

@johren @dalebremner @brianparry @larry-dean @gpaulos @jimturnquist @keedya 