### PR TITLE
RAC-4749: ignore the certificate check

### DIFF
--- a/HWIMO-BUILD
+++ b/HWIMO-BUILD
@@ -12,7 +12,7 @@ git clone . packagebuild
 pushd packagebuild
 cp -r ../debian .
 
-wget https://raw.githubusercontent.com/RackHD/RackHD/master/packer/ansible/roles/monorail/files/config.json  -O config.json
+wget --no-check-certificate https://raw.githubusercontent.com/RackHD/RackHD/master/packer/ansible/roles/monorail/files/config.json   -O config.json
 
 # If PKG_VERSION is not set as an environment variable
 # compute it as below:


### PR DESCRIPTION
**Background**
https://rackhd.atlassian.net/browse/RAC-4749

in MasterCI(Nightly Build), the rackhd.deb building requires download the config.json as a template .
But it met below error during ```wget``` the config.json template file.
```
ERROR: cannot verify raw.githubusercontent.com's certificate, issued by ‘/C=US/O=DigiCert Inc/OU=www.digicert.com/CN=DigiCert SHA2 High Assurance Server CA’:
Issued certificate not yet valid.
```

**Fix**:
As recommended, we add "--no-check-certificate" parameter, because the GitHub raw file download URL seems trust-able. 


**Reviewer**
@yyscamper  @anhou  @PengTian0  @changev 