### PR TITLE
Cached OVA from a Pre-Build VMX

### DIFF
--- a/packer/HWIMO-BUILD
+++ b/packer/HWIMO-BUILD
@@ -196,9 +196,9 @@ fi
 
 # pre-process the packer template file
 PACKER_TEMP=template-${OS_VER}.json.tmp
+TMP_FILE_STREAM=$(cat template-${OS_VER}.json)
 if [[ $IS_UPLOAD_ATLAS == false ]] && [[ "$BUILD_TYPE"  != "vmware" ]]
 then
-    TMP_FILE_STREAM=$(cat template-${OS_VER}.json)
     if [ ! -n "$(which jq)" ] ; then
         echo "${ERROR_HEADER} jq is not installed . please install it, e.x. sudo apt-get install jq... Aborting. "
         exit 5
@@ -209,8 +209,8 @@ then
 
      echo "[Info] the template-${OS_VER}.json has been cutomized , to remove the vagrant-upload step"
      # Write back the template file
-     echo "$TMP_FILE_STREAM" > $PACKER_TEMP
 fi
+echo "$TMP_FILE_STREAM" > $PACKER_TEMP
 
 # indictor of packer build type for vmware
 if [ "$BUILD_TYPE"  == "vmware" ];  then

--- a/packer/HWIMO-BUILD
+++ b/packer/HWIMO-BUILD
@@ -11,8 +11,11 @@
 # * ATLAS_NAME     - optional, required only when UPLOAD_BOX_TO_ATLAS is true.
 # * ATLAS_TOKEN    - optional, required only when UPLOAD_BOX_TO_ATLAS is true.
 # * ATLAS_VERSION  - optional, by default is "".when UPLOAD_BOX_TO_ATLAS is true, the box will be uploaded to ATLAS as ATLAS_VERSION( format only accepts like 1.2.3).
-# * CUSTOMIZED_PROPERTY_OVA - optional, by default false, only effective when BUILD_TYPE is vmware.. if true, the OVA can be specified IP during deployment. only supported by vCenter
-# * BUILD_STAGE     - optional, by default is BUILD_ALL. Other options are "BUILD_TEMPLATE" (a prebuild cache, vmx or ovf), "BUILD_FINAL"( Build ova or box from the template) , or "BUILD_ALL"(including both steps).
+# * CUSTOMIZED_PROPERTY_OVA - optional, by default false, only effective when BUILD_TYPE is vmware.. 
+#                           - if true, the OVA can be specified IP during deployment. only supported by vCenter
+# * BUILD_STAGE     - optional, by default is BUILD_ALL. other options as below:
+#                   - "BUILD_TEMPLATE" (a prebuild cache, vmx or ovf),
+#                   - "BUILD_FINAL"( Build ova or box from the template) , or "BUILD_ALL"(including both steps).
 ###################################################
 
 INFO_HEADER="[Info]"

--- a/packer/HWIMO-BUILD
+++ b/packer/HWIMO-BUILD
@@ -12,11 +12,13 @@
 # * ATLAS_TOKEN    - optional, required only when UPLOAD_BOX_TO_ATLAS is true.
 # * ATLAS_VERSION  - optional, by default is "".when UPLOAD_BOX_TO_ATLAS is true, the box will be uploaded to ATLAS as ATLAS_VERSION( format only accepts like 1.2.3).
 # * CUSTOMIZED_PROPERTY_OVA - optional, by default false, only effective when BUILD_TYPE is vmware.. if true, the OVA can be specified IP during deployment. only supported by vCenter
+# * BUILD_STAGE     - optional, by default is BUILD_ALL. Other options are "BUILD_TEMPLATE" (a prebuild cache, vmx or ovf), "BUILD_FINAL"( Build ova or box from the template) , or "BUILD_ALL"(including both steps).
 ###################################################
 
 INFO_HEADER="[Info]"
 WARNING_HEADER="[Warning]"
 ERROR_HEADER="[Error]"
+
 
 # early exit on command failure
 set -e
@@ -78,7 +80,21 @@ if [ ! -f "ansible/${ANSIBLE_PLAYBOOK}.yml" ]; then
     echo "${ERROR_HEADER} The target ansible playbook(ansible/${ANSIBLE_PLAYBOOK}.yml) does not exist. Aborting..."
     exit 3
 fi
-echo "${INFO_HEADER} Install RackHD with ansible :  ${ANSIBLE_PLAYBOOK}.yml "
+if [ "$BUILD_STAGE" == "BUILD_ALL" ] ; then
+    echo "${INFO_HEADER} Full Build:  Install RackHD with (1) ansible playbook rackhd_prepare.yml, (2) ansible playbook ${ANSIBLE_PLAYBOOK}_mini.yml "
+else
+    if [ "$BUILD_STAGE" == "BUILD_FINAL" ] ; then
+        echo "${INFO_HEADER} Second Half Build: Install RackHD with ansible :  ${ANSIBLE_PLAYBOOK}_mini.yml "
+    else
+        if [ "$BUILD_STAGE" == "BUILD_TEMPLATE" ] ; then
+            echo "${INFO_HEADER} First Half Build: Prepare RackHD dependency with ansible :  rackhd_prepare.yml "
+        else
+            echo "${ERROR_HEADER} Unrecongnized parameter BUILD_STAGE=$BUILD_STAGE. Abort ! "
+            exit 2
+        fi
+    fi
+fi
+
 
 ### $RACKHD_VERSION is used for package install provisioner:  `apt-get install rackhd=$RACKHD_VERSION` ###
 
