### PR TITLE
RAC-4753, RAC-4752

### DIFF
--- a/test/common/fit_common.py
+++ b/test/common/fit_common.py
@@ -196,12 +196,16 @@ def apply_stack_config():
     stack = fitargs()['stack']
     if stack is not None:
         mkcfg().add_from_file('stack_config.json', stack)
-        if fitargs()['rackhd_host'] == 'localhost' and 'rackhd_host' in fitcfg():
-            fitargs()['rackhd_host'] = fitcfg()['rackhd_host']
-        if 'bmc' in fitcfg():
-            fitargs()['bmc'] = fitcfg()['bmc']
-        if 'hyper' in fitcfg():
-            fitargs()['hyper'] = fitcfg()['hyper']
+
+    if mkcfg().config_exists('deploy_generated.json'):
+        mkcfg().add_from_file('deploy_generated.json')
+
+    if fitargs()['rackhd_host'] == 'localhost' and 'rackhd_host' in fitcfg():
+        fitargs()['rackhd_host'] = fitcfg()['rackhd_host']
+    if 'bmc' in fitcfg():
+        fitargs()['bmc'] = fitcfg()['bmc']
+    if 'hyper' in fitcfg():
+        fitargs()['hyper'] = fitcfg()['hyper']
 
 
 def add_globals():

--- a/test/common/mkcfg.py
+++ b/test/common/mkcfg.py
@@ -60,6 +60,9 @@ class mkcfg(object):
     def config_is_loaded(self):
         return self.config_path is not None
 
+    def config_exists(self, filename):
+        return os.path.isfile(self.config_dir + '/' + filename)
+
     def create(self, config_dir='config'):
         if self.config_path:
             raise mkcfgException('creating configuration on top of existing object')

--- a/test/config/install_default.json
+++ b/test/config/install_default.json
@@ -6,8 +6,8 @@
         "http": 9090,
         "https": 9093,
         "httpd": 9010,
-        "amqp":5672,
-        "amqp-vagrant":9091,
+        "amqp_nossl": 5671,
+        "amqp_ssl": 5672,
         "ssh": 2222
       },
       "install": {

--- a/test/config/stack_config.json
+++ b/test/config/stack_config.json
@@ -19,6 +19,11 @@
   },
   "vagrant_remote": {
     "rackhd_host": "127.0.0.1",
-    "type": "vagrant"
+    "type": "vagrant",
+    "install-config": {
+      "ports": {
+        "amqp_ssl": 9091
+      }
+    }
   }
 }

--- a/test/tests/amqp/test_amqp_node_rediscover.py
+++ b/test/tests/amqp/test_amqp_node_rediscover.py
@@ -61,10 +61,7 @@ class AmqpWorker(threading.Thread):
             pika_logger.setLevel(logging.WARNING)
         else:
             pika_logger.setLevel(logging.ERROR)
-        if fit_common.API_PORT == 9090:
-            amqp_port = fit_common.fitports()['amqp-vagrant']
-        else:
-            amqp_port = fit_common.fitports()['amqp']
+        amqp_port = fit_common.fitports()['amqp_ssl']
         self.connection = pika.BlockingConnection(
             pika.ConnectionParameters(host=fit_common.fitargs()["rackhd_host"], port=amqp_port))
         self.channel = self.connection.channel()

--- a/test/tests/amqp/test_amqp_poller_alert.py
+++ b/test/tests/amqp/test_amqp_poller_alert.py
@@ -53,10 +53,7 @@ class AmqpWorker(threading.Thread):
             pika_logger.setLevel(logging.WARNING)
         else:
             pika_logger.setLevel(logging.ERROR)
-        if fit_common.API_PORT == 9090:
-            amqp_port = fit_common.fitports()['amqp-vagrant']
-        else:
-            amqp_port = fit_common.fitports()['amqp']
+        amqp_port = fit_common.fitports()['amqp_ssl']
         self.connection = pika.BlockingConnection(pika.ConnectionParameters(host=fit_common.fitargs()["rackhd_host"],
                                                                             port=amqp_port))
         self.channel = self.connection.channel()

--- a/test/tests/amqp/test_amqp_racknode.py
+++ b/test/tests/amqp/test_amqp_racknode.py
@@ -48,10 +48,7 @@ class AmqpWorker(threading.Thread):
             pika_logger.setLevel(logging.WARNING)
         else:
             pika_logger.setLevel(logging.ERROR)
-        if fit_common.API_PORT == 9090:
-            amqp_port = fit_common.fitports()['amqp-vagrant']
-        else:
-            amqp_port = fit_common.fitports()['amqp']
+        amqp_port = fit_common.fitports()['amqp_ssl']
         self.connection = pika.BlockingConnection(
             pika.ConnectionParameters(host=fit_common.fitargs()["ora"], port=amqp_port))
         self.channel = self.connection.channel()


### PR DESCRIPTION
Normalize the use of amqp with/without ssl.

Add logic that looks for file named deploy-generated.json in
the config directory.  If found, this file gets applied on
top of the configuration being generated.   This allows for a
given deployment to stamp out the ports, etc it needs without
having to make changes to stack_config.json.

@hohene @johren @stuart-stanley @gpaulos 