### PR TITLE
RAC-4182 - Adding converted CIT redfish v1 scripts into staging.

### DIFF
--- a/test/tests/api/tmp_fit_staging/redfish_1_0/event_service_tests.py
+++ b/test/tests/api/tmp_fit_staging/redfish_1_0/event_service_tests.py
@@ -1,129 +1,165 @@
-from config.redfish1_0_config import *
-from config.settings import *
-from on_http_redfish_1_0 import RedfishvApi as redfish
-from modules.httpd import Httpd, BaseHandler, open_ssh_forward
-from modules.logger import Log
-from modules.worker import WorkerThread, WorkerTasks
-from proboscis.asserts import assert_equal
-from proboscis.asserts import assert_false
-from proboscis.asserts import assert_raises
-from proboscis.asserts import assert_not_equal
-from proboscis.asserts import assert_true
-from proboscis.asserts import assert_is_not_none
-from proboscis.asserts import fail
-from proboscis import SkipTest
-from proboscis import test
-from json import loads
+"""
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+"""
+import fit_path  # NOQA: unused import                                                                                          
+import unittest
+import flogging
 import thread
 
-LOG = Log(__name__)
+from config.redfish1_0_config import config
+from config.settings import HTTPD_PORT
+from on_http_redfish_1_0 import RedfishvApi as redfish
+from modules.worker import WorkerThread, WorkerTasks
+from modules.httpd import Httpd, BaseHandler, open_ssh_forward
+from json import loads, dumps
+from nosedep import depends
+from nose.plugins.attrib import attr
 
-@test(groups=['redfish.event_service.tests'])
-class EventServiceTests(object):
-    def __init__(self):
+logs = flogging.get_loggers()
+
+
+# @test(groups=['redfish.event_service.tests'])
+@attr(regression=True, smoke=True, event_service_rf1_tests=True)
+class EventServiceTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.eventHandlerFailed = False
+
+    def setUp(self):
+        self.__client = config.api_client
         self.__client = config.api_client
         self.__httpd_port = 9995
-        
+
     def __get_data(self):
         return loads(self.__client.last_response.data)
 
-    def __httpd_start(self,worker,id):
+    def __httpd_start(self, worker, id):
         worker.start()
 
     class EventServiceHandler(BaseHandler):
         def do_POST(self):
+            self.__class__.eventHandlerFailed = False
             self._set_headers()
-            content_length = int(self.headers.getheader('content-length'),0)
+            content_length = int(self.headers.getheader('content-length'), 0)
             body = loads(self.rfile.read(content_length))
-            LOG.info(body,json=True)
+            logs.info(dumps(body, indent=4))
+
             def shutdown(task):
                 task.worker.stop()
                 task.running = False
-            thread.start_new_thread(shutdown, (task,)) # spawn thread to avoid deadlock
-            assert_equal(subscription.get('Id'), body.get('MemberId'))
-    
-    @test(groups=['redfish.event_service_root'])
+            thread.start_new_thread(shutdown, (task,))  # spawn thread to avoid deadlock
+            if str(subscription.get('Id')) != str(body.get('MemberId')):
+                # unittest does not catch the assertion inside a non-unittest class,
+                # so setting class variable for the test to catch
+                self.__class__.eventHandlerFailed = True
+                logs.error("Subscription Id: %s does not match MemberId: %s",
+                           str(subscription.get('Id')),
+                           str(body.get('MemberId')))
+                raise AssertionError("Subscription Id: {} does not match MemberId: {}".format(str(subscription.get('Id')),
+                                                                                              str(body.get('MemberId'))))
+
+    # @test(groups=['redfish.event_service_root'])
     def test_event_service_root(self):
-        """ Testing GET /EventService """
+        # """ Testing GET /EventService """
         redfish().event_service_root()
-        data = self.__get_data()
         status = self.__client.last_response.status
