### PR TITLE
RAC-4182 - Converted last three redfish scripts from CIT to FIT format in staging.

### DIFF
--- a/test/tests/api/tmp_fit_staging/redfish_1_0/account_service_tests.py
+++ b/test/tests/api/tmp_fit_staging/redfish_1_0/account_service_tests.py
@@ -1,140 +1,156 @@
-from config.redfish1_0_config import *
-from modules.logger import Log
+"""
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+"""
+import fit_path  # NOQA: unused import                                                                                          
+import unittest
+import flogging
+
+from config.redfish1_0_config import config
 from modules.redfish_auth import Auth
 from on_http_redfish_1_0 import RedfishvApi as redfish
-from on_http_redfish_1_0 import rest
-from datetime import datetime
-from proboscis.asserts import assert_equal
-from proboscis.asserts import assert_false
-from proboscis.asserts import assert_raises
-from proboscis.asserts import assert_not_equal
-from proboscis.asserts import assert_true
-from proboscis.asserts import fail
-from proboscis import SkipTest
-from proboscis import test
-from json import loads,dumps
-from proboscis import before_class
-from proboscis import after_class
+from json import loads, dumps
+from nosedep import depends
+from nose.plugins.attrib import attr
+
+logs = flogging.get_loggers()
 
 
-LOG = Log(__name__)
+# @test(groups=['redfish.account_service.tests'], depends_on_groups=['obm.tests'])
+@attr(regression=True, smoke=True, account_service_rf1_tests=True)
+class AccountServiceTests(unittest.TestCase):
 
-@test(groups=['redfish.account_service.tests'], depends_on_groups=['obm.tests'])
-class AccountServiceTests(object):
+    @classmethod
+    def setUpClass(cls):
+        cls.__client = config.api_client
+        cls.__accounts = None
 
-    def __init__(self):
-        self.__client = config.api_client
-        self.__accounts = None
-        self.__roles = None
-
-    @before_class()
-    def setup(self):
-        """setup test environment"""
+        # setup test environment
         Auth.enable()
 
-    @after_class(always_run=True)
-    def teardown(self):
-        """ restore test environment """
+    @classmethod
+    def tearDownClass(cls):
+        # """ restore test environment """
         Auth.disable()
 
     def __get_data(self):
         return loads(self.__client.last_response.data)
 
-    @test(groups=['redfish.get_account_service'])
+    # @test(groups=['redfish.get_account_service'])
     def test_get_account_service(self):
-        """ Testing GET /AccountService """
+        # """ Testing GET /AccountService """
         redfish().get_account_service()
         service = self.__get_data()
-        LOG.debug(service,json=True)
+        logs.debug(" Service: ")
+        logs.debug(dumps(service, indent=4))
         id = service.get('Id')
-        assert_equal('AccountService', id, message='unexpected id {0}, expected {1}'.format(id,'AccountService'))
+        self.assertEqual('AccountService', id, msg='unexpected id {0}, expected {1}'.format(id, 'AccountService'))
         accounts = service.get('Accounts')
         roles = service.get('Roles')
-        assert_not_equal(None, accounts, message='Failed to get accounts')
-        assert_not_equal(None, roles, message='Failed to get roles')
+        self.assertNotEqual(None, accounts, msg='Failed to get accounts')
+        self.assertNotEqual(None, roles, msg='Failed to get roles')
 
-    @test(groups=['redfish.list_roles'], depends_on_groups=['redfish.get_account_service'])
+    # @test(groups=['redfish.list_roles'], depends_on_groups=['redfish.get_account_service'])
+    @depends(after='test_get_account_service')
     def test_list_roles(self):
-        """ Testing GET /AcountService/Roles """
+        # """ Testing GET /AcountService/Roles """
         redfish().list_roles()
         roles = self.__get_data()