@@ -110,6 +126,13 @@ then
     fi
 fi
 
+### For OVA Build, option is to build OVA directlly from VMX, or build a VMX (which includes all RackHD Prerequisite)
+if  [ ! -n "${BUILD_STAGE}" ];  then
+    BUILD_STAGE="BUILD_ALL"
+fi
+
+
+
 
 ############################  Parameter Process ################ end #############
 
@@ -123,7 +146,12 @@ export PACKER_NO_COLOR=1  # for Jenkins usage. if manual run, suggest to turn co
 
 
 # default is output-${type}. you can customized in packer's json by "output_directory" param
-VMDIR=output-${BUILD_TYPE}-iso
+if [ "$BUILD_TYPE"  == "vmware" ]; then
+     VMDIR=output-${BUILD_TYPE}-vmx # output of Build VMWare from VMX
+else
+     VMDIR=output-${BUILD_TYPE}-ovf # output of Build VirtualBox from OVF
+fi
+
 
 VM_NAME=rackhd-${OS_VER}
 
@@ -153,12 +181,6 @@ then
     PACKER=/opt/packer/packer
 fi
 
-if [ -x /usr/local/bin/ts ]
-then
-    TS=/usr/local/bin/ts
-else
-    TS=cat
-fi
 
 
 # Check Free Disk Space,  VMWare Workstation may stuck if disk space too small
@@ -173,29 +195,69 @@ if [ "$BUILD_TYPE"  == "vmware" ];  then
 fi
 
 # pre-process the packer template file
-PACKER_TEMP=$(cat template-${OS_VER}.json)
-if [[ $IS_UPLOAD_ATLAS == false ]]
+PACKER_TEMP=template-${OS_VER}.json.tmp
+if [[ $IS_UPLOAD_ATLAS == false ]] && [[ "$BUILD_TYPE"  != "vmware" ]]
 then
+    TMP_FILE_STREAM=$(cat template-${OS_VER}.json)
     if [ ! -n "$(which jq)" ] ; then
         echo "${ERROR_HEADER} jq is not installed . please install it, e.x. sudo apt-get install jq... Aborting. "
         exit 5
     fi
     # Delete the post-processors blocks in the template.json, before sending to 'packer build'
-#    PACKER_TEMP=$( jq 'del(."post-processors")'  template-${OS_VER}.json)
-     PACKER_TEMP=$( jq 'del(.["post-processors"][0][1])' template-${OS_VER}.json | jq 'del(.["push"])')
+#    TMP_FILE_STREAM=$( jq 'del(."post-processors")'  template-${OS_VER}.json)
+     TMP_FILE_STREAM=$( jq 'del(.["post-processors"][0][1])' template-${OS_VER}.json | jq 'del(.["push"])')
+
+     echo "[Info] the template-${OS_VER}.json has been cutomized , to remove the vagrant-upload step"
+     # Write back the template file
+     echo "$TMP_FILE_STREAM" > $PACKER_TEMP
+fi
+
+# indictor of packer build type for vmware
+if [ "$BUILD_TYPE"  == "vmware" ];  then
+      temp_src_format=vmx
+else
+      temp_src_format=ovf
 fi
 
 
 # execute 'packer build'
-echo ${PACKER_TEMP} | $PACKER build --force --only=${BUILD_TYPE}-iso --var-file=$CFG_FILE  - | $TS | tee packer-install.log 
+if [ "$BUILD_STAGE" == "BUILD_TEMPLATE" ]; then
+    #Build from  iso, create a Pre-build Cache ( vmware:iso-->vmx, virtualbox: iso-->ovf )
+    $PACKER build --force --only=${BUILD_TYPE}-iso  --var-file=$CFG_FILE  ${PACKER_TEMP}  | tee packer-install.log
+else
 
-if [ $? != 0 ]; then
+    if [ "$BUILD_STAGE" == "BUILD_FINAL" ]; then
+         #Build from cache template, and output the final image .(vmware: vmx-->ova, virtualbox: ovf-->box)
+         $PACKER build --force --only=${BUILD_TYPE}-${temp_src_format}  --var-file=$CFG_FILE  --var "playbook=${ANSIBLE_PLAYBOOK}_mini" ${PACKER_TEMP}   | tee packer-install.log
+
+    else
+         #Build from scratch, vmware: iso-->vmx-->ova, virtualbox: iso-->ovf-->box
+         $PACKER build --force --only=${BUILD_TYPE}-${temp_src_format}  --var-file=$CFG_FILE  --var "playbook=rackhd_prepare" ${PACKER_TEMP}   | tee packer-install.log            && \
+         $PACKER build --force --only=${BUILD_TYPE}-vmx  --var-file=$CFG_FILE  --var "playbook=${ANSIBLE_PLAYBOOK}_mini" ${PACKER_TEMP}    | tee packer-install.log
+    fi
+fi
+
+## Check packer build command status, because above we use pipeline, so use  ${PIPESTATUS[0]} to catch return-code of command before pipeline.(only works on bash)
+if [ ${PIPESTATUS[0]} != 0 ]; then
     echo "${ERROR_HEADER} Packer Build failed.. exit"
     exit 3
 fi
 
