### PR TITLE
bugfix: failed to cleanup mongodb when packer build

### DIFF
--- a/packer/scripts/cleanup.sh
+++ b/packer/scripts/cleanup.sh
@@ -7,6 +7,7 @@ apt-get -y clean
 apt-get purge linux-headers-$(uname -r) build-essential zlib1g-dev libssl-dev libreadline-gplv2-dev
 
 echo "Cleaning up mongodb"
+sudo service mongodb start
 echo "db.dropDatabase()" | mongo pxe
 
 echo "Cleaning up rackhd log"


### PR DESCRIPTION
In ```firstuser.sh``` after testing rackhd services, mongodb service was stopped.

so then in ```cleanup.sh``` 

```
vmware-iso: Cleaning up mongodb
vmware-iso: MongoDB shell version: 2.4.9
vmware-iso: connecting to: pxe
vmware-iso: exception: connect failed
vmware-iso: Fri Apr 14 04:55:32.242 Error: couldn't connect to server 127.0.0.1:27017 src/mongo/shell/mongo.js:145
```

Uncleaned mongodb may lead to various problems.

@panpan0000 @PengTian0 