-        assert_equal(200, status, message='unexpected status')
-    
-    @test(groups=['redfish.create_subscription'], \
-          depends_on_groups=['redfish.event_service_root'])
-    def test_create_event_subscription(self):
-        """ Testing POST /EventService/Subscription  """
-        global subscription 
-        payload = {
-            'Id': '12345',
-            'Name': 'Alert 1',
-            'Destination': 'http://localhost:{0}'.format(self.__httpd_port), 
-            'EventTypes': ['Alert'], 
-            'Context': 'Client Alerting', 
-            'Protocol': 'Redfish' 
-        }
-        redfish().create_subscription(payload)
-        subscription = self.__get_data()
-        assert_is_not_none(subscription)
-        LOG.info(subscription,json=True)
-        status = self.__client.last_response.status
-        assert_equal(201, status, message='unexpected status on create')
-        
-    @test(groups=['redfish.subscriptions_collection'], \
-          depends_on_groups=['redfish.create_subscription'])
-    def test_get_event_subscription(self):
-        """ Testing GET /EventService/Subscription/:id  """
-        redfish().get_event(subscription.get('Id'))
-        data = self.__get_data()
-        status = self.__client.last_response.status
-        assert_equal(200, status, message='unexpected status')
-        assert_equal(subscription.get('Id'), data.get('Id'), \
-            message='subscription id not found')
-        
-    @test(groups=['redfish.submit_test_event'], \
-          depends_on_groups=['redfish.create_subscription'])
-    def test_submit_test_event(self):
-        """ Testing POST /EventService/SubmitTestEvent  """
-        global task
-        server = Httpd(port=int(HTTPD_PORT), handler_class=self.EventServiceHandler)
-        task = WorkerThread(server,'httpd')
-        worker = WorkerTasks(tasks=[task], func=self.__httpd_start)
-        worker.run()
-        
-        # forward port for services running on a guest host
-        session = open_ssh_forward(self.__httpd_port) 
-        
-        redfish().test_event(body={})
-        worker.wait_for_completion(timeout_sec=60)
-        session.logout()
-        assert_false(task.timeout, message='timeout waiting for task {0}'.format(task.id))
-   
-    @test(groups=['redfish.subscriptions_collection'], \
-          depends_on_groups=['redfish.submit_test_event'])
-    def test_subscription_collection(self):
-        """ Testing GET /EventService/Subscription  """
-        redfish().get_events_collection()
-        data = self.__get_data()
-        status = self.__client.last_response.status
-        assert_equal(200, status, message='unexpected status on GET')
-        ids = []
-        for member in data.get('Members'):
-            ids.append(member.get('@odata.id') \
-                .split('/redfish/v1/EventService/Subscriptions/')[1])
-        assert_true(subscription.get('Id') in ids, message='subscription id not found')
-        
-    @test(groups=['redfish.delete_subscriptions'], \
-          depends_on_groups=['redfish.subscriptions_collection'])
-    def test_delete_subscriptions(self):
-        """ Testing DELETE /EventService/Subscription  """
+        self.assertEqual(200, status, msg='Expected 200 status, received status of {}'.format(status))
+
+    @depends(after='test_event_service_root')
+    def test_clean_up_subscriptions(self):
+        # """ Delete any exising subscripts left over on old runs """
         redfish().get_events_collection()
         data = self.__get_data()
         for member in data.get('Members'):
             id = member.get('@odata.id').split('/redfish/v1/EventService/Subscriptions/')[1]
             redfish().delete_event(id)
             status = self.__client.last_response.status
-            assert_equal(204, status, message='unexpected status on DELETE')
+            self.assertEqual(204, status, msg='Expected 204 status for DELETE, received status of {}'.format(status))
         redfish().get_events_collection()
         data = self.__get_data()