-if [ "$BUILD_TYPE"  != "vmware" ];  then
+if  [ "$BUILD_STAGE" == "BUILD_TEMPLATE" ]; then
+     if [ "$BUILD_TYPE"  == "vmware" ];  then
+        echo "{INFO_HEADER} Build VMX is successful... Exit the HWIMO-BUILD Script. Use BUILD_STAGE=BUILD_FINAL and ANSIBLE_PLAYBOOK=rackhd_mini_xxxx env variable to build OVA from this VMX."
+     else
+        echo "{INFO_HEADER} Build OVF is successful... Exit the HWIMO-BUILD Script. Use BUILD_STAGE=BUILD_FINAL and ANSIBLE_PLAYBOOK=rackhd_mini_xxxx env variable to build Box from this OVF."
+     fi
+     exit 0
+ fi
+
+if [ "$BUILD_TYPE"  == "virtualbox" ];  then
     echo "${INFO_HEADER} Skip the post-processing(signing/clamscan/ovf-template injection) for virtualbox for the time being ..."
+    mv packer_virtualbox-ovf_virtualbox.box ${VM_NAME}.box
+    echo "****************"
+    echo "Successfully create ${VM_NAME}.box"
+    echo "****************"
     exit 0
 fi
 

--- a/packer/README.md
+++ b/packer/README.md
@@ -54,6 +54,7 @@ jq 'del(.["post-processors", "push"])' /tmp/template-${OS_VER}.json > template-$
 - use VMWare Tools
 
  Option #1:  Install VMWare WorkStation locally on the same OS where the packer build runs ( example: install VMware Workstation 12.x )
+ Note: the licensed version of VMWare WorkStation is required, to enable the 2-stages vmware build.(iso -> temp_vmx -> final_ova )
 
  Option #2:  To use a remote VMware vSphere Hypervisor to build your VM, just to add below lines in template-ubuntu-*.json as sub fields of "builders"(refer to https://www.packer.io/docs/builders/vmware-iso.html for more info.)
 

--- a/packer/ansible/rackhd_ci_builds_mini.yml
+++ b/packer/ansible/rackhd_ci_builds_mini.yml
@@ -1,0 +1,9 @@
+---
+- name: RackHD Demonstration Server
+  hosts: local
+  vars:
+    rackhd_version: ""
+    is_release: false
+  sudo: no
+  roles:
+    - rackhd-builds

--- a/packer/ansible/rackhd_local_mini.yml
+++ b/packer/ansible/rackhd_local_mini.yml
@@ -1,0 +1,11 @@
+---
+- name: Development Server
+  hosts: local
+  sudo: no
+  roles:
+    - remoterepos
+    - images
+    - swagger
+  vars:
+# branch of https://github.com/rackhd/rackhd to be used
+    - branch: "master"

--- a/packer/ansible/rackhd_packer_mini.yml
+++ b/packer/ansible/rackhd_packer_mini.yml
@@ -1,0 +1,7 @@
+---
+- name: RackHD Demonstration Server
+  hosts: local
+  sudo: no
+  roles:
+    - rackhd-packages
+    - images

--- a/packer/ansible/rackhd_prepare.yml
+++ b/packer/ansible/rackhd_prepare.yml
@@ -1,0 +1,23 @@
+---
+- name: RackHD Demonstration Server
+  hosts: local
+  vars:
+  sudo: no
+  roles:
+    - apt
+    - build
+    - git
+    - rabbitmq
+    - mongodb
+    - node
+    - isc-dhcp-server
+    - monorail
+    - config_admin_ip
+    - snmptool
+    - ipmitool
+    - foreman
+    - pm2
+
+    - integrationtest
+    - postgresql
+    - setuptools

--- a/packer/ansible/rackhd_release_mini.yml
+++ b/packer/ansible/rackhd_release_mini.yml
@@ -1,0 +1,9 @@
+---
+- name: RackHD Demonstration Server
+  hosts: local
+  vars:
+    rackhd_version: ""
+    is_release: true
+  sudo: no
+  roles:
+    - rackhd-builds

--- a/packer/scripts/cleanup.sh
+++ b/packer/scripts/cleanup.sh
@@ -30,9 +30,4 @@ echo "Adding a 2 sec delay to the interface up, to make the dhclient happy"
 echo "pre-up sleep 2" >> /etc/network/interfaces
 
 
-# Modify the /etc/hosts to align with hostname setting in RackHD/packer/scripts/dep.sh
-# by default, the hostname in both /etc/hosts & /etc/hostname are obtained from DHCP server during install.
-# in RackHD/packer/scripts/dep.sh, it's modified , but /etc/hosts(127.0.1.1) never get changed.
 
-NEW_HOST_NAME=$(cat /etc/hostname)
-sed -i  "/127.0.1.1/,/$/c127.0.1.1\t${NEW_HOST_NAME}" /etc/hosts

--- a/packer/scripts/dep.sh
+++ b/packer/scripts/dep.sh
@@ -9,6 +9,10 @@ pip install --upgrade setuptools
 pip install ansible==2.2.0.0
 
 # set a friendly hostname
+# by default, the hostname in both /etc/hosts & /etc/hostname are obtained from DHCP server during install.
 rm -f /etc/hostname
 echo "rackhd" > /etc/hostname
+#Below two lines were moved from scripts/cleanup.sh. I can't recall why they didn't go with /etc/hostname change together...
+NEW_HOST_NAME=$(cat /etc/hostname)
+sed -i  "/127.0.1.1/,/$/c127.0.1.1\t${NEW_HOST_NAME}" /etc/hosts
 

--- a/packer/template-ubuntu-14.04.json
+++ b/packer/template-ubuntu-14.04.json
@@ -12,7 +12,7 @@
         "playbook": "rackhd_mini_release",
         "rackhd_version": ""
     },