-        LOG.debug(roles,json=True)
-        self.__roles = roles.get('Members')
-        assert_equal(len(self.__roles), 3, message='expected role length to be 3')
-        for member in self.__roles:
+        logs.debug(" Roles: ")
+        logs.debug(dumps(roles, indent=4))
+        __roles = roles.get('Members')
+        self.assertEqual(len(__roles), 3, msg='expected role length to be 3')
+        for member in __roles:
             dataId = member.get('@odata.id')
-            assert_not_equal(None,dataId)
+            self.assertNotEqual(None, dataId)
             dataId = dataId.split('/redfish/v1/AccountService/Roles/')[1]
             redfish().get_role(dataId)
             role = self.__get_data()
-            LOG.debug(role,json=True)
+            logs.debug(dumps(role, indent=4))
             name = role.get('Name')
-            assert_equal(dataId, name, message='unexpected name {0}, expected {1}'.format(name,dataId))
+            self.assertEqual(dataId, name, msg='unexpected name {0}, expected {1}'.format(name, dataId))
 
-    @test(groups=['redfish.get_accounts'], depends_on_groups=['redfish.get_account_service'])
+    # @test(groups=['redfish.get_accounts'], depends_on_groups=['redfish.get_account_service'])
+    @depends(after='test_get_account_service')
     def test_get_accounts(self):
-        """ Testing GET /AcountService/Accounts """
+        # """ Testing GET /AcountService/Accounts """
         redfish().get_accounts()
         accounts = self.__get_data()
-        LOG.debug(accounts,json=True)
-        self.__accounts = accounts.get('Members')
-        for member in self.__accounts:
+        logs.debug(" Accounts: ")
+        logs.debug(dumps(accounts, indent=4))
+        self.__class__.__accounts = accounts.get('Members')
+        for member in self.__class__.__accounts:
             dataId = member.get('@odata.id')
-            assert_not_equal(None,dataId)
+            self.assertNotEqual(None, dataId)
             dataId = dataId.split('/redfish/v1/AccountService/Accounts/')[1]
             redfish().get_account(dataId)
             account = self.__get_data()
-            LOG.debug(account,json=True)
+            logs.debug(dumps(account, indent=4))
             username = account.get('UserName')
-            assert_equal(dataId, username, message='unexpected username {0}, expected {1}'.format(username,dataId))
+            self.assertEqual(dataId, username, msg='unexpected username {0}, expected {1}'.format(username, dataId))
 
-    @test(groups=['redfish.create_account'], depends_on_groups=['redfish.get_accounts'])
+    @depends(after='test_get_accounts')
+    def test_clear_test_account(self):
+        # """ Clearing out any existing test Accounts funtest-name """
+        self.test_get_accounts()
+        for member in self.__class__.__accounts:
+            dataId = member.get('@odata.id')
+            if dataId:
+                dataId = dataId.split('/redfish/v1/AccountService/Accounts/')[1]
+                if dataId == 'funtest-name':
+                    # If user tries to rerun after a failed test, this should clear out left overs
+                    redfish().remove_account('funtest-name')
+
+    # @test(groups=['redfish.create_account'], depends_on_groups=['redfish.get_accounts'])
+    @depends(after='test_clear_test_account')
     def test_create_account(self):
-        """ Testing POST /AcountService/Accounts """
+        # """ Testing POST /AcountService/Accounts """
         body = {
             'UserName': 'funtest-name',
             'Password': 'funtest123',
             'RoleId': 'Administrator'
         }
+        logs.debug(" Creating Account: ")
         redfish().create_account(payload=body)
         self.test_get_accounts()
         found = False
-        for member in self.__accounts:
+        for member in self.__class__.__accounts:
             dataId = member.get('@odata.id')
-            assert_not_equal(None,dataId)
+            self.assertNotEqual(None, dataId)
             dataId = dataId.split('/redfish/v1/AccountService/Accounts/')[1]
             if dataId == 'funtest-name':
                 found = True
                 redfish().get_account(dataId)
                 account = self.__get_data()
