### PR TITLE
Rac 4327 Parallel API 2.0 OS install test for proxy repos

### DIFF
--- a/test/tests/bootstrap/test_api20_os_bootstrap_parallel_proxy.py
+++ b/test/tests/bootstrap/test_api20_os_bootstrap_parallel_proxy.py
@@ -150,7 +150,7 @@ for item in OSLIST:
 # ------------------------ Tests -------------------------------------
 
 
-@attr(all=True)
+@attr(all=False)
 class api20_bootstrap_base(fit_common.unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/test/tests/bootstrap/test_api20_os_bootstrap_parallel_proxy.py
+++ b/test/tests/bootstrap/test_api20_os_bootstrap_parallel_proxy.py
@@ -65,6 +65,7 @@ import fit_path  # NOQA: unused import
 from nose.plugins.attrib import attr
 import fit_common
 import flogging
+import sys
 import time
 log = flogging.get_loggers()
 

--- a/test/tests/bootstrap/test_api20_os_bootstrap_parallel_proxy.py
+++ b/test/tests/bootstrap/test_api20_os_bootstrap_parallel_proxy.py
@@ -84,7 +84,8 @@ rackhdhost = "http://" + str(rackhdconfig['apiServerAddress']) + ":" + str(rackh
 
 # this routine polls a workflow task ID for completion
 def wait_for_workflow_complete(taskid):
-    while time.time() - START_TIME < 1800:  # limit test to 30 minutes
+    result = None
+    while time.time() - START_TIME < 1800 or result is None:  # limit test to 30 minutes
         result = fit_common.rackhdapi("/api/2.0/workflows/" + taskid)
         if result['status'] != 200:
             log.error(" HTTP error: " + result['text'])

--- a/test/tests/bootstrap/test_api20_os_bootstrap_parallel_proxy.py
+++ b/test/tests/bootstrap/test_api20_os_bootstrap_parallel_proxy.py
@@ -4,7 +4,7 @@ Copyright 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 Author(s):
 George Paulos
 
-This script tests base case of the RackHD API 2.0 OS bootstrap workflows.
+This script tests minimum payload base case of the RackHD API 2.0 OS bootstrap workflows using proxy method.
 This routine runs OS bootstrap jobs simultaneously on multiple nodes.
 For 11 tests to run, 11 nodes are required in the stack. If there are less than that, tests will be skipped.
 This test takes 15-20 minutes to run.
@@ -65,6 +65,7 @@ import fit_path  # NOQA: unused import
 from nose.plugins.attrib import attr
 import fit_common
 import flogging
+import time
 log = flogging.get_loggers()
 
 # This gets the list of nodes
@@ -73,27 +74,29 @@ NODECATALOG = fit_common.node_select()
 # dict containing bootstrap workflow IDs and states
 NODE_STATUS = {}
 
+# global timer
+START_TIME = time.time()
+
 # download RackHD config from host
 rackhdconfig = fit_common.rackhdapi('/api/2.0/config')['json']
 rackhdhost = "http://" + str(rackhdconfig['apiServerAddress']) + ":" + str(rackhdconfig['apiServerPort'])
 
 
-# this routine polls a task ID for completion
-def wait_for_task_complete(taskid, retries=60):
-    for dummy in range(0, retries):
+# this routine polls a workflow task ID for completion
+def wait_for_workflow_complete(taskid):
+    while time.time() - START_TIME < 1800:  # limit test to 30 minutes
         result = fit_common.rackhdapi("/api/2.0/workflows/" + taskid)
         if result['status'] != 200:
-            log.error(" " + result['text'])
+            log.error(" HTTP error: " + result['text'])
             return False
         if result['json']['status'] == 'running' or result['json']['status'] == 'pending':
             log.info_5("{} workflow status: {}".format(result['json']['injectableName'], result['json']['status']))
             fit_common.time.sleep(30)
         elif result['json']['status'] == 'succeeded':
             log.info_5("{} workflow status: {}".format(result['json']['injectableName'], result['json']['status']))
-            log.info_5(" " + result['text'])
             return True
         else:
-            log.error(" " + result['text'])
+            log.error(" Workflow failed: " + result['text'])
             return False
     log.error(" Workflow Timeout: " + result['text'])
     return False
@@ -153,6 +156,7 @@ class api20_bootstrap_base(fit_common.unittest.TestCase):
             if proxy_select(item['path']) and nodeindex < len(NODECATALOG):
                 # delete active workflows for specified node
                 fit_common.cancel_active_workflows(NODECATALOG[nodeindex])
+                # base payload common to all Linux
                 payload_data = {"options": {"defaults": {
                                 "version": item['version'],
                                 "kvm": item['kvm'],
@@ -163,7 +167,7 @@ class api20_bootstrap_base(fit_common.unittest.TestCase):
                                 "users": [{"name": "rackhduser",
                                            "password": "RackHDRocks!",
                                            "uid": 1010}]}}}
-                # OS specific requirements
+                # OS specific payload requirements
                 if item['workflow'] == "Graph.InstallUbuntu":
                     payload_data["options"]["defaults"]["baseUrl"] = "install/netboot/ubuntu-installer/amd64"
                     payload_data["options"]["defaults"]["kargs"] = {"live-installer/net-image": rackhdhost +
@@ -175,16 +179,16 @@ class api20_bootstrap_base(fit_common.unittest.TestCase):
                                               '/workflows?name=' + item['workflow'],
                                               action='post', payload=payload_data)
                 if result['status'] == 201:
-                    # this branch saves the task and node IDs
+                    # this saves the task and node IDs
                     NODE_STATUS[NODECATALOG[nodeindex]] = \
                         {"workflow": item['workflow'],
                          "version": item['version'],
                          "kvm": item['kvm'],
                          "id": result['json']['instanceId']}
-                    log.info_5(" TaskID: " + result['text'])
+                    log.info_5(" TaskID: " + result['json']['instanceId'])
                     log.info_5(" Payload: " + fit_common.json.dumps(payload_data))
                 else:
-                    # this is the failure case where there is no task ID
+                    # if no task ID is returned put 'failed' in ID field
                     NODE_STATUS[NODECATALOG[nodeindex]] = \
                         {"workflow": item['workflow'],
                          "version": item['version'],
@@ -198,57 +202,57 @@ class api20_bootstrap_base(fit_common.unittest.TestCase):
     @fit_common.unittest.skipUnless(node_taskid("Graph.InstallESXi", "5.5", False) != '',
                                     "Skipping ESXi5.5, repo not configured or node unavailable")
     def test_api20_bootstrap_esxi55(self):
-        self.assertTrue(wait_for_task_complete(node_taskid("Graph.InstallESXi", "5.5", False)), "ESXi5.5 failed.")
+        self.assertTrue(wait_for_workflow_complete(node_taskid("Graph.InstallESXi", "5.5", False)), "ESXi5.5 failed.")
 
     @fit_common.unittest.skipUnless(node_taskid("Graph.InstallESXi", "6.0", False) != '',
                                     "Skipping ESXi6.0, repo not configured or node unavailable")
     def test_api20_bootstrap_esxi60(self):
-        self.assertTrue(wait_for_task_complete(node_taskid("Graph.InstallESXi", "6.0", False)), "ESXi6.0 failed.")
+        self.assertTrue(wait_for_workflow_complete(node_taskid("Graph.InstallESXi", "6.0", False)), "ESXi6.0 failed.")
 
     @fit_common.unittest.skipUnless(node_taskid("Graph.InstallCentOS", "6.5", False) != '',
                                     "Skipping Centos 6.5, repo not configured or node unavailable")
     def test_api20_bootstrap_centos65(self):
-        self.assertTrue(wait_for_task_complete(node_taskid("Graph.InstallCentOS", "6.5", False)), "Centos 6.5 failed.")
+        self.assertTrue(wait_for_workflow_complete(node_taskid("Graph.InstallCentOS", "6.5", False)), "Centos 6.5 failed.")
 
     @fit_common.unittest.skipUnless(node_taskid("Graph.InstallCentOS", "6.5", True) != '',
                                     "Skipping Centos 6.5 KVM, repo not configured or node unavailable")
     def test_api20_bootstrap_centos65_kvm(self):
-        self.assertTrue(wait_for_task_complete(node_taskid("Graph.InstallCentOS", "6.5", True)), "Centos 6.5 KVM failed.")
+        self.assertTrue(wait_for_workflow_complete(node_taskid("Graph.InstallCentOS", "6.5", True)), "Centos 6.5 KVM failed.")
 
     @fit_common.unittest.skipUnless(node_taskid("Graph.InstallCentOS", "7", False) != '',
                                     "Skipping Centos 7.0, repo not configured or node unavailable")
     def test_api20_bootstrap_centos70(self):
-        self.assertTrue(wait_for_task_complete(node_taskid("Graph.InstallCentOS", "7", False)), "Centos 7.0 failed.")
+        self.assertTrue(wait_for_workflow_complete(node_taskid("Graph.InstallCentOS", "7", False)), "Centos 7.0 failed.")
 
     @fit_common.unittest.skipUnless(node_taskid("Graph.InstallCentOS", "7", True) != '',
                                     "Skipping Centos 7.0 KVM, repo not configured or node unavailable")
     def test_api20_bootstrap_centos70_kvm(self):
-        self.assertTrue(wait_for_task_complete(node_taskid("Graph.InstallCentOS", "7", True)), "Centos 7.0 KVM failed.")
+        self.assertTrue(wait_for_workflow_complete(node_taskid("Graph.InstallCentOS", "7", True)), "Centos 7.0 KVM failed.")
 
     @fit_common.unittest.skipUnless(node_taskid("Graph.InstallRHEL", "7", False) != '',
                                     "Skipping Redhat 7.0, repo not configured or node unavailable")
     def test_api20_bootstrap_rhel70(self):
-        self.assertTrue(wait_for_task_complete(node_taskid("Graph.InstallRHEL", "7", False)), "RHEL 7.0 failed.")
+        self.assertTrue(wait_for_workflow_complete(node_taskid("Graph.InstallRHEL", "7", False)), "RHEL 7.0 failed.")
 
     @fit_common.unittest.skipUnless(node_taskid("Graph.InstallRHEL", "7", True) != '',
                                     "Skipping Redhat 7.0 KVM, repo not configured or node unavailable")
     def test_api20_bootstrap_rhel70_kvm(self):
-        self.assertTrue(wait_for_task_complete(node_taskid("Graph.InstallRHEL", "7", True)), "RHEL 7.0 KVM failed.")
+        self.assertTrue(wait_for_workflow_complete(node_taskid("Graph.InstallRHEL", "7", True)), "RHEL 7.0 KVM failed.")
 
     @fit_common.unittest.skipUnless(node_taskid("Graph.InstallUbuntu", "trusty", False) != '',
                                     "Skipping Ubuntu 14, repo not configured or node unavailable")
     def test_api20_bootstrap_ubuntu14(self):
-        self.assertTrue(wait_for_task_complete(node_taskid("Graph.InstallUbuntu", "trusty", False)), "Ubuntu 14 failed.")
+        self.assertTrue(wait_for_workflow_complete(node_taskid("Graph.InstallUbuntu", "trusty", False)), "Ubuntu 14 failed.")
 
     @fit_common.unittest.skipUnless(node_taskid("Graph.InstallCoreOS", "899.17.0", False) != '',
                                     "Skipping CoreOS 899.17.0, repo not configured or node unavailable")
     def test_api20_bootstrap_coreos899_17(self):
-        self.assertTrue(wait_for_task_complete(node_taskid("Graph.InstallCoreOS", "899.17.0", False)), "CoreOS 899.17 failed.")
+        self.assertTrue(wait_for_workflow_complete(node_taskid("Graph.InstallCoreOS", "899.17.0", False)), "CoreOS 899 failed.")
 
     @fit_common.unittest.skipUnless(node_taskid("Graph.InstallSUSE", "12", False) != '',
                                     "Skipping SuSe 12, repo not configured or node unavailable")
     def test_api20_bootstrap_suse12(self):
-        self.assertTrue(wait_for_task_complete(node_taskid("Graph.InstallSUSE", "12", False)), "SuSe 12 failed.")
+        self.assertTrue(wait_for_workflow_complete(node_taskid("Graph.InstallSUSE", "12", False)), "SuSe 12 failed.")
 
 
 if __name__ == '__main__':

--- a/test/tests/bootstrap/test_api20_os_bootstrap_parallel_proxy.py
+++ b/test/tests/bootstrap/test_api20_os_bootstrap_parallel_proxy.py
@@ -78,7 +78,11 @@ NODE_STATUS = {}
 START_TIME = time.time()
 
 # download RackHD config from host
-rackhdconfig = fit_common.rackhdapi('/api/2.0/config')['json']
+rackhdresult = fit_common.rackhdapi('/api/2.0/config')
+if rackhdresult['status'] != 200:
+    log.error(" Unable to contact host, exiting. ")
+    sys.exit(255)
+rackhdconfig = rackhdresult['json']
 rackhdhost = "http://" + str(rackhdconfig['apiServerAddress']) + ":" + str(rackhdconfig['apiServerPort'])
 
 
@@ -92,7 +96,7 @@ def wait_for_workflow_complete(taskid):
             return False
         if result['json']['status'] == 'running' or result['json']['status'] == 'pending':
             log.info_5("{} workflow status: {}".format(result['json']['injectableName'], result['json']['status']))
-            fit_common.time.sleep(30)
+            time.sleep(30)
         elif result['json']['status'] == 'succeeded':
             log.info_5("{} workflow status: {}".format(result['json']['injectableName'], result['json']['status']))
             return True

--- a/test/tests/bootstrap/test_api20_os_bootstrap_parallel_proxy.py
+++ b/test/tests/bootstrap/test_api20_os_bootstrap_parallel_proxy.py
@@ -142,7 +142,7 @@ for item in OSLIST:
 # ------------------------ Tests -------------------------------------
 
 
-@attr(all=True, regression=True)
+@attr(all=True)
 class api20_bootstrap_base(fit_common.unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -166,7 +166,9 @@ class api20_bootstrap_base(fit_common.unittest.TestCase):
                 # OS specific requirements
                 if item['workflow'] == "Graph.InstallUbuntu":
                     payload_data["options"]["defaults"]["baseUrl"] = "install/netboot/ubuntu-installer/amd64"
-                    payload_data["options"]["defaults"]["kargs"] = {"live-installer/net-image": rackhdhost + proxy_select(item['path']) + "/ubuntu/install/filesystem.squashfs"}
+                    payload_data["options"]["defaults"]["kargs"] = {"live-installer/net-image": rackhdhost +
+                                                                    proxy_select(item['path']) +
+                                                                    "/ubuntu/install/filesystem.squashfs"}
                 # run workflow
                 result = fit_common.rackhdapi('/api/2.0/nodes/' +
                                               NODECATALOG[nodeindex] +

--- a/test/tests/bootstrap/test_api20_os_bootstrap_parallel_proxy.py
+++ b/test/tests/bootstrap/test_api20_os_bootstrap_parallel_proxy.py
@@ -160,8 +160,8 @@ class api20_bootstrap_base(fit_common.unittest.TestCase):
                                 "rootPassword": "1234567",
                                 "hostname": "rackhdnode",
                                 "dnsServers": [rackhdconfig['apiServerAddress']],
-                                "users": [{"name": "RackHDRocks!",
-                                           "password": "R@ckHD1!",
+                                "users": [{"name": "rackhduser",
+                                           "password": "RackHDRocks!",
                                            "uid": 1010}]}}}
                 # OS specific requirements
                 if item['workflow'] == "Graph.InstallUbuntu":

--- a/test/tests/bootstrap/test_api20_os_bootstrap_parallel_proxy.py
+++ b/test/tests/bootstrap/test_api20_os_bootstrap_parallel_proxy.py
@@ -1,0 +1,253 @@
+'''
+Copyright 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+Author(s):
+George Paulos
+
+This script tests base case of the RackHD API 2.0 OS bootstrap workflows.
+This routine runs OS bootstrap jobs simultaneously on multiple nodes.
+For 11 tests to run, 11 nodes are required in the stack. If there are less than that, tests will be skipped.
+This test takes 15-20 minutes to run.
+
+OS bootstrap tests require special RackHD configuration and mirror repositories for the OS images.
+OS images are loaded via RackHD "httpProxies" settings in config.json.
+
+Example:
+      "httpProxies": [
+        {
+          "localPath": "/ESXi/5.5",
+          "remotePath": "/",
+          "server": "http://os-mirror-server/esxi/5.5/esxi"
+        },
+        {
+          "localPath": "/ESXi/6.0",
+          "remotePath": "/",
+          "server": "http://os-mirror-server/6.0/esxi6"
+        },
+        {
+          "localPath": "/CentOS/6.5",
+          "remotePath": "/",
+          "server": "http://os-mirror-server/centos/6.5/os/x86_64"
+        },
+        {
+          "localPath": "/CentOS/7.0",
+          "remotePath": "/",
+          "server": "http://os-mirror-server/centos/7/os/x86_64"
+        },
+        {
+          "localPath": "/RHEL/7.0",
+          "remotePath": "/",
+          "server": "http://os-mirror-server/rhel/7.0/os/x86_64"
+        },
+        {
+          "localPath": "/coreos",
+          "remotePath": "/",
+          "server": "http://os-mirror-server/mirrors/coreos/17"
+        },
+        {
+          "localPath": "/SLES/12",
+          "remotePath": "/",
+          "server": "http://os-mirror-server/mirrors/sles/12"
+        },
+        {
+          "localPath": "/Ubuntu/14",
+          "remotePath": "/",
+          "server": "http://os-mirror-server/mirrors/ubuntu/boot/14.04.4"
+        }
+      ],
+
+For each OS type, the "localpath" string must conform to the convention above.
+The "server' URL points to the location of the OS executables in an image repository.
+
+'''
+
+import fit_path  # NOQA: unused import
+from nose.plugins.attrib import attr
+import fit_common
+import flogging
+log = flogging.get_loggers()
+
+# This gets the list of nodes
+NODECATALOG = fit_common.node_select()
+
+# dict containing bootstrap workflow IDs and states
+NODE_STATUS = {}
+
+# download RackHD config from host
+rackhdconfig = fit_common.rackhdapi('/api/2.0/config')['json']
+rackhdhost = "http://" + str(rackhdconfig['apiServerAddress']) + ":" + str(rackhdconfig['apiServerPort'])
+
+
+# this routine polls a task ID for completion
+def wait_for_task_complete(taskid, retries=60):
+    for dummy in range(0, retries):
+        result = fit_common.rackhdapi("/api/2.0/workflows/" + taskid)
+        if result['status'] != 200:
+            log.error(" " + result['text'])
+            return False
+        if result['json']['status'] == 'running' or result['json']['status'] == 'pending':
+            log.info_5("{} workflow status: {}".format(result['json']['injectableName'], result['json']['status']))
+            fit_common.time.sleep(30)
+        elif result['json']['status'] == 'succeeded':
+            log.info_5("{} workflow status: {}".format(result['json']['injectableName'], result['json']['status']))
+            log.info_5(" " + result['text'])
+            return True
+        else:
+            log.error(" " + result['text'])
+            return False
+    log.error(" Workflow Timeout: " + result['text'])
+    return False
+
+
+# helper routine for selecting OS image path by matching proxy 'localPath'
+def proxy_select(tag):
+    for entry in rackhdconfig['httpProxies']:
+        if tag == entry['localPath']:
+            return entry['localPath']
+    return ''
+
+
+# helper routine to return the task ID associated with the running bootstrap workflow
+def node_taskid(workflow, version, kvm):
+    for entry in NODE_STATUS:
+        if NODE_STATUS[entry]['workflow'] == workflow \
+                and NODE_STATUS[entry]['version'] == version \
+                and NODE_STATUS[entry]['kvm'] == kvm:
+            return NODE_STATUS[entry]['id']
+    return ""
+
+
+OSLIST = [
+    {"workflow": "Graph.InstallESXi", "version": "5.5", "path": "/ESXi/5.5", "kvm": False},
+    {"workflow": "Graph.InstallESXi", "version": "6.0", "path": "/ESXi/6.0", "kvm": False},
+    {"workflow": "Graph.InstallCentOS", "version": "6.5", "path": "/CentOS/6.5", "kvm": False},
+    {"workflow": "Graph.InstallCentOS", "version": "7", "path": "/CentOS/7.0", "kvm": False},
+    {"workflow": "Graph.InstallRHEL", "version": "7", "path": "/RHEL/7.0", "kvm": False},
+    {"workflow": "Graph.InstallSUSE", "version": "12", "path": "/SLES/12", "kvm": False},
+    {"workflow": "Graph.InstallUbuntu", "version": "trusty", "path": "/Ubuntu/14", "kvm": False},
+    {"workflow": "Graph.InstallCoreOS", "version": "899.17.0", "path": "/coreos", "kvm": False},
+    {"workflow": "Graph.InstallRHEL", "version": "7", "path": "/RHEL/7.0", "kvm": True},
+    {"workflow": "Graph.InstallCentOS", "version": "6.5", "path": "/CentOS/6.5", "kvm": True},
+    {"workflow": "Graph.InstallCentOS", "version": "7", "path": "/CentOS/7.0", "kvm": True}
+]
+
+# Match up tests to node IDs to feed skip decorators
+index = 0  # node index
+for item in OSLIST:
+    if proxy_select(item['path']) and index < len(NODECATALOG):
+        NODE_STATUS[NODECATALOG[index]] = \
+            {"workflow": item['workflow'], "version": item['version'], "kvm": item['kvm'], "id": "Pending"}
+    index += 1
+
+# ------------------------ Tests -------------------------------------
+
+
+@attr(all=True, regression=True)
+class api20_bootstrap_base(fit_common.unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # run all OS install workflows first
+        nodeindex = 0
+        for item in OSLIST:
+            # if OS proxy entry exists in RackHD config, run bootstrap against selected node
+            if proxy_select(item['path']) and nodeindex < len(NODECATALOG):
+                # delete active workflows for specified node
+                fit_common.cancel_active_workflows(NODECATALOG[nodeindex])
+                payload_data = {"options": {"defaults": {
+                                "version": item['version'],
+                                "kvm": item['kvm'],
+                                "repo": rackhdhost + proxy_select(item['path']),
+                                "rootPassword": "1234567",
+                                "hostname": "rackhdnode",
+                                "dnsServers": [rackhdconfig['apiServerAddress']],
+                                "users": [{"name": "RackHDRocks!",
+                                           "password": "R@ckHD1!",
+                                           "uid": 1010}]}}}
+                # OS specific requirements
+                if item['workflow'] == "Graph.InstallUbuntu":
+                    payload_data["options"]["defaults"]["baseUrl"] = "install/netboot/ubuntu-installer/amd64"
+                    payload_data["options"]["defaults"]["kargs"] = {"live-installer/net-image": rackhdhost + proxy_select(item['path']) + "/ubuntu/install/filesystem.squashfs"}
+                # run workflow
+                result = fit_common.rackhdapi('/api/2.0/nodes/' +
+                                              NODECATALOG[nodeindex] +
+                                              '/workflows?name=' + item['workflow'],
+                                              action='post', payload=payload_data)
+                if result['status'] == 201:
+                    # this branch saves the task and node IDs
+                    NODE_STATUS[NODECATALOG[nodeindex]] = \
+                        {"workflow": item['workflow'],
+                         "version": item['version'],
+                         "kvm": item['kvm'],
+                         "id": result['json']['instanceId']}
+                    log.info_5(" TaskID: " + result['text'])
+                    log.info_5(" Payload: " + fit_common.json.dumps(payload_data))
+                else:
+                    # this is the failure case where there is no task ID
+                    NODE_STATUS[NODECATALOG[nodeindex]] = \
+                        {"workflow": item['workflow'],
+                         "version": item['version'],
+                         "kvm": item['kvm'],
+                         'id': "failed"}
+                    log.error(" TaskID: " + result['text'])
+                    log.error(" Payload: " + fit_common.json.dumps(payload_data))
+                # increment node index to run next bootstrap
+                nodeindex += 1
+
+    @fit_common.unittest.skipUnless(node_taskid("Graph.InstallESXi", "5.5", False) != '',
+                                    "Skipping ESXi5.5, repo not configured or node unavailable")
+    def test_api20_bootstrap_esxi55(self):
+        self.assertTrue(wait_for_task_complete(node_taskid("Graph.InstallESXi", "5.5", False)), "ESXi5.5 failed.")
+
+    @fit_common.unittest.skipUnless(node_taskid("Graph.InstallESXi", "6.0", False) != '',
+                                    "Skipping ESXi6.0, repo not configured or node unavailable")
+    def test_api20_bootstrap_esxi60(self):
+        self.assertTrue(wait_for_task_complete(node_taskid("Graph.InstallESXi", "6.0", False)), "ESXi6.0 failed.")
+
+    @fit_common.unittest.skipUnless(node_taskid("Graph.InstallCentOS", "6.5", False) != '',
+                                    "Skipping Centos 6.5, repo not configured or node unavailable")
+    def test_api20_bootstrap_centos65(self):
+        self.assertTrue(wait_for_task_complete(node_taskid("Graph.InstallCentOS", "6.5", False)), "Centos 6.5 failed.")
+
+    @fit_common.unittest.skipUnless(node_taskid("Graph.InstallCentOS", "6.5", True) != '',
+                                    "Skipping Centos 6.5 KVM, repo not configured or node unavailable")
+    def test_api20_bootstrap_centos65_kvm(self):
+        self.assertTrue(wait_for_task_complete(node_taskid("Graph.InstallCentOS", "6.5", True)), "Centos 6.5 KVM failed.")
+
+    @fit_common.unittest.skipUnless(node_taskid("Graph.InstallCentOS", "7", False) != '',
+                                    "Skipping Centos 7.0, repo not configured or node unavailable")
+    def test_api20_bootstrap_centos70(self):
+        self.assertTrue(wait_for_task_complete(node_taskid("Graph.InstallCentOS", "7", False)), "Centos 7.0 failed.")
+
+    @fit_common.unittest.skipUnless(node_taskid("Graph.InstallCentOS", "7", True) != '',
+                                    "Skipping Centos 7.0 KVM, repo not configured or node unavailable")
+    def test_api20_bootstrap_centos70_kvm(self):
+        self.assertTrue(wait_for_task_complete(node_taskid("Graph.InstallCentOS", "7", True)), "Centos 7.0 KVM failed.")
+
+    @fit_common.unittest.skipUnless(node_taskid("Graph.InstallRHEL", "7", False) != '',
+                                    "Skipping Redhat 7.0, repo not configured or node unavailable")
+    def test_api20_bootstrap_rhel70(self):
+        self.assertTrue(wait_for_task_complete(node_taskid("Graph.InstallRHEL", "7", False)), "RHEL 7.0 failed.")
+
+    @fit_common.unittest.skipUnless(node_taskid("Graph.InstallRHEL", "7", True) != '',
+                                    "Skipping Redhat 7.0 KVM, repo not configured or node unavailable")
+    def test_api20_bootstrap_rhel70_kvm(self):
+        self.assertTrue(wait_for_task_complete(node_taskid("Graph.InstallRHEL", "7", True)), "RHEL 7.0 KVM failed.")
+
+    @fit_common.unittest.skipUnless(node_taskid("Graph.InstallUbuntu", "trusty", False) != '',
+                                    "Skipping Ubuntu 14, repo not configured or node unavailable")
+    def test_api20_bootstrap_ubuntu14(self):
+        self.assertTrue(wait_for_task_complete(node_taskid("Graph.InstallUbuntu", "trusty", False)), "Ubuntu 14 failed.")
+
+    @fit_common.unittest.skipUnless(node_taskid("Graph.InstallCoreOS", "899.17.0", False) != '',
+                                    "Skipping CoreOS 899.17.0, repo not configured or node unavailable")
+    def test_api20_bootstrap_coreos899_17(self):
+        self.assertTrue(wait_for_task_complete(node_taskid("Graph.InstallCoreOS", "899.17.0", False)), "CoreOS 899.17 failed.")
+
+    @fit_common.unittest.skipUnless(node_taskid("Graph.InstallSUSE", "12", False) != '',
+                                    "Skipping SuSe 12, repo not configured or node unavailable")
+    def test_api20_bootstrap_suse12(self):
+        self.assertTrue(wait_for_task_complete(node_taskid("Graph.InstallSUSE", "12", False)), "SuSe 12 failed.")
+
+
+if __name__ == '__main__':
+    fit_common.unittest.main()


### PR DESCRIPTION
This script implements 'parallel' OS install via proxy using API 2.0 commands. As with the Redfish proxy test, the script harvests test repo information from the config.json 'http-proxies' section then runs a minimum-payload installation test on each.  This test script is suitable for use in PR gate because it uses minimum resources and executes in under 20 minutes.

To run all tests, a stack must contain 11 nodes, virtual or physical but can be run with fewer. As with the proxy-based tests, this test will skip any test where there are insufficient nodes to run or where appropriate repo info is not present in config.json.

This test does NOT contain a Windows OS install which cannot be performed via proxy.

This test is NOT tagged to run under Smoke or Regression runs and must be executed at the run_test.py command line for use in its own pipeline.

CoreOS test may fail due to this product bug:
https://rackhd.atlassian.net/browse/RAC-4755

ESXi tests fail in MN lab due to this product bug:
https://rackhd.atlassian.net/browse/RAC-4125

@hohene @jimturnquist @johren @keedya