-     "provisioners": [
+    "provisioners": [
         {
             "type": "shell",
             "script": "scripts/base.sh",
@@ -54,7 +54,7 @@
             "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'",
             "only": ["virtualbox-ovf","vmware-vmx"]
         },
-         {
+        {
             "type": "ansible-local",
             "inventory_groups": "local",
             "playbook_file": "ansible/rackhd_prepare.yml",
@@ -83,76 +83,76 @@
     ],
   "builders": [
     {
-      "type": "virtualbox-iso",
-      "boot_command": [
-        "<esc><wait>",
-        "<esc><wait>",
-        "<enter><wait>",
-        "/install/vmlinuz<wait>",
-        " auto<wait>",
-        " console-setup/ask_detect=false<wait>",
-        " console-setup/layoutcode=us<wait>",
-        " console-setup/modelcode=pc105<wait>",
-        " debian-installer=en_US<wait>",
-        " fb=false<wait>",
-        " initrd=/install/initrd.gz<wait>",
-        " kbd-chooser/method=us<wait>",
-        " keyboard-configuration/layout=USA<wait>",
-        " keyboard-configuration/variant=USA<wait>",
-        " locale=en_US<wait>",
-        " netcfg/get_hostname=rackhd<wait>",
-        " netcfg/hostname=rackhd<wait>",
-        " noapic<wait>",
-        " interface=auto",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg<wait>",
-        " -- <wait>",
-        "<enter><wait>"
-      ],
-      "format": "ovf",
-      "output_directory": "output-virtualbox-iso",
-      "vm_name": "{{user `vm_name`}}",
-      "boot_wait": "20s",
-      "headless": true,
-      "disk_size": 40960,
-      "headless": true,
-      "guest_os_type": "Ubuntu_64",
-      "http_directory": "http",
-      "iso_checksum": "dd54dc8cfc2a655053d19813c2f9aa9f",
-      "iso_checksum_type": "md5",
-      "iso_url": "http://releases.ubuntu.com/14.04/ubuntu-14.04.5-server-amd64.iso",
-      "ssh_username": "vagrant",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'shutdown -P now' > /tmp/shutdown.sh; echo 'vagrant'|sudo -S sh '/tmp/shutdown.sh'",
-      "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "512" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ],
-        [ "modifyvm", "{{.Name}}", "--nic2", "intnet" ]
-      ]
-      },
-     {
-      "type": "virtualbox-ovf",
-      "source_path": "output-virtualbox-iso/rackhd-ubuntu-14.04.ovf",
-      "vm_name": "{{user `vm_name`}}",
-      "boot_wait": "20s",
-      "headless": true,
-      "headless": true,
-      "http_directory": "http",
-      "ssh_username": "vagrant",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'shutdown -P now' > /tmp/shutdown.sh; echo 'vagrant'|sudo -S sh '/tmp/shutdown.sh'",
-      "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "512" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ],
-        [ "modifyvm", "{{.Name}}", "--nic2", "intnet" ]
-      ]
-      },
+        "type": "virtualbox-iso",
+        "boot_command": [
+            "<esc><wait>",
+            "<esc><wait>",
+            "<enter><wait>",
+            "/install/vmlinuz<wait>",
+            " auto<wait>",
+            " console-setup/ask_detect=false<wait>",
+            " console-setup/layoutcode=us<wait>",
+            " console-setup/modelcode=pc105<wait>",
+            " debian-installer=en_US<wait>",
+            " fb=false<wait>",
+            " initrd=/install/initrd.gz<wait>",
+            " kbd-chooser/method=us<wait>",
+            " keyboard-configuration/layout=USA<wait>",
+            " keyboard-configuration/variant=USA<wait>",
+            " locale=en_US<wait>",
+            " netcfg/get_hostname=rackhd<wait>",
+            " netcfg/hostname=rackhd<wait>",
+            " noapic<wait>",
+            " interface=auto",
+            " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg<wait>",
+            " -- <wait>",
+            "<enter><wait>"
+        ],
+        "format": "ovf",
+        "output_directory": "output-virtualbox-iso",
+        "vm_name": "{{user `vm_name`}}",
+        "boot_wait": "20s",
+        "headless": true,
+        "disk_size": 40960,
+        "headless": true,
+        "guest_os_type": "Ubuntu_64",
+        "http_directory": "http",
+        "iso_checksum": "dd54dc8cfc2a655053d19813c2f9aa9f",
+        "iso_checksum_type": "md5",
+        "iso_url": "http://releases.ubuntu.com/14.04/ubuntu-14.04.5-server-amd64.iso",
+        "ssh_username": "vagrant",
+        "ssh_password": "vagrant",
+        "ssh_port": 22,
+        "ssh_wait_timeout": "10000s",
+        "shutdown_command": "echo 'shutdown -P now' > /tmp/shutdown.sh; echo 'vagrant'|sudo -S sh '/tmp/shutdown.sh'",
+        "vboxmanage": [
+            [ "modifyvm", "{{.Name}}", "--memory", "512" ],
+            [ "modifyvm", "{{.Name}}", "--cpus", "1" ],
+            [ "modifyvm", "{{.Name}}", "--nic2", "intnet" ]
+        ]
+    },
+    {
+        "type": "virtualbox-ovf",
+        "source_path": "output-virtualbox-iso/rackhd-ubuntu-14.04.ovf",
+        "vm_name": "{{user `vm_name`}}",
+        "boot_wait": "20s",
+        "headless": true,
+        "headless": true,
+        "http_directory": "http",
+        "ssh_username": "vagrant",
+        "ssh_password": "vagrant",
+        "ssh_port": 22,
+        "ssh_wait_timeout": "10000s",
+        "shutdown_command": "echo 'shutdown -P now' > /tmp/shutdown.sh; echo 'vagrant'|sudo -S sh '/tmp/shutdown.sh'",
+        "vboxmanage": [
+            [ "modifyvm", "{{.Name}}", "--memory", "512" ],
+            [ "modifyvm", "{{.Name}}", "--cpus", "1" ],
+            [ "modifyvm", "{{.Name}}", "--nic2", "intnet" ]
+        ]
+    },
 
 
-      {
+    {
         "type": "vmware-vmx",
         "vm_name": "{{user `vm_name`}}",
         "output_directory": "output-vmware-vmx",
@@ -205,12 +205,12 @@
             "ethernet3.pcislotnumber": "3"
         }
 
-      },
+    },
 
 
 
 
-      {
+    {
         "type": "vmware-iso",
         "vm_name": "{{user `vm_name`}}",
         "boot_command": [
@@ -289,7 +289,7 @@
             "ethernet3.present": "TRUE",
             "ethernet3.addressType": "generated"
         }
-      }
+    }
   ],
   "post-processors": [
     [{

--- a/packer/template-ubuntu-14.04.json
+++ b/packer/template-ubuntu-14.04.json
@@ -9,14 +9,15 @@
         "atlas_version": "",
         "atlas_token": "{{env `ATLAS_TOKEN`}}",
         "vm_name" : "rackhd-vm",
-        "playbook": "rackhd_package",
+        "playbook": "rackhd_mini_release",
         "rackhd_version": ""
     },
-    "provisioners": [
+     "provisioners": [
         {
             "type": "shell",
             "script": "scripts/base.sh",
-            "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'"
+            "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'",
+            "only": ["virtualbox-iso","vmware-iso"]
         },
         {
             "type": "shell",
@@ -36,26 +37,37 @@
                 "scripts/vagrant.sh",
                 "scripts/dep.sh"
             ],
-            "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'"
+            "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'",
+            "only": ["virtualbox-iso","vmware-iso"]
         },
         {
               "type": "file",
               "source": "scripts/common/get_nic_name_by_index.sh",
-              "destination": "/tmp/get_nic_name_by_index.sh"
+              "destination": "/tmp/get_nic_name_by_index.sh",
+              "only": ["virtualbox-ovf","vmware-vmx"]
         },
         {
             "type": "shell",
             "scripts": [
                 "scripts/addnetif.sh"
             ],
-            "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'"
+            "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'",
+            "only": ["virtualbox-ovf","vmware-vmx"]
+        },
+         {
+            "type": "ansible-local",
+            "inventory_groups": "local",
+            "playbook_file": "ansible/rackhd_prepare.yml",
+            "playbook_dir": "ansible",
+            "only": ["virtualbox-iso", "vmware-iso"]
         },
         {
             "type": "ansible-local",
             "inventory_groups": "local",
             "playbook_file": "ansible/{{user `playbook`}}.yml",
             "playbook_dir": "ansible",
-            "extra_arguments": [ "--extra-vars \"rackhd_version={{user `rackhd_version`}}\"" ]
+            "extra_arguments": [ "--extra-vars \"rackhd_version={{user `rackhd_version`}}\"" ],
+            "only": ["virtualbox-ovf","vmware-vmx"]
         },
         {
             "type": "shell",
@@ -64,8 +76,10 @@
                 "scripts/cleanup.sh",
                 "scripts/zerodisk.sh"
             ],
-            "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'"
+            "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'",
+            "only": ["virtualbox-ovf","vmware-vmx"]
         }
+
     ],
   "builders": [
     {
@@ -94,9 +108,13 @@
         " -- <wait>",
         "<enter><wait>"
       ],
+      "format": "ovf",
+      "output_directory": "output-virtualbox-iso",
+      "vm_name": "{{user `vm_name`}}",
       "boot_wait": "20s",
       "headless": true,
       "disk_size": 40960,
+      "headless": true,
       "guest_os_type": "Ubuntu_64",
       "http_directory": "http",
       "iso_checksum": "dd54dc8cfc2a655053d19813c2f9aa9f",
@@ -113,6 +131,84 @@
         [ "modifyvm", "{{.Name}}", "--nic2", "intnet" ]
       ]
       },
