### PR TITLE
Temporary removal of CIT test blocking an API fix

### DIFF
--- a/test/tests/api/v2_0/nodes_tests.py
+++ b/test/tests/api/v2_0/nodes_tests.py
@@ -279,9 +279,14 @@ class NodesTests(object):
             if n.get('type') == 'compute':
                 Api().nodes_get_workflow_by_id(identifier=n.get('id'))
                 resps.append(self.__get_data())
-        for resp in resps:
-            assert_not_equal(0, len(resp), message='No Workflows found for Node')
         Api().nodes_get_workflow_by_id('fooey')
+
+#        try:
+#            Api().nodes_get_workflow_by_id('fooey')
+#            fail(message='did not raise exception for nodes_get_workflow_by_id with bad id')
+#        except rest.ApiException as e:
+#            assert_equal(404, e.status,
+#                message='unexpected response {0}, expected 404 for bad nodeId'.format(e.status))
 
     @test(groups=['node_post_workflows-api2'], depends_on_groups=['node_workflows-api2'])
     def test_node_workflows_post(self):


### PR DESCRIPTION
Here is an API fix for nodes/:id/workflows - RackHD/on-http#613
It cannot pass because it causes a CIT test failure. That CIT test was made based on the APIs original flawed implementation.
This PR comments out the failing assert while also presenting the new CIT test in comments.

Ideally, this PR will be merged immediately followed by the above API fix followed by a final PR for the new CIT test being un-commented out.