-                assert_equal(account.get('RoleId'), 'Administrator', message='unexpected RoleId')
+                logs.debug(dumps(account, indent=4))
+                self.assertEqual(account.get('RoleId'), 'Administrator', msg='unexpected RoleId')
                 break
         if not found:
-            fail(message='newly created user was not found')
+            self.fail(msg='newly created user was not found')
 
-    @test(groups=['redfish.modify_account'], depends_on_groups=['redfish.create_account'])
+    # @test(groups=['redfish.modify_account'], depends_on_groups=['redfish.create_account'])
+    @depends(after='test_create_account')
     def test_modify_account(self):
-        """ Testing PATCH /AcountService/Accounts/{name} """
+        # """ Testing PATCH /AcountService/Accounts/{name} """
         body = {
             'Password': 'funtest456',
             'RoleId': 'ReadOnly'
         }
+        logs.debug(" Modifying Account: ")
         redfish().modify_account('funtest-name', payload=body)
         redfish().get_account('funtest-name')
         account = self.__get_data()
-        assert_equal(account.get('RoleId'), 'ReadOnly', message='unexpected RoleId')
+        logs.debug(dumps(account, indent=4))
+        self.assertEqual(account.get('RoleId'), 'ReadOnly', msg='unexpected RoleId')
 
-    @test(groups=['redfish.remove_account'], depends_on_groups=['redfish.create_account'])
+    # @test(groups=['redfish.remove_account'], depends_on_groups=['redfish.create_account'])
+    @depends(after='test_modify_account')
     def test_remove_account(self):
+        # """ Testing DELETE /AcountService/Accounts/{name} """
         redfish().remove_account('funtest-name')
         self.test_get_accounts()
-        found = False
-        for member in self.__accounts:
+        for member in self.__class__.__accounts:
             dataId = member.get('@odata.id')
-            assert_not_equal(None,dataId)
+            self.assertNotEqual(None, dataId)
             dataId = dataId.split('/redfish/v1/AccountService/Accounts/')[1]
             if dataId == 'funtest-name':
-                fail(message='failed to delete account')
-
-
-
+                self.fail(msg='failed to delete account')

--- a/test/tests/api/tmp_fit_staging/redfish_1_0/registry_tests.py
+++ b/test/tests/api/tmp_fit_staging/redfish_1_0/registry_tests.py
@@ -1,98 +1,110 @@
-from config.redfish1_0_config import *
-from modules.logger import Log
+"""
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+"""
+import fit_path  # NOQA: unused import                                                                                          
+import unittest
+
+from config.redfish1_0_config import config
 from on_http_redfish_1_0 import RedfishvApi as redfish
 from on_http_redfish_1_0 import rest
-from datetime import datetime
-from proboscis.asserts import assert_equal
-from proboscis.asserts import assert_false
-from proboscis.asserts import assert_raises
-from proboscis.asserts import assert_not_equal
-from proboscis.asserts import assert_true
-from proboscis.asserts import fail
-from proboscis import SkipTest
-from proboscis import test
-from json import loads,dumps
+from json import loads, dumps
+from nosedep import depends
+import flogging
+from nose.plugins.attrib import attr
 
-LOG = Log(__name__)
+logs = flogging.get_loggers()
 
-@test(groups=['redfish.registry.tests'], depends_on_groups=['obm.tests'])
-class RegistryTests(object):
 
-    def __init__(self):
-        self.__client = config.api_client
-        self.__registryList = None
-        self.__membersList = None
-        self.__locationUri = []
+# @test(groups=['redfish.registry.tests'], depends_on_groups=['obm.tests'])
+@attr(regression=True, smoke=True, registry_rf1_tests=True)
+class RegistryTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.__client = config.api_client
+        cls.__registryList = None
+        cls.__membersList = None
+        cls.__locationUri = list()
 
     def __get_data(self):
         return loads(self.__client.last_response.data)
 