+     {
+      "type": "virtualbox-ovf",
+      "source_path": "output-virtualbox-iso/rackhd-ubuntu-14.04.ovf",
+      "vm_name": "{{user `vm_name`}}",
+      "boot_wait": "20s",
+      "headless": true,
+      "headless": true,
+      "http_directory": "http",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "echo 'shutdown -P now' > /tmp/shutdown.sh; echo 'vagrant'|sudo -S sh '/tmp/shutdown.sh'",
+      "vboxmanage": [
+        [ "modifyvm", "{{.Name}}", "--memory", "512" ],
+        [ "modifyvm", "{{.Name}}", "--cpus", "1" ],
+        [ "modifyvm", "{{.Name}}", "--nic2", "intnet" ]
+      ]
+      },
+
+
+      {
+        "type": "vmware-vmx",
+        "vm_name": "{{user `vm_name`}}",
+        "output_directory": "output-vmware-vmx",
+        "boot_wait": "20s",
+        "headless": true,
+        "http_directory": "http",
+        "source_path": "output-vmware-iso/rackhd-ubuntu-14.04.vmx",
+        "ssh_username": "vagrant",
+        "ssh_password": "vagrant",
+        "ssh_port": 22,
+        "ssh_wait_timeout": "10000s",
+        "shutdown_command": "echo 'shutdown -P now' > /tmp/shutdown.sh; echo 'vagrant'|sudo -S sh '/tmp/shutdown.sh'",
+        "vmx_data": {
+            "memsize": "1024",
+            "numvcpus": "2",
+            "ethernet0.networkName": "NAT",
+
+            "ethernet1.virtualDev": "e1000",
+            "ethernet1.present": "TRUE",
+            "ethernet1.pcislotnumber": "1"
+
+        },
+        "vmx_data_post":
+        {
+            "memsize": "1024",
+            "numvcpus": "2",
+            "cpuid.coresPerSocket": "1",
+
+            "ethernet0.networkName": "ADMIN",
+            "ethernet0.virtualDev": "e1000",
+            "ethernet0.present": "TRUE",
+            "ethernet0.pcislotnumber": "0",
+
+            "ethernet1.networkName": "CONTROL",
+            "ethernet1.virtualDev": "e1000",
+            "ethernet1.present": "TRUE",
+            "ethernet1.addressType": "generated",
+            "ethernet1.pcislotnumber": "1",
+
+            "ethernet2.networkName": "PDU",
+            "ethernet2.virtualDev": "e1000",
+            "ethernet2.present": "TRUE",
+            "ethernet2.addressType": "generated",
+            "ethernet2.pcislotnumber": "2",
+
+            "ethernet3.networkName": "BMC",
+            "ethernet3.virtualDev": "e1000",
+            "ethernet3.present": "TRUE",
+            "ethernet3.addressType": "generated",
+            "ethernet3.pcislotnumber": "3"
+        }
+
+      },
+
+
+
 
       {
         "type": "vmware-iso",
@@ -140,6 +236,7 @@
           " -- <wait>",
           "<enter><wait>"
         ],
