### PR TITLE
Rac 1984 cit test removal

### DIFF
--- a/test/tests/amqp/test_amqp_heartbeat.py
+++ b/test/tests/amqp/test_amqp_heartbeat.py
@@ -1,6 +1,5 @@
 '''
 Copyright 2017 Dell Inc. or its subsidiaries.  All Rights Reserved.
-
 Author(s):
 Norton Luo
 This test will monitor amqp heartbeat message and validate the message format per latest notification event format
@@ -30,7 +29,6 @@ class AmqpWorker(threading.Thread):
     def callback(self, ch, method, properties, body):
         logs.debug(" [x] %r:%r" % (method.routing_key, body))
         logs.debug(" [x] %r:%r" % (method.routing_key, body))
-
     td = fit_amqp.AMQP_worker("node.added.#", callback)
     td.setDaemon(True)
     td.start()

--- a/test/tests/amqp/test_amqp_node_rediscover.py
+++ b/test/tests/amqp/test_amqp_node_rediscover.py
@@ -1,6 +1,5 @@
 '''
 Copyright 2017 Dell Inc. or its subsidiaries.  All Rights Reserved.
-
 Author(s):
 Norton Luo
 This test validate the AMQP message send out in the workflow, and node delete and discover.
@@ -42,11 +41,9 @@ class AmqpWorker(threading.Thread):
     def callback(self, ch, method, properties, body):
         logs.debug(" [x] %r:%r" % (method.routing_key, body))
         logs.debug(" [x] %r:%r" % (method.routing_key, body))
-
     td = fit_amqp.AMQP_worker("node.added.#", callback)
     td.setDaemon(True)
     td.start()
-
     TODO:
     The common AMQP related test module of FIT is being refactoring. This AMQP test class is only for temporary use.
     It will be obsolete and replaced by a common AMQP test module.

--- a/test/tests/amqp/test_amqp_poller_alert.py
+++ b/test/tests/amqp/test_amqp_poller_alert.py
@@ -1,6 +1,5 @@
 '''
 Copyright 2017 Dell Inc. or its subsidiaries.  All Rights Reserved.
-
 Author(s):
 Norton Luo
 This test validate the amqp message alert send out from RackHD by monitor SEL log poller and power state poller. The
@@ -38,7 +37,6 @@ class AmqpWorker(threading.Thread):
     def callback(self, ch, method, properties, body):
         logs.debug(" [x] %r:%r" % (method.routing_key, body))
         logs.debug(" [x] %r:%r" % (method.routing_key, body))
-
     td = fit_amqp.AMQP_worker("node.added.#", callback)
     td.setDaemon(True)
     td.start()

--- a/test/tests/amqp/test_amqp_racknode.py
+++ b/test/tests/amqp/test_amqp_racknode.py
@@ -1,9 +1,7 @@
 '''
 Copyright (c) 2017 Dell Inc. or its subsidiaries.  All Rights Reserved.
-
 Author(s):
 Norton Luo
-
 '''
 from time import sleep
 from datetime import datetime
@@ -33,7 +31,6 @@ class AmqpWorker(threading.Thread):
     def callback(self, ch, method, properties, body):
         logs.debug(" [x] %r:%r" % (method.routing_key, body))
         logs.debug(" [x] %r:%r" % (method.routing_key, body))
-
     td = AMQP_worker("node.added.#", callback)
     td.setDaemon(True)
     td.start()

--- a/test/tests/api/v2_0/nodes_tests.py
+++ b/test/tests/api/v2_0/nodes_tests.py
@@ -281,7 +281,13 @@ class NodesTests(object):
                 resps.append(self.__get_data())
         for resp in resps:
             assert_not_equal(0, len(resp), message='No Workflows found for Node')
+
+#        try:
         Api().nodes_get_workflow_by_id('fooey')
+#            fail(message='did not raise exception for nodes_get_workflow_by_id with bad id')
+#        except rest.ApiException as e:
+#            assert_equal(404, e.status,
+#                message='unexpected response {0}, expected 404 for bad nodeId'.format(e.status))
 
     @test(groups=['node_post_workflows-api2'], depends_on_groups=['node_workflows-api2'])
     def test_node_workflows_post(self):


### PR DESCRIPTION
Here is an API fix for nodes/:id/workflows - RackHD/on-http#613
It cannot pass because it causes a CIT test failure. That CIT test was made based on the APIs original flawed implementation.
This PR comments out the failing assert while also presenting the new CIT test in comments.

Ideally, this PR will be merged immediately followed by the above API fix followed by a final PR for the new CIT test being un-commented out.