-        assert_equal(len(data.get('Members')), 0, message='unexpected subscription size, expected zero')
+        self.assertEqual(len(data.get('Members')), 0, msg='unexpected subscription size, expected zero')
+
+    # @test(groups=['redfish.create_subscription'], \
+    #      depends_on_groups=['redfish.event_service_root'])
+    @depends(after='test_clean_up_subscriptions')
+    def test_create_event_subscription(self):
+        # """ Testing POST /EventService/Subscription  """
+        global subscription
+        payload = {
+            'Id': '12345',
+            'Name': 'Alert 1',
+            'Destination': 'http://localhost:{0}'.format(self.__httpd_port),
+            'EventTypes': ['Alert'],
+            'Context': 'Client Alerting',
+            'Protocol': 'Redfish'
+        }
+        logs.info(" Post payload: ")
+        logs.info(dumps(payload, indent=4))
+        redfish().create_subscription(payload)
+        subscription = self.__get_data()
+        self.assertIsNotNone(subscription)
+        logs.info(dumps(subscription, indent=4))
+        status = self.__client.last_response.status
+        self.assertEqual(201, status, msg='Expected 201 status, received status of {}'.format(status))
+
+    # @test(groups=['redfish.subscriptions_collection'], \
+    #      depends_on_groups=['redfish.create_subscription'])
+    @depends(after='test_create_event_subscription')
+    def test_get_event_subscription(self):
+        # """ Testing GET /EventService/Subscription/:id  """
+        redfish().get_event(subscription.get('Id'))
+        data = self.__get_data()
+        status = self.__client.last_response.status
+        self.assertEqual(200, status, msg='Expected 200 status, received status of {}'.format(status))
+        self.assertEqual(subscription.get('Id'), data.get('Id'),
+                         msg='subscription id not found')
+
+    # @test(groups=['redfish.submit_test_event'], \
+    #      depends_on_groups=['redfish.create_subscription'])
+    @depends(after='test_create_event_subscription')
+    def test_submit_test_event(self):
+        # """ Testing POST /EventService/SubmitTestEvent  """
+        global task
+        server = Httpd(port=int(HTTPD_PORT), handler_class=self.EventServiceHandler)
+        task = WorkerThread(server, 'httpd')
+        worker = WorkerTasks(tasks=[task], func=self.__httpd_start)
+        worker.run()
+
+        # forward port for services running on a guest host
+        session = open_ssh_forward(self.__httpd_port)
+
+        redfish().test_event(body={})
+        worker.wait_for_completion(timeout_sec=60)
+        session.logout()
+        self.assertFalse(task.timeout, msg='timeout waiting for task {0}'.format(task.id))
+        self.assertFalse(self.__class__.eventHandlerFailed, msg='Event handler reported subscriptionId / memberId mismatch')
+
+    # @test(groups=['redfish.subscriptions_collection'], \
+    #      depends_on_groups=['redfish.submit_test_event'])
+    @depends(after='test_submit_test_event')
+    def test_subscription_collection(self):
+        # """ Testing GET /EventService/Subscription  """
+        redfish().get_events_collection()
+        data = self.__get_data()
+        status = self.__client.last_response.status
+        self.assertEqual(200, status, msg='Expected 200 status for GET, received status of {}'.format(status))
+        ids = []
+        for member in data.get('Members'):
+            ids.append(member.get('@odata.id').split('/redfish/v1/EventService/Subscriptions/')[1])
+        self.assertTrue(subscription.get('Id') in ids, msg='subscription id not found')
+
+    # @test(groups=['redfish.delete_subscriptions'], \
+    #      depends_on_groups=['redfish.subscriptions_collection'])
+    @depends(after='test_subscription_collection')
+    def test_delete_subscriptions(self):
+        # """ Testing DELETE /EventService/Subscription  """
+        redfish().get_events_collection()
+        data = self.__get_data()
+        for member in data.get('Members'):
+            id = member.get('@odata.id').split('/redfish/v1/EventService/Subscriptions/')[1]
+            redfish().delete_event(id)
+            status = self.__client.last_response.status
+            self.assertEqual(204, status, msg='Expected 204 status for DELETE, received status of {}'.format(status))
+        redfish().get_events_collection()
+        data = self.__get_data()
+        self.assertEqual(len(data.get('Members')), 0, msg='unexpected subscription size, expected zero')

--- a/test/tests/api/tmp_fit_staging/redfish_1_0/schema_tests.py
+++ b/test/tests/api/tmp_fit_staging/redfish_1_0/schema_tests.py
@@ -56,7 +56,12 @@ class SchemaTests(unittest.TestCase):
             self.assertEqual(dataId, id, msg='unexpected id {0}, expected {1}'.format(id, dataId))
             self.assertEqual(type(schema_ref.get('Location')), list, msg='expected list not found')
             location = schema_ref.get('Location')[0]