+        "output_directory": "output-vmware-iso",
         "boot_wait": "20s",
         "headless": true,
         "disk_size": 40960,

--- a/packer/template-ubuntu-16.04.json
+++ b/packer/template-ubuntu-16.04.json
@@ -9,14 +9,15 @@
         "atlas_version": "",
         "atlas_token": "{{env `ATLAS_TOKEN`}}",
         "vm_name" : "rackhd-vm",
-        "playbook": "rackhd_package",
+        "playbook": "rackhd_mini_release",
         "rackhd_version": ""
     },
-    "provisioners": [
+     "provisioners": [
         {
             "type": "shell",
             "script": "scripts/base.sh",
-            "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'"
+            "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'",
+            "only": ["virtualbox-iso","vmware-iso"]
         },
         {
             "type": "shell",
@@ -36,26 +37,37 @@
                 "scripts/vagrant.sh",
                 "scripts/dep.sh"
             ],
-            "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'"
+            "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'",
+            "only": ["virtualbox-iso","vmware-iso"]
         },
         {
               "type": "file",
               "source": "scripts/common/get_nic_name_by_index.sh",
-              "destination": "/tmp/get_nic_name_by_index.sh"
+              "destination": "/tmp/get_nic_name_by_index.sh",
+              "only": ["virtualbox-ovf","vmware-vmx"]
         },
         {
             "type": "shell",
             "scripts": [
                 "scripts/addnetif.sh"
             ],
-            "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'"
+            "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'",
+            "only": ["virtualbox-ovf","vmware-vmx"]
+        },
+         {
+            "type": "ansible-local",
+            "inventory_groups": "local",
+            "playbook_file": "ansible/rackhd_prepare.yml",
+            "playbook_dir": "ansible",
+            "only": ["virtualbox-iso", "vmware-iso"]
         },
         {
             "type": "ansible-local",
             "inventory_groups": "local",
             "playbook_file": "ansible/{{user `playbook`}}.yml",
             "playbook_dir": "ansible",
-            "extra_arguments": [ "--extra-vars \"rackhd_version={{user `rackhd_version`}}\"" ]
+            "extra_arguments": [ "--extra-vars \"rackhd_version={{user `rackhd_version`}}\"" ],
+            "only": ["virtualbox-ovf","vmware-vmx"]
         },
         {
             "type": "shell",
@@ -64,8 +76,10 @@
                 "scripts/cleanup.sh",
                 "scripts/zerodisk.sh"
             ],
-            "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'"
+            "execute_command": "echo 'vagrant'|sudo -S bash '{{.Path}}'",
+            "only": ["virtualbox-ovf","vmware-vmx"]
         }
+
     ],
   "builders": [
     {
@@ -95,10 +109,12 @@
         " -- <wait>",
         "<enter><wait>"
       ],
+      "format": "ovf",
+      "output_directory": "output-virtualbox-iso",
+      "vm_name": "{{user `vm_name`}}",
       "boot_wait": "20s",
       "headless": true,
       "disk_size": 40960,
-      "headless": true,
       "guest_os_type": "Ubuntu_64",
       "http_directory": "http",
       "iso_checksum": "2bce60d18248df9980612619ff0b34e6",
@@ -115,6 +131,83 @@
         [ "modifyvm", "{{.Name}}", "--nic2", "intnet" ]
       ]
       },