-    @test(groups=['redfish.list_registry'])
+    # @test(groups=['redfish.list_registry'])
     def test_list_registry(self):
-        """ Testing GET /Registries """
+        # """ Testing GET /Registries """
         redfish().list_registry()
         registry = self.__get_data()
-        LOG.debug(registry,json=True)
-        assert_not_equal(0, len(registry), message='Registry list was empty!')
-        self.__registryList = registry
+        logs.debug(dumps(registry, indent=4))
+        self.assertNotEqual(0, len(registry), msg='Registry list was empty!')
+        self.__class__.__registryList = registry
 
-    @test(groups=['redfish.get_registry_file'], depends_on_groups=['redfish.list_registry'])
+    # @test(groups=['redfish.get_registry_file'], depends_on_groups=['redfish.list_registry'])
+    @depends(after='test_list_registry')
     def test_get_registry_file(self):
-        """ Testing GET /Registries/{identifier} """
-        self.__membersList = self.__registryList.get('Members')
-        assert_not_equal(None, self.__membersList)
-        for member in self.__membersList:
+        # """ Testing GET /Registries/{identifier} """
+        self.__class__.__membersList = self.__class__.__registryList.get('Members')
+        self.assertIsNotNone(self.__class__.__membersList, msg='Members section not present')
+        self.assertNotEqual(len(self.__class__.__membersList), 0, msg='Members section is empty')
+        for member in self.__class__.__membersList:
             dataId = member.get('@odata.id')
-            assert_not_equal(None,dataId)
+            self.assertNotEqual(None, dataId)
             dataId = dataId.split('/redfish/v1/Registries/')[1]
             redfish().get_registry_file(dataId)
             registry_file = self.__get_data()
-            LOG.debug(registry_file,json=True)
+            logs.debug(dumps(registry_file, indent=4))
             id = registry_file.get('Id')
-            assert_equal(dataId, id, message='unexpected id {0}, expected {1}'.format(id,dataId))
-            assert_equal(type(registry_file.get('Location')), list, message='expected list not found')
+            self.assertEqual(dataId, id, msg='unexpected id {0}, expected {1}'.format(id, dataId))
+            self.assertEqual(type(registry_file.get('Location')), list, msg='expected list not found')
             location = registry_file.get('Location')[0]
-            assert_equal(type(location.get('Uri')), unicode, message='expected uri string not found')
-            self.__locationUri.append(location.get('Uri'))
+            location_uri = location.get('Uri')
+            # avoid python3 hound error by not using the word unicode
+            self.assertEqual(type(location_uri),
+                             type(u'unicode_string_type'),
+                             msg='expected type for Uri not string-like, received {}'.format(location_uri))
+            self.assertIn(dataId, location_uri, msg='expected dataId {} not in Uri {}'.format(dataId, location_uri))
+            self.__class__.__locationUri.append(location.get('Uri'))
 
-    @test(groups=['redfish.get_registry_file_invalid'], depends_on_groups=['redfish.list_registry'])
+    # @test(groups=['redfish.get_registry_file_invalid'], depends_on_groups=['redfish.list_registry'])
+    @depends(after='test_list_registry')
     def test_get_registry_file_invalid(self):
-        """ Testing GET /Registries/{identifier} 404s properly """
-        self.__membersList = self.__registryList.get('Members')
-        assert_not_equal(None, self.__membersList)
-        for member in self.__membersList:
+        # """ Testing GET /Registries/{identifier} 404s properly """
+        self.__class__.__membersList = self.__class__.__registryList.get('Members')
+        self.assertNotEqual(None, self.__class__.__membersList)
+        for member in self.__class__.__membersList:
             dataId = member.get('@odata.id')
-            assert_not_equal(None,dataId)
+            self.assertNotEqual(None, dataId)
             dataId = dataId.split('/redfish/v1/Registries/')[1]
             try:
                 redfish().get_registry_file(dataId + '-invalid')