-            self.assertEqual(type(location.get('Uri')), unicode, msg='expected uri string not found')
+            location_uri = location.get('Uri')
+            # avoid python3 hound error by not using the word unicode
+            self.assertEqual(type(location_uri),
+                             type(u'unicode_string_type'),
+                             msg='expected type for Uri not string-like, received {}'.format(location_uri))
+            self.assertIn(dataId, location_uri, msg='expected dataId {} not in Uri {}'.format(dataId, location_uri))
             self.__class__.__locationUri.append(location.get('Uri'))
 
     # @test(groups=['redfish.get_schema_invalid'], depends_on_groups=['redfish.list_schemas'])

--- a/test/tests/api/tmp_fit_staging/redfish_1_0/task_service_tests.py
+++ b/test/tests/api/tmp_fit_staging/redfish_1_0/task_service_tests.py
@@ -1,94 +1,99 @@
-from config.redfish1_0_config import *
-from modules.logger import Log
+"""
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+"""
+import fit_path  # NOQA: unused import                                                                                          
+import unittest
+import flogging
+
+from config.redfish1_0_config import config
 from on_http_redfish_1_0 import RedfishvApi as redfish
-from datetime import datetime
-from proboscis.asserts import assert_equal
-from proboscis.asserts import assert_false
-from proboscis.asserts import assert_raises
-from proboscis.asserts import assert_not_equal
-from proboscis.asserts import assert_true
-from proboscis.asserts import assert_is_not_none
-from proboscis.asserts import fail
-from proboscis import SkipTest
-from proboscis import test
-from json import loads,dumps
+from json import loads, dumps
+from nosedep import depends
+from nose.plugins.attrib import attr
 
-LOG = Log(__name__)
+logs = flogging.get_loggers()
 
-@test(groups=['redfish.task_service.tests'], \
-      depends_on_groups=['redfish.systems.tests'])
-class TaskServiceTests(object):
 
-    def __init__(self):
-        self.__client = config.api_client
-        self.__oemServiceList = None
-        self.__taskServiceList = None
-        self.__taskList = None
+@attr(regression=True, smoke=True, task_service_rf1_tests=True)
+class TaskServiceTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.__client = config.api_client
+        cls.__oemServiceList = None
+        cls.__taskServiceList = None
+        cls.__taskList = None
 
     def __get_data(self):
         return loads(self.__client.last_response.data)
 
-    @test(groups=['redfish.get_task_service_root'])
+    # @test(groups=['redfish.get_task_service_root'])
     def test_get_task_service_root(self):
-        """ Testing GET /TaskService """
+        # """ Testing GET /TaskService """
         redfish().task_service_root()
         taskService = self.__get_data()
-        LOG.debug(taskService,json=True)
-        self.__oemServiceList = taskService.get('Oem')
-        assert_is_not_none(self.__oemServiceList)
-        oemMembers = self.__oemServiceList['RackHD'] \
-                                          ['SystemTaskCollection'].get('Members')
-        assert_is_not_none(oemMembers)
-        assert_not_equal(0, len(oemMembers), message='OEM members list was empty!')
-        self.__taskServiceList = taskService.get('Tasks')
-        assert_is_not_none(self.__taskServiceList)
+        logs.debug(dumps(taskService, indent=4))
+        self.__class__.__oemServiceList = taskService.get('Oem')
+        self.__oemServiceList = self.__class__.__oemServiceList
+        self.assertIsNotNone(self.__oemServiceList)
+        oemMembers = self.__oemServiceList['RackHD']['SystemTaskCollection'].get('Members')
+        self.assertIsNotNone(oemMembers)
+        self.assertNotEqual(0, len(oemMembers), msg='OEM members list was empty!')
+        self.__class__.__taskServiceList = taskService.get('Tasks')
+        self.__taskServiceList = self.__class__.__taskServiceList
+        self.assertIsNotNone(self.__taskServiceList)
         taskMembers = self.__taskServiceList.get('Members')
-        assert_is_not_none(taskMembers)
-        assert_not_equal(0, len(taskMembers), message='Task service members list was empty!')
+        self.assertIsNotNone(taskMembers)
+        self.assertNotEqual(0, len(taskMembers), msg='Task service members list was empty!')
 
-    @test(groups=['redfish.get_list_tasks'], \
-          depends_on_groups=['redfish.get_task_service_root'])
+    # @test(groups=['redfish.get_list_tasks'], \
+    #      depends_on_groups=['redfish.get_task_service_root'])
+    @depends(after='test_get_task_service_root')
     def test_get_list_tasks(self):