+     {
+      "type": "virtualbox-ovf",
+      "source_path": "output-virtualbox-iso/rackhd-ubuntu-16.04.ovf",
+      "vm_name": "{{user `vm_name`}}",
+      "boot_wait": "20s",
+      "headless": true,
+      "http_directory": "http",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "echo 'shutdown -P now' > /tmp/shutdown.sh; echo 'vagrant'|sudo -S sh '/tmp/shutdown.sh'",
+      "vboxmanage": [
+        [ "modifyvm", "{{.Name}}", "--memory", "512" ],
+        [ "modifyvm", "{{.Name}}", "--cpus", "1" ],
+        [ "modifyvm", "{{.Name}}", "--nic2", "intnet" ]
+      ]
+      },
+
+
+      {
+        "type": "vmware-vmx",
+        "vm_name": "{{user `vm_name`}}",
+        "output_directory": "output-vmware-vmx",
+        "boot_wait": "20s",
+        "headless": true,
+        "http_directory": "http",
+        "source_path": "output-vmware-iso/rackhd-ubuntu-16.04.vmx",
+        "ssh_username": "vagrant",
+        "ssh_password": "vagrant",
+        "ssh_port": 22,
+        "ssh_wait_timeout": "10000s",
+        "shutdown_command": "echo 'shutdown -P now' > /tmp/shutdown.sh; echo 'vagrant'|sudo -S sh '/tmp/shutdown.sh'",
+        "vmx_data": {
+            "memsize": "1024",
+            "numvcpus": "2",
+            "ethernet0.networkName": "NAT",
+
+            "ethernet1.virtualDev": "e1000",
+            "ethernet1.present": "TRUE",
+            "ethernet1.pcislotnumber": "1"
+
+        },
+        "vmx_data_post":
+        {
+            "memsize": "1024",
+            "numvcpus": "2",
+            "cpuid.coresPerSocket": "1",
+
+            "ethernet0.networkName": "ADMIN",
+            "ethernet0.virtualDev": "e1000",
+            "ethernet0.present": "TRUE",
+            "ethernet0.pcislotnumber": "0",
+
+            "ethernet1.networkName": "CONTROL",
+            "ethernet1.virtualDev": "e1000",
+            "ethernet1.present": "TRUE",
+            "ethernet1.addressType": "generated",
+            "ethernet1.pcislotnumber": "1",
+
+            "ethernet2.networkName": "PDU",
+            "ethernet2.virtualDev": "e1000",
+            "ethernet2.present": "TRUE",
+            "ethernet2.addressType": "generated",
+            "ethernet2.pcislotnumber": "2",
+
+            "ethernet3.networkName": "BMC",
+            "ethernet3.virtualDev": "e1000",
+            "ethernet3.present": "TRUE",
+            "ethernet3.addressType": "generated",
+            "ethernet3.pcislotnumber": "3"
+        }
+
+      },
+
+
+
 
       {
         "type": "vmware-iso",
@@ -143,6 +236,7 @@
           " -- <wait>",
           "<enter><wait>"
         ],
+        "output_directory": "output-vmware-iso",
         "boot_wait": "20s",
         "headless": true,
         "disk_size": 40960,

--- a/packer/template-ubuntu-16.04.json
+++ b/packer/template-ubuntu-16.04.json
@@ -12,7 +12,7 @@
         "playbook": "rackhd_mini_release",
         "rackhd_version": ""
     },