-                fail(message='did not raise exception')
+                self.fail(msg='did not raise exception')
             except rest.ApiException as e:
-                assert_equal(404, e.status, message='unexpected response {0}, expected 404'.format(e.status))
+                self.assertEqual(404, e.status, msg='unexpected response {0}, expected 404'.format(e.status))
 
-    @test(groups=['redfish.get_registry_file_contents'], depends_on_groups=['redfish.get_registry_file'])
+    # @test(groups=['redfish.get_registry_file_contents'], depends_on_groups=['redfish.get_registry_file'])
+    @depends(after='test_get_registry_file')
     def test_get_registry_file_contents(self):
-        """ Testing GET /Registries/en/{identifier} """
-        assert_not_equal([], self.__locationUri)
-        for member in self.__locationUri:
-            assert_not_equal(None,member)
+        # """ Testing GET /Registries/en/{identifier} """
+        self.assertNotEqual([], self.__class__.__locationUri)
+        for member in self.__class__.__locationUri:
+            self.assertNotEqual(None, member)
             dataId = member.split('/redfish/v1/Registries/en/')[1]
             redfish().get_registry_file_contents(dataId)
             registry_file_contents = self.__get_data()
-            LOG.debug(registry_file_contents,json=True)
+            logs.debug(dumps(registry_file_contents, indent=4))
             id = registry_file_contents.get('Id')
-            assert_equal(dataId, id, message='unexpected id {0}, expected {1}'.format(id,dataId))
+            self.assertEqual(dataId, id, msg='unexpected id {0}, expected {1}'.format(id, dataId))
 
-    @test(groups=['redfish.get_registry_file_contents_invalid'], depends_on_groups=['redfish.get_registry_file'])
+    # @test(groups=['redfish.get_registry_file_contents_invalid'], depends_on_groups=['redfish.get_registry_file'])
+    @depends(after='test_get_registry_file')
     def test_get_registry_file_contents_invalid(self):
-        """ Testing GET /Registries/en/{identifier} 404s properly """
-        assert_not_equal([], self.__locationUri)
-        for member in self.__locationUri:
-            assert_not_equal(None,member)
+        # """ Testing GET /Registries/en/{identifier} 404s properly """
+        self.assertNotEqual([], self.__class__.__locationUri)
+        for member in self.__class__.__locationUri:
+            self.assertNotEqual(None, member)
             dataId = member.split('/redfish/v1/Registries/en/')[1]
             try:
                 redfish().get_registry_file_contents(dataId + '-invalid')
-                fail(message='did not raise exception')
+                self.fail(msg='did not raise exception')
             except rest.ApiException as e:
-                assert_equal(404, e.status, message='unexpected response {0}, expected 404'.format(e.status))
-
+                self.assertEqual(404, e.status, msg='unexpected response {0}, expected 404'.format(e.status))

--- a/test/tests/api/tmp_fit_staging/redfish_1_0/session_service_tests.py
+++ b/test/tests/api/tmp_fit_staging/redfish_1_0/session_service_tests.py
@@ -1,118 +1,119 @@
-from config.redfish1_0_config import *
-from modules.logger import Log
+"""
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+"""
+import fit_path  # NOQA: unused import                                                                                          
+import unittest
+import flogging
+
+from config.redfish1_0_config import config
 from modules.redfish_auth import Auth
 from on_http_redfish_1_0 import RedfishvApi as redfish
 from on_http_redfish_1_0 import rest
-from datetime import datetime
-from proboscis.asserts import assert_equal
-from proboscis.asserts import assert_false
-from proboscis.asserts import assert_raises
-from proboscis.asserts import assert_not_equal
-from proboscis.asserts import assert_true
-from proboscis.asserts import fail
-from proboscis import SkipTest
-from proboscis import test
-from json import loads,dumps
-from proboscis import before_class
-from proboscis import after_class
+from json import loads, dumps
+from nosedep import depends
+from nose.plugins.attrib import attr
+
+logs = flogging.get_loggers()
 
 
-LOG = Log(__name__)
+# @test(groups=['redfish.session_service.tests'], depends_on_groups=['obm.tests'])
+@attr(regression=True, smoke=True, schema_rf1_tests=True)
+class SessionServiceTests(unittest.TestCase):
 