-        """ Testing GET /TaskService/Tasks """
+        # """ Testing GET /TaskService/Tasks """
         redfish().list_tasks()
-        self.__taskList = self.__get_data()
-        LOG.debug(self.__taskList,json=True)
+        self.__class__.__taskList = self.__get_data()
+        self.__taskList = self.__class__.__taskList
+        logs.debug(dumps(self.__taskList, indent=4))
         members = self.__taskList.get('Members')
-        assert_is_not_none(members)
-        assert_not_equal(0, len(members), message='Task members list was empty!')
+        self.assertIsNotNone(members)
+        self.assertNotEqual(0, len(members), msg='Task members list was empty!')
 
-    @test(groups=['redfish.get_task'], \
-          depends_on_groups=['redfish.get_list_tasks'])
+    # @test(groups=['redfish.get_task'], \
+    #      depends_on_groups=['redfish.get_list_tasks'])
+    @depends(after='test_get_list_tasks')
     def test_get_task(self):
-        """ Testing GET /TaskService/Tasks/{identifier} """
-        assert_is_not_none(self.__taskList)
+        # """ Testing GET /TaskService/Tasks/{identifier} """
+        self.__taskList = self.__class__.__taskList
+        self.assertIsNotNone(self.__taskList)
         members = self.__taskList.get('Members')
         for member in members:
             dataId = member.get('@odata.id')
-            assert_is_not_none(dataId)
+            self.assertIsNotNone(dataId)
             dataId = dataId.split('/redfish/v1/TaskService/Tasks/')[1]
             redfish().get_task(dataId)
             task = self.__get_data()
-            LOG.debug(task,json=True)
+            logs.debug(dumps(task, indent=4))
             taskId = task.get('@odata.id')
             taskId = taskId.split('/redfish/v1/TaskService/Tasks/')[1]
-            assert_equal(dataId,taskId)
+            self.assertEqual(dataId, taskId)
 
-    @test(groups=['redfish.get_system_task'], \
-          depends_on_groups=['redfish.get_list_tasks'])
+    # @test(groups=['redfish.get_system_task'], \
+    #      depends_on_groups=['redfish.get_list_tasks'])
+    @depends(after='test_get_list_tasks')
     def test_get_system_task(self):
-        """ Testing GET /TaskService/Oem/Tasks/{identifier} """
-        assert_is_not_none(self.__oemServiceList)
-        oemMembers = self.__oemServiceList['RackHD'] \
-                                          ['SystemTaskCollection'].get('Members')
+        # """ Testing GET /TaskService/Oem/Tasks/{identifier} """
+        self.__oemServiceList = self.__class__.__oemServiceList
+        self.assertIsNotNone(self.__oemServiceList)
+        oemMembers = self.__oemServiceList['RackHD']['SystemTaskCollection'].get('Members')
         for member in oemMembers:
             dataId = member.get('@odata.id')
-            assert_is_not_none(dataId)
+            self.assertIsNotNone(dataId)
             dataId = dataId.split('/redfish/v1/TaskService/Oem/Tasks/')[1]
             redfish().get_system_tasks(dataId)
             task = self.__get_data()
-            LOG.debug(task,json=True)
+            logs.debug(dumps(task, indent=4))
             taskId = task.get('@odata.id')
             taskId = taskId.split('/redfish/v1/TaskService/Oem/Tasks/')[1]
-            assert_equal(dataId,taskId)
-
+            self.assertEqual(dataId, taskId)


### PR DESCRIPTION
Second set (of three) of redfish CIT to FIT converted scripts for review. 
- task_service_tests.py
- schema_tests.py
- event_service_tests.py

The tests aren't enabled yet in smoke, but I have 'enabled' and tested outside of this PR against vagrant and physical stacks.

This is part of step 2 in associated PR 673.
Plan is now:
1. copy the original scripts into this staging area (this PR)
2. apply the converted script on top do show the diffs only for review
3. mv the script and allow the converted script to run in FIT smoke suite.

@johren @dalebremner @brianparry @larry-dean @gpaulos @jimturnquist @keedya