-     "provisioners": [
+    "provisioners": [
         {
             "type": "shell",
             "script": "scripts/base.sh",
@@ -82,76 +82,74 @@
 
     ],
   "builders": [
-    {
-      "type": "virtualbox-iso",
-      "boot_command": [
-        "<enter><wait><f6><esc><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-        "/install/vmlinuz<wait>",
-        " auto<wait>",
-        " console-setup/ask_detect=false<wait>",
-        " console-setup/layoutcode=us<wait>",
-        " console-setup/modelcode=pc105<wait>",
-        " debian-installer=en_US<wait>",
-        " fb=false<wait>",
-        " initrd=/install/initrd.gz<wait>",
-        " kbd-chooser/method=us<wait>",
-        " keyboard-configuration/layout=USA<wait>",
-        " keyboard-configuration/variant=USA<wait>",
-        " locale=en_US<wait>",
-        " netcfg/get_hostname=rackhd<wait>",
-        " netcfg/hostname=rackhd<wait>",
-        " noapic<wait>",
-        " interface=auto",
-        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg<wait>",
-        " -- <wait>",
-        "<enter><wait>"
-      ],
-      "format": "ovf",
-      "output_directory": "output-virtualbox-iso",
-      "vm_name": "{{user `vm_name`}}",
-      "boot_wait": "20s",
-      "headless": true,
-      "disk_size": 40960,
-      "guest_os_type": "Ubuntu_64",
-      "http_directory": "http",
-      "iso_checksum": "2bce60d18248df9980612619ff0b34e6",
-      "iso_checksum_type": "md5",
-      "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.2-server-amd64.iso",
-      "ssh_username": "vagrant",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'shutdown -P now' > /tmp/shutdown.sh; echo 'vagrant'|sudo -S sh '/tmp/shutdown.sh'",
-      "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "512" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ],
-        [ "modifyvm", "{{.Name}}", "--nic2", "intnet" ]
-      ]
-      },
      {
-      "type": "virtualbox-ovf",
-      "source_path": "output-virtualbox-iso/rackhd-ubuntu-16.04.ovf",
-      "vm_name": "{{user `vm_name`}}",
-      "boot_wait": "20s",
-      "headless": true,
-      "http_directory": "http",
-      "ssh_username": "vagrant",
-      "ssh_password": "vagrant",
-      "ssh_port": 22,
-      "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'shutdown -P now' > /tmp/shutdown.sh; echo 'vagrant'|sudo -S sh '/tmp/shutdown.sh'",
-      "vboxmanage": [
-        [ "modifyvm", "{{.Name}}", "--memory", "512" ],
-        [ "modifyvm", "{{.Name}}", "--cpus", "1" ],
-        [ "modifyvm", "{{.Name}}", "--nic2", "intnet" ]
-      ]
-      },
-
-
-      {
+         "type": "virtualbox-iso",
+         "boot_command": [
+             "<enter><wait><f6><esc><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+             "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+             "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+             "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+             "/install/vmlinuz<wait>",
+             " auto<wait>",
+             " console-setup/ask_detect=false<wait>",
+             " console-setup/layoutcode=us<wait>",
+             " console-setup/modelcode=pc105<wait>",
+             " debian-installer=en_US<wait>",
+             " fb=false<wait>",
+             " initrd=/install/initrd.gz<wait>",
+             " kbd-chooser/method=us<wait>",
+             " keyboard-configuration/layout=USA<wait>",
+             " keyboard-configuration/variant=USA<wait>",
+             " locale=en_US<wait>",
+             " netcfg/get_hostname=rackhd<wait>",
+             " netcfg/hostname=rackhd<wait>",
+             " noapic<wait>",
+             " interface=auto",
+             " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg<wait>",
+             " -- <wait>",
+             "<enter><wait>"
+         ],
+         "format": "ovf",
+         "output_directory": "output-virtualbox-iso",
+         "vm_name": "{{user `vm_name`}}",
+         "boot_wait": "20s",
+         "headless": true,
+         "disk_size": 40960,
+         "guest_os_type": "Ubuntu_64",
+         "http_directory": "http",
+         "iso_checksum": "2bce60d18248df9980612619ff0b34e6",
+         "iso_checksum_type": "md5",
+         "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.2-server-amd64.iso",
+         "ssh_username": "vagrant",
+         "ssh_password": "vagrant",
+         "ssh_port": 22,
+         "ssh_wait_timeout": "10000s",
+         "shutdown_command": "echo 'shutdown -P now' > /tmp/shutdown.sh; echo 'vagrant'|sudo -S sh '/tmp/shutdown.sh'",
+         "vboxmanage": [
+             [ "modifyvm", "{{.Name}}", "--memory", "512" ],
+             [ "modifyvm", "{{.Name}}", "--cpus", "1" ],
+             [ "modifyvm", "{{.Name}}", "--nic2", "intnet" ]
+          ]
+    },
+    {
+        "type": "virtualbox-ovf",
+        "source_path": "output-virtualbox-iso/rackhd-ubuntu-16.04.ovf",
+        "vm_name": "{{user `vm_name`}}",
+        "boot_wait": "20s",
+        "headless": true,
+        "http_directory": "http",
+        "ssh_username": "vagrant",
+        "ssh_password": "vagrant",
+        "ssh_port": 22,
+        "ssh_wait_timeout": "10000s",
+        "shutdown_command": "echo 'shutdown -P now' > /tmp/shutdown.sh; echo 'vagrant'|sudo -S sh '/tmp/shutdown.sh'",
+        "vboxmanage": [
+            [ "modifyvm", "{{.Name}}", "--memory", "512" ],
+            [ "modifyvm", "{{.Name}}", "--cpus", "1" ],
+            [ "modifyvm", "{{.Name}}", "--nic2", "intnet" ]
+        ]
+    },
+    {
         "type": "vmware-vmx",
         "vm_name": "{{user `vm_name`}}",
         "output_directory": "output-vmware-vmx",
@@ -204,12 +202,8 @@
             "ethernet3.pcislotnumber": "3"
         }
 
-      },
-
-
-
-
-      {
+    },
+    {
         "type": "vmware-iso",
         "vm_name": "{{user `vm_name`}}",
         "boot_command": [
@@ -293,7 +287,7 @@
             "ethernet3.addressType": "generated",
             "ethernet3.pcislotnumber": "3"
         }
-      }
+    }
   ],
   "post-processors": [
     [{


### PR DESCRIPTION
**Background**
more detail in RAC-4360
PPT in https://rackhd.atlassian.net/wiki/display/RAC1/RackHD+CI%3A+packer+build+enhancement+oppotunity

the OVA packer build is too long for 1 hour. but in 80% time, the actions are the same for each build.

so we use 2-way packer build 
(1) build a template VMX which OS installed and all RackHD dependency installed
(2) install specific version of RackHD deb into above VMX, then pack to OVA

vagrant-box is in the similar way.
 
----
**detail in code**

HWIMO-BUILD: use "BUILD_STAGE " to select which way to go.
-BUILD_TEMPLATE : it build the template cached VMX. 
-BUILD_FINAL:  based from the cached VMX, build the final OVA
-BUILD_ALL:  it includes above 2 steps  (NOTE: it requires VMWare Workstation licensed version)

original packer ansible playbooks are divided into 2 parts:
```packer/ansible/rackhd_prepare.yml```
this will install rackhd dependencies
```packer/ansible/rackhd_xxxx_mini.yml```
this will install RackHD


the packer build type in template-ubuntu-1x.04.json

```virtualbox-iso``` :  it installs OS from iso, and install all RackHD dependency, it export ovf & vmdk files
```virtualbox-ovf```:  it will import the ovf in ```virtualbox-iso``` step,  and install RackHD, and output  a box 

```vmware-iso```: it installs OS from iso, and install all RackHD dependency , it export vmx & vmdk files
```vmware-vmx```:  it will import the vmx in ```vmware-iso``` step,  and install RackHD, and output  an OVA


Reviewer:
@PengTian0  @changev  @iceiilin  @johren 