-@test(groups=['redfish.session_service.tests'], depends_on_groups=['obm.tests'])
-class SessionServiceTests(object):
+    @classmethod
+    def setUpClass(cls):
+        # setup test environment
+        cls.__client = config.api_client
+        cls.__sessionList = None
+        cls.__session = None
 
-    def __init__(self):
-        self.__client = config.api_client
-        self.__sessionList = None
-        self.__session = None
-
-    @before_class()
-    def setup(self):
-        """setup test environment"""
         Auth.enable()
 
-    @after_class(always_run=True)
-    def teardown(self):
-        """ restore test environment """
+    @classmethod
+    def tearDownClass(cls):
+        # restore test environment
         Auth.disable()
 
     def __get_data(self):
         return loads(self.__client.last_response.data)
 
-    @test(groups=['redfish.get_session_service'])
+    # @test(groups=['redfish.get_session_service'])
     def test_get_session_service(self):
-        """ Testing GET /SessionService """
+        # """ Testing GET /SessionService """
         redfish().get_session_service()
         service = self.__get_data()
-        LOG.debug(service,json=True)
+        logs.debug(dumps(service, indent=4))
         id = service.get('Id')
-        assert_equal('SessionService', id, message='unexpected id {0}, expected {1}'.format(id,'SessionService'))
+        self.assertEqual('SessionService', id, msg='unexpected id {0}, expected {1}'.format(id, 'SessionService'))
         sessions = service.get('Sessions')
-        assert_not_equal(None, sessions, message='Failed to get sessions')
+        self.assertNotEqual(None, sessions, msg='Failed to get sessions')
 
-    @test(groups=['redfish.post_session'], depends_on_groups=['redfish.get_session_service'])
+    # @test(groups=['redfish.post_session'], depends_on_groups=['redfish.get_session_service'])
+    @depends(after='test_get_session_service')
     def test_post_session(self):
-        """ Testing POST /SessionService/Sessions """
+        # """ Testing POST /SessionService/Sessions """
         body = {
             'UserName': 'admin',
             'Password': 'admin123'
         }
         redfish().post_session(payload=body)
         sessions = self.__get_data()
-        self.__session = sessions.get('Id')
-        assert_not_equal(None, self.__session)
+        self.__class__.__session = sessions.get('Id')
+        self.assertNotEqual(None, self.__class__.__session)
 
-    @test(groups=['redfish.get_sessions'], depends_on_groups=['redfish.post_session'])
+    # @test(groups=['redfish.get_sessions'], depends_on_groups=['redfish.post_session'])
+    @depends(after='test_post_session')
     def test_get_sessions(self):
-        """ Testing GET /SessionService/Sessions """
+        # """ Testing GET /SessionService/Sessions """
         redfish().get_sessions()
         sessions = self.__get_data()
-        self.__sessionList = sessions.get('Members')
+        self.__class__.__sessionList = sessions.get('Members')
 
-    @test(groups=['redfish.get_session_info'], depends_on_groups=['redfish.get_sessions'])
+    # @test(groups=['redfish.get_session_info'], depends_on_groups=['redfish.get_sessions'])
+    @depends(after='test_get_sessions')
     def test_get_session_info(self):
-        """ Testing GET /SessionService/Sessions/{identifier} """
-        assert_not_equal(None, self.__sessionList)
-        for member in self.__sessionList:
+        # """ Testing GET /SessionService/Sessions/{identifier} """
+        self.assertNotEqual(None, self.__class__.__sessionList)
+        for member in self.__class__.__sessionList:
             dataId = member.get('@odata.id')
