### PR TITLE
Packer: update hostname and hosts together

### DIFF
--- a/packer/scripts/cleanup.sh
+++ b/packer/scripts/cleanup.sh
@@ -30,9 +30,3 @@ echo "Adding a 2 sec delay to the interface up, to make the dhclient happy"
 echo "pre-up sleep 2" >> /etc/network/interfaces
 
 
-# Modify the /etc/hosts to align with hostname setting in RackHD/packer/scripts/dep.sh
-# by default, the hostname in both /etc/hosts & /etc/hostname are obtained from DHCP server during install.
-# in RackHD/packer/scripts/dep.sh, it's modified , but /etc/hosts(127.0.1.1) never get changed.
-
-NEW_HOST_NAME=$(cat /etc/hostname)
-sed -i  "/127.0.1.1/,/$/c127.0.1.1\t${NEW_HOST_NAME}" /etc/hosts

--- a/packer/scripts/dep.sh
+++ b/packer/scripts/dep.sh
@@ -9,6 +9,9 @@ pip install --upgrade setuptools
 pip install ansible==2.2.0.0
 
 # set a friendly hostname
+# by default, the hostname in both /etc/hosts & /etc/hostname are obtained from DHCP server during install.
 rm -f /etc/hostname
 echo "rackhd" > /etc/hostname
-
+#Below two lines were moved from scripts/cleanup.sh. I can't recall why they didn't go with /etc/hostname change together...
+NEW_HOST_NAME=$(cat /etc/hostname)
+sed -i  "/127.0.1.1/,/$/c127.0.1.1\t${NEW_HOST_NAME}" /etc/hosts


### PR DESCRIPTION
otherwise, in the following script firstuser.sh (run after dep.sh)
it will be very **slow** when doing any shell command with "sudo"
and packer will dump warning message like ```sudo: unable to resolve host perfl133```


@yyscamper  @anhou  @PengTian0  @changev 