-            assert_not_equal(None,dataId)
+            self.assertNotEqual(None, dataId)
             dataId = dataId.split('/redfish/v1/SessionService/Sessions/')[1]
             redfish().get_session_info(dataId)
             session_ref = self.__get_data()
-            LOG.debug(session_ref,json=True)
+            logs.debug(dumps(session_ref, indent=4))
             id = session_ref.get('Id')
-            assert_equal(dataId, id, message='unexpected id {0}, expected {1}'.format(id,dataId))
+            self.assertEqual(dataId, id, msg='unexpected id {0}, expected {1}'.format(id, dataId))
 
-    @test(groups=['redfish.get_session_info_invalid'], depends_on_groups=['redfish.get_session_info'])
+    # @test(groups=['redfish.get_session_info_invalid'], depends_on_groups=['redfish.get_session_info'])
+    @depends(after='test_get_session_info')
     def test_get_session_info_invalid(self):
-        """ Testing GET /SessionService/Sessions/{identifier} 404s properly"""
-        assert_not_equal(None, self.__sessionList)
-        for member in self.__sessionList:
+        # """ Testing GET /SessionService/Sessions/{identifier} 404s properly"""
+        self.assertNotEqual(None, self.__class__.__sessionList)
+        for member in self.__class__.__sessionList:
             dataId = member.get('@odata.id')
-            assert_not_equal(None,dataId)
+            self.assertNotEqual(None, dataId)
             dataId = dataId.split('/redfish/v1/SessionService/Sessions/')[1]
             try:
                 redfish().get_session_info(dataId + 'invalid')
-                fail(message='did not raise exception')
+                self.fail(msg='did not raise exception')
             except rest.ApiException as e:
-                assert_equal(404, e.status, message='unexpected response {0}, expected 404'.format(e.status))
+                self.assertEqual(404, e.status, msg='unexpected response {0}, expected 404'.format(e.status))
             break
 
-    @test(groups=['redfish.do_logout_session'], depends_on_groups=['redfish.get_session_info_invalid'])
+    # @test(groups=['redfish.do_logout_session'], depends_on_groups=['redfish.get_session_info_invalid'])
+    @depends(after='test_get_session_info_invalid')
     def test_do_logout_session(self):
-        """ Testing DELETE /SessionService/Sessions/{identifier} """
-        redfish().do_logout_session(self.__session)
+        # """ Testing DELETE /SessionService/Sessions/{identifier} """
+        redfish().do_logout_session(self.__class__.__session)
         try:
-            redfish().get_session_info(self.__session)
-            fail(message='did not raise exception')
+            redfish().get_session_info(self.__class__.__session)
+            self.fail(msg='did not raise exception')
         except rest.ApiException as e:
-            assert_equal(404, e.status, message='unexpected response {0}, expected 404'.format(e.status))
+            self.assertEqual(404, e.status, msg='unexpected response {0}, expected 404'.format(e.status))
 
         self.test_get_sessions()
-        for member in self.__sessionList:
+        for member in self.__class__.__sessionList:
             dataId = member.get('@odata.id')
             dataId = dataId.split('/redfish/v1/SessionService/Sessions/')[1]
-            assert_not_equal(self.__session,dataId)
-
-
+            self.assertNotEqual(self.__class__.__session, dataId)


### PR DESCRIPTION
This PR is to convert the following three redfish scripts from CIT to FIT format.
Third set (of three).
  - account_service_tests.py
  - registry_tests.py
  - session_service_tests.py

Tested against physical stacks and virtual stack.
This is part of step 2 in associated PR 673.
Plan is now:
1. copy the original scripts into this staging area (this PR)
2. apply the converted script on top do show the diffs only for review
3. mv the script and allow the converted script to run in FIT smoke suite.

@johren @dalebremner @brianparry @larry-dean @gpaulos @jimturnquist @keedya