### PR TITLE
RAC-180 - migrate the loggather utility from autotest to rackhd.

### DIFF
--- a/test/tools/save-logs/README.md
+++ b/test/tools/save-logs/README.md
@@ -1,0 +1,133 @@
+# Save Logs
+This utility provides the ability to gather log files and other useful information from a designated RackHD server and return it to the user.
+
+## save_logs.py
+Script which takes command line inputs and information from the optional configuration file to gather and return log data in the form of a tarball (tgz).  By default, it will extract the tarball in the deginated output directory.
+It requires rackhd_gather_info.py and extract_logs.py to run.  
+
+### save_logs_config.json
+Optional configuration file for save_logs.py in json format.  This file allows defaulting certain parameters.
+
+Supported fields are: username, password, webserver, log_directory_path, and ip. See the template confile for an example. 
+
+## Usage:
+```
+save_logs.py  
+usage: save_logs.py [-h] [-v] [-ip IP] [-port PORT] [-user USER] [-pwd PWD]
+                    [-no_extract] [-log_path LOG_PATH]
+                    [-target_dir TARGET_DIR]
+
+  Command Help
+
+  optional arguments:
+    -h, --help            show this help message and exit
+    -v                    Turn on verbose mode
+    -ip IP                Appliance IP address or hostname
+    -port PORT            Optional port argument for scp/ssh
+    -user USER            Appliance username
+    -pwd PWD              Appliance password
+    -no_extract           Do not extract the tarball, default to extract
+    -log_path LOG_PATH    Logging Directory Path
+    -target_dir TARGET_DIR
+                          Target directory name to store logs
+```
+
+### Usage examples:
+Basic usage:
+```
+python save_logs.py -ip 1.2.3.4 -user name -pwd pass -target_dir mylogs
+```
+Without a config file present, it will save to current working dirctory path and prompt for target dir.
+```
+python save_logs.py -ip 1.2.3.4 -user name -pwd pass
+```
+With a config file present which contains ip, username, and password fields filled in:
+```
+python save_logs.py
+```
+With a config file present and using command line override for ip and logpath:
+```
+python save_logs -ip stack6-ora.admin -log_path /emc/higgib3/logfiles
+```
+
+## extract_logs.py  
+Script to unfurl the save_logs tarball into the current or desginated directory.
+
+```
+extract_logs.py  
+usage: extract_logs.py [-h] [-pkg PKG] [-dir DIR] [-output_dir OUTPUT_DIR]
+
+  Command Help
+
+  optional arguments:
+    -h, --help            show this help message and exit
+    -pkg PKG              .tgz file to be extracted
+    -dir DIR              directory .tgz file is located and default extraction
+                          location
+    -output_dir OUTPUT_DIR
+                          optional directory to extract to, defaults to tgz
+                          location
+```
+Extract to directory holding the file
+```
+python extract_logs.py -dir logs -pkg RackHDLogs-ora-20161118-104809.tgz
+```
+
+Extract to different directory
+```
+python extract_logs.py -dir logs -pkg RackHDLogs-ora-20161118-104809.tgz -output_dir /emc/higgib3/scripts
+```
+
+## rackhd_gather_info.py
+The main script used by save_logs.py to gather data from the RackHD stack(server). The script runs locally on the RackHD stack(server).
+
+This script is based upon an EMC Isilon utility and not all functionallity listed within it is currently used, but was left in for future improvements. The base default functionality is all that is needed for save_logs for RackHD.
+
+
+## Sample Run Output:
+Save logs and do not extract:
+```
+python save_logs.py -ip stack10-ora.admin -user onrack -pwd onrack -no_extract -target_dir eh-demo1
+
+save_logs: Using configuration from "save_logs_conf.json".
+Saving logs in directory path: /mnt/cilogserver/bug_logs/
+This utility will attempt to gather log files and data from your appliance for debugging.
+Pushing gather script to stack....
+Running gather logs script, please wait.....
+Saved logs on stack in  /tmp/rackhd/pkg/RackHDLogs-ora-20161205-105524.tgz
+Copying from stack....
+
+Log directory: /mnt/cilogserver/bug_logs/eh-demo1
+Webserver: https://web.hwimo.lab.emc.com/qa/log/bug_logs/eh-demo1
+```
+Save logs and extract:
+```
+python save_logs.py -ip stack10-ora.admin -target_dir eh-demo10 -user onrack -pwd onrack
+
+save_logs: No config file found
+Saving logs in current directory: /mydir/rackhd/loggather/test/tools/save-logs
+This utility will attempt to gather log files and data from your appliance for debugging.
+Pushing gather script to stack....
+Running gather logs script, please wait.....
+Saved logs on stack in  /tmp/rackhd/pkg/RackHDLogs-ora-20170418-084932.tgz
+Copying from stack....
+Extracting tarball.....
+
+Log directory: /mydir/rackhd/loggather/test/tools/save-logs/eh-demo10
+```
+
+# Running in a virtual environment.
+It may be necessary to run in a vitural environment if not all imported packages are available from your system.
+Here is an example of this if pexpect missing.
+```
+virtualenv myenv
+source myenv/bin/activate
+  pip list
+  pip install pexpect
+
+  python save_logs.py [args]
+  python extract_logs.py [args]
+
+deactivate
+```
+

--- a/test/tools/save-logs/extract_logs.py
+++ b/test/tools/save-logs/extract_logs.py
@@ -14,6 +14,7 @@ It will create the target dir, expand tarball, and chmod 777 all the directories
 and included files to allow the user and others to easily read, add, delete as needed.
 
 '''
+from __future__ import print_function
 import os
 import errno
 import tarfile

--- a/test/tools/save-logs/extract_logs.py
+++ b/test/tools/save-logs/extract_logs.py
@@ -70,8 +70,7 @@ def extract_tgz_file_to_datadir(pkginfo, logdir):
     '''
     status = False
     pstr = pkginfo.split("/")
-    nlen = len(pstr)
-    pn = pstr[nlen - 1]
+    pn = pstr[-1]
     pkgname = pn.rstrip("\r")
 
     # Check the log directory for the existance of the tarball

--- a/test/tools/save-logs/extract_logs.py
+++ b/test/tools/save-logs/extract_logs.py
@@ -150,12 +150,6 @@ def chmod_logpath(logdir):
                         continue
 
 
-def handle_pexpect_error(child, errstr):
-    print(errstr)
-    print(child.before, child.after)
-    child.terminate()
-
-
 def mk_datadir(logdir, name):
     '''
     This function creates a dirctory name on the logserver or current dir path

--- a/test/tools/save-logs/extract_logs.py
+++ b/test/tools/save-logs/extract_logs.py
@@ -35,10 +35,10 @@ def main():
     # parse arguments to ARGS_LIST dict
     ARGS_LIST = ARG_PARSER.parse_args()
     if ARGS_LIST.pkg == "None":
-        print "No package given, please provide a package with the -pkg flag"
+        print("No package given, please provide a package with the -pkg flag")
         exit(1)
     if ARGS_LIST.dir == "None":
-        print "No source directory given, please provide the source directory with the -dir flag"
+        print("No s(urce directory given, please provide the source directory with the -dir flag")
         exit(1)
     if ARGS_LIST.dir[-1] != "/":
         ARGS_LIST.dir = ARGS_LIST.dir + "/"
@@ -53,7 +53,7 @@ def main():
         pn = pstr[-1]
         pkgname = pn.rstrip("\r")
         shutil.copy(ARGS_LIST.dir + pkgname, out_dir)
-    print "Extracting to: {0}".format(out_dir)
+    print("Extracting to: {}".format(out_dir))
     extract_tgz_file_to_datadir(ARGS_LIST.pkg, out_dir)
 
 
@@ -78,7 +78,7 @@ def extract_tgz_file_to_datadir(pkginfo, logdir):
     if os.path.isfile(tgzpkg) is True:
         # Extract the tarball
         if tarfile.is_tarfile(tgzpkg) is True:
-            print "Extracting tarball....."
+            print("Extracting tarball.....")
             tar = tarfile.open(tgzpkg)
             tar.extractall(path=logdir)
             tar.close()
@@ -86,10 +86,10 @@ def extract_tgz_file_to_datadir(pkginfo, logdir):
             unpack_tarballs(logdir + "/stack")
             status = True
         else:
-            print "Error: Could not unpack tarfile", tgzpkg
+            print("Error: Could not unpack tarfile {}".format(tgzpkg))
             status = False
     else:
-        print "Error: Cannot find tarball" + pkgname
+        print("Error: Cannot find tarball {}".format(pkgname))
         status = False
 
     if status is True:
@@ -119,7 +119,7 @@ def unpack_tarballs(logdir):
                 # that are already extracted
                 continue
     else:
-        print "Directory does not exist ", logdir
+        print("Directory does not exist {} ".format(logdir))
 
 
 def chmod_logpath(logdir):
@@ -130,29 +130,29 @@ def chmod_logpath(logdir):
     '''
     # Walk the log directory and chmod to 0777 for directories and 0666 for files
     if os.path.isdir(logdir):
-        os.chmod(logdir, 0777)
+        os.chmod(logdir, 0o777)
         for root, dirs, files in os.walk(logdir):
             for dname in dirs:
                 try:
-                    os.chmod(os.path.join(root, dname), 0777)
+                    os.chmod(os.path.join(root, dname), 0o777)
                 except:
                     continue
             for fname in files:
                 if os.access(os.path.join(root, fname), os.X_OK) is True:
                     try:
-                        os.chmod(os.path.join(root, fname), 0777)
+                        os.chmod(os.path.join(root, fname), 0o777)
                     except:
                         continue
                 else:
                     try:
-                        os.chmod(os.path.join(root, fname), 0666)
+                        os.chmod(os.path.join(root, fname), 0o666)
                     except:
                         continue
 
 
 def handle_pexpect_error(child, errstr):
-    print errstr
-    print child.before, child.after
+    print(errstr)
+    print(child.before, child.after)
     child.terminate()
 
 
@@ -167,12 +167,11 @@ def mk_datadir(logdir, name):
         False on any error
     '''
     try:
-        os.makedirs(logdir, 0777)
+        os.makedirs(logdir, 0o777)
     except OSError as exc:
         if exc.errno == errno.EEXIST and os.path.isdir(logdir):
-            print "Directory exists for ", logdir
-            print "Error: {0} already exists.".format(logdir)
-            print "Please use a new name, such as " + name + "-1 or delete the existing one."
+            print("Error: Directory {} already exists.".format(logdir))
+            print("Please use a new name, such as {}-1 or delete the existing one.".format(name))
             return False
     return True
 

--- a/test/tools/save-logs/extract_logs.py
+++ b/test/tools/save-logs/extract_logs.py
@@ -1,0 +1,181 @@
+#!/usr/bin/python
+
+'''
+Copyright 2017 Dell Inc. or its subsidiaries.  All Rights Reserved.
+
+ScriptName: extract_logs.py
+Author(s): Brent Higgins, E Hohenstein
+Initial date: 09/01/16
+
+Purpose:
+This script is intended to expand the tarball created from save_logs.py
+into a target directory.
+It will create the target dir, expand tarball, and chmod 777 all the directories
+and included files to allow the user and others to easily read, add, delete as needed.
+
+'''
+import os
+import errno
+import tarfile
+import time
+import argparse
+
+import shutil
+
+
+def main():
+    ARG_PARSER = argparse.ArgumentParser(description="Command Help")
+    ARG_PARSER.add_argument("-pkg", default="None",
+                            help=".tgz file to be extracted")
+    ARG_PARSER.add_argument("-dir", default="None",
+                            help="directory .tgz file is located and default extraction location")
+    ARG_PARSER.add_argument("-output_dir", default="None",
+                            help="optional directory to extract to, defaults to tgz location")
+
+    # parse arguments to ARGS_LIST dict
+    ARGS_LIST = ARG_PARSER.parse_args()
+    if ARGS_LIST.pkg == "None":
+        print "No package given, please provide a package with the -pkg flag"
+        exit(1)
+    if ARGS_LIST.dir == "None":
+        print "No source directory given, please provide the source directory with the -dir flag"
+        exit(1)
+    if ARGS_LIST.dir[-1] != "/":
+        ARGS_LIST.dir = ARGS_LIST.dir + "/"
+    if ARGS_LIST.output_dir == "None":
+        out_dir = ARGS_LIST.dir
+    else:
+        if ARGS_LIST.output_dir[-1] != "/":
+            ARGS_LIST.output_dir = ARGS_LIST.output_dir + "/"
+        out_dir = ARGS_LIST.output_dir
+        mk_datadir(out_dir, out_dir)
+        pstr = ARGS_LIST.pkg.split("/")
+        pn = pstr[-1]
+        pkgname = pn.rstrip("\r")
+        shutil.copy(ARGS_LIST.dir + pkgname, out_dir)
+    print "Extracting to: {0}".format(out_dir)
+    extract_tgz_file_to_datadir(ARGS_LIST.pkg, out_dir)
+
+
+def extract_tgz_file_to_datadir(pkginfo, logdir):
+    '''
+    This function extracts the gathered tarball into the target directory
+    printing progress as it goes for the user.
+    :param pkginfo: string returned from gather script
+    :param logdir: full local path to bug directory
+    : return
+        True on success unpack of main tarball
+        False on any error
+    '''
+    status = False
+    pstr = pkginfo.split("/")
+    nlen = len(pstr)
+    pn = pstr[nlen - 1]
+    pkgname = pn.rstrip("\r")
+
+    # Check the log directory for the existance of the tarball
+    tgzpkg = logdir + "/" + pkgname
+    if os.path.isfile(tgzpkg) is True:
+        # Extract the tarball
+        if tarfile.is_tarfile(tgzpkg) is True:
+            print "Extracting tarball....."
+            tar = tarfile.open(tgzpkg)
+            tar.extractall(path=logdir)
+            tar.close()
+            time.sleep(2)
+            unpack_tarballs(logdir + "/stack")
+            status = True
+        else:
+            print "Error: Could not unpack tarfile", tgzpkg
+            status = False
+    else:
+        print "Error: Cannot find tarball" + pkgname
+        status = False
+
+    if status is True:
+        chmod_logpath(logdir)
+
+    return status
+
+
+def unpack_tarballs(logdir):
+    '''
+    This function will walk the specified log directory and attempt to extract any tgz or tar files
+    it finds.  No error returned, best effort.
+    :param logdir: full local path to log directory
+    '''
+    # Walk the log directory to extrack tarfiles
+    if os.path.isdir(logdir):
+        my_files = os.listdir(logdir)
+        for file in my_files:
+            myfile = logdir + "/" + file
+            try:
+                tarfile.is_tarfile(myfile)
+                tar = tarfile.open(myfile)
+                tar.extractall(path=logdir)
+                tar.close()
+            except:
+                # Check for error - if extracting the same log directory twice, an error is tossed on files
+                # that are already extracted
+                continue
+    else:
+        print "Directory does not exist ", logdir
+
+
+def chmod_logpath(logdir):
+    '''
+    This function will walk the specified log directory and attempt to chmod to readable by all, best effort
+    We could add chown as an enhancement.
+    :param logdir: full local path to log directory
+    '''
+    # Walk the log directory and chmod to 0777 for directories and 0666 for files
+    if os.path.isdir(logdir):
+        os.chmod(logdir, 0777)
+        for root, dirs, files in os.walk(logdir):
+            for dname in dirs:
+                try:
+                    os.chmod(os.path.join(root, dname), 0777)
+                except:
+                    continue
+            for fname in files:
+                if os.access(os.path.join(root, fname), os.X_OK) is True:
+                    try:
+                        os.chmod(os.path.join(root, fname), 0777)
+                    except:
+                        continue
+                else:
+                    try:
+                        os.chmod(os.path.join(root, fname), 0666)
+                    except:
+                        continue
+
+
+def handle_pexpect_error(child, errstr):
+    print errstr
+    print child.before, child.after
+    child.terminate()
+
+
+def mk_datadir(logdir, name):
+    '''
+    This function creates a dirctory name on the logserver or current dir path
+    It currently will not overwrite an existing directory.
+    :param logdir: full local path to bug directory
+    :param odr: the odr number specified by the user
+    : return
+        True on success
+        False on any error
+    '''
+    try:
+        os.makedirs(logdir, 0777)
+    except OSError as exc:
+        if exc.errno == errno.EEXIST and os.path.isdir(logdir):
+            print "Directory exists for ", logdir
+            print "Error: {0} already exists.".format(logdir)
+            print "Please use a new name, such as " + name + "-1 or delete the existing one."
+            return False
+    return True
+
+
+if __name__ == "__main__":
+    main()

--- a/test/tools/save-logs/rackhd_gather_info.py
+++ b/test/tools/save-logs/rackhd_gather_info.py
@@ -77,7 +77,7 @@ UTILITIES = {
     'pm2o_log': ('tar', "cd /home", "onrack-pm2log.tar onrack/.pm2"),
     'pm2_status': ('exe', "${SUDO} pm2 status ", "pm2status"),
     # 'apache2status': ('exe', "${SUDO}service apache2 status", "apache2status"),
-    #'conductor': ('exe', "systemctl status conductor", "conductor_status"),
+    # 'conductor': ('exe', "systemctl status conductor", "conductor_status"),
     'df': ('exe', "/bin/df -li", "df"),
     'dpkg_info': ('exe', "dpkg -l | grep \"ii  on\"", "dpkg_list"),
     'dhcp_leases': ('tar', "cd /var/lib", "varlib-dhcp.tar dhcp"),

--- a/test/tools/save-logs/rackhd_gather_info.py
+++ b/test/tools/save-logs/rackhd_gather_info.py
@@ -1,0 +1,1052 @@
+#!/usr/bin/python
+
+# Copyright 2015, EMC, Inc.
+# ex: set shiftwidth=4 tabstop=4 expandtab:
+#
+# 07/14/2015 ehohenstein
+#
+# This utility is based off of EMC Isilon's isi_gather_info script and
+# all appreciation for the script can be directed to the original authors.
+#
+# The utility is intended to be installed onto the RackHD appliance
+# to use and will gather a defined set of log files and output of
+# commands, capturing all into a single tarfile.  The tarfile can
+# then be placed off the applicance and extracted.
+#
+# The utiilty only makes use of the basic modules in this script to
+# run commands and gather logs into the tarfile and storing them in the
+# /tmp directory.  Reference to incremental builds, full and local
+# log gathers, and groups are a hold over from the full version
+# of this script.  Updates could be added back in to make uses of all
+# the options.
+
+import errno
+import getopt
+import os
+import random
+import re
+import signal
+import sys
+import time
+import threading
+import traceback
+import subprocess
+
+# for package xml metadata
+import xml.etree.ElementTree as etree
+
+PROGNAME = os.path.basename(sys.argv[0])
+REVISION = "Revision: 001"
+
+try:
+    True
+except NameError:
+    True = 1
+    False = 0
+
+SUPPORT_DIR = None
+TMP_SUPPORT_DIR = None
+LOCAL_TMP_SUPPORT_DIR = None
+PKG_SUPPORT_DIR = None
+GATHER_SCRIPT = None
+PACKAGE_INFO = None
+SAVED_COMMAND_LINE = None
+
+_TMP_SUPPORT_DIR = 'tmp/'
+_PKG_SUPPORT_DIR = 'pkg/'
+_GATHER_SCRIPT = '_gather'
+_LOCAL_GATHER_SCRIPT = '_stack_gather'
+_LOCAL_TMP_SUPPORT_DIR = "stack"
+_PACKAGE_INFO = 'package_info.xml'
+_SAVED_COMMAND_LINE = 'command_line'
+_FULLGATHER_FILE = 'last_full_gather'
+
+VAR_SUPPORT_DIR = '/tmp/rackhd'
+
+GATHER_STATUS_PATH = '/var/run/gather-status'
+GATHER_STATUS_LOCK = GATHER_STATUS_PATH + '.lock'
+
+CONFIGDIR = '/tmp'
+
+# 'exe': cmd, name: cmd==command, name==output filename
+# 'tar': cmd, name: cmd==cd to parent dir; name==tarball_filename tarball_dir
+# See generate_scripts for the consumer of this information.
+UTILITIES = {
+    'var_log': ('tar', "cd /", "varlog.tar /var/log"),
+    'pm2v_log': ('tar', "cd /home", "vagrant-pm2log.tar vagrant/.pm2"),
+    'pm2o_log': ('tar', "cd /home", "onrack-pm2log.tar onrack/.pm2"),
+    'pm2_status': ('exe', "${SUDO} pm2 status ", "pm2status"),
+    # 'apache2status': ('exe', "${SUDO}service apache2 status", "apache2status"),
+    #'conductor': ('exe', "systemctl status conductor", "conductor_status"),
+    'df': ('exe', "/bin/df -li", "df"),
+    'dpkg_info': ('exe', "dpkg -l | grep \"ii  on\"", "dpkg_list"),
+    'dhcp_leases': ('tar', "cd /var/lib", "varlib-dhcp.tar dhcp"),
+    'etc': ('tar', "cd /etc", "etc_init.tar init.d"),
+    'ipinfo': ('exe', "ip addr", "ipinfo"),
+    'bash_history': ('tar', "cd /root", "bash_history.tar .bash_history"),
+    'meminfo': ('exe', "/bin/cat /proc/meminfo", "meminfo"),
+    'services': ('exe', "(service on-http status; echo;" \
+                 "service on-tftp status; echo;" \
+                 "service on-dhcp-proxy status; echo;" \
+                 "service on-syslog status; echo;" \
+                 "service on-taskgraph status;)", "services"),
+    'mongodump': ('exe', "cd /var/log;/usr/bin/mongodump --out mongodumpdir", "mongodump"),
+    'slabinfo': ('exe', "${SUDO} /bin/cat /proc/slabinfo", "slabinfo"),
+    'top': ('exe', "/usr/bin/top -S -b -d 1 -n 3", "top"),
+    'uname': ('exe', "/bin/uname -a", "uname"),
+    'uptime': ('exe', "/usr/bin/uptime", "uptime"),
+    'ps': ('exe', "/bin/ps auxxxx", "ps"),
+    'netstat': ('exe', "(/bin/netstat -sn; echo; " \
+                "/bin/netstat -rn; echo; " \
+                "/bin/netstat -lan)", "netstat"),
+}
+
+# List of commands that are run
+EXEMPT = [
+    'var_log',
+    # 'apache2status',
+    # 'conductor',
+    'dhcp_leases',
+    'df',
+    'dpkg_info',
+    'etc',
+    'ipinfo',
+    'bash_history',
+    'meminfo',
+    'services',
+    # 'monorail',
+    'mongodump',
+    'slabinfo',
+    'top',
+    'uname',
+    'uptime',
+    'pm2_status',
+    'pm2v_log',
+    'pm2o_log',
+    'ps',
+    'netstat',
+]
+
+# GROUPS holds the groups of utilities that can be specified by the
+# not fully implemented yet
+# --group command line option.
+GROUPS = {
+    "service": [
+        # "conductor",
+        # "conductor_2x",
+        "services",
+        # "monorail",
+        # "apache2status",
+    ],
+    "system": [
+        "ipinfo",
+        "df",
+        "top",
+        "meminfo",
+        "slabinfo",
+        "top",
+        "uname",
+        "uptime",
+        "dpkg_info",
+    ],
+    "network": [
+        "ipinfo",
+        "netstat",
+    ],
+    "logs": [
+        "var_log",
+    ],
+}
+
+
+class Stack:
+    pass
+
+
+class Options:
+    pass
+
+
+# Globals
+stack = Stack()
+options = Options()
+log = ''    # used later on to write to gather-status log file
+re_upload = ''
+
+
+def update_support_dirs(options):
+    global SUPPORT_DIR
+    global TMP_SUPPORT_DIR
+    global PKG_SUPPORT_DIR
+    global GATHER_SCRIPT
+    global LOCAL_GATHER_SCRIPT
+    global PACKAGE_INFO
+    global SAVED_COMMAND_LINE
+    global LOCAL_TMP_SUPPORT_DIR
+    global FULLGATHER_FILE
+
+    if options.tempdir:
+        if options.tempdir[0] != '/':
+            error("Only full path tempdir specifications allowed.")
+        SUPPORT_DIR = options.tempdir
+    else:
+        SUPPORT_DIR = VAR_SUPPORT_DIR
+
+    # generate a unique random tempdir. this is not safe against races, but
+    # shouldn't need to be.
+    chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
+    while True:
+        tmpdir = ""
+        for i in range(16):
+            tmpdir += chars[random.randint(0, len(chars) - 1)]
+        # this directory is expected to end in "/" elsewhere in the code, but
+        # to verify that a file doesn't exist by the name of the directory
+        # we wish to create, we have to check if the directory exists without
+        # the trailing slash, first.
+        TMP_SUPPORT_DIR = os.path.join(SUPPORT_DIR, _TMP_SUPPORT_DIR, tmpdir)
+        if not os.path.exists(TMP_SUPPORT_DIR):
+            TMP_SUPPORT_DIR += "/"
+            break
+
+    if options.tardir:
+        PKG_SUPPORT_DIR = options.tardir
+    else:
+        PKG_SUPPORT_DIR = os.path.join(SUPPORT_DIR, _PKG_SUPPORT_DIR)
+
+    FULLGATHER_FILE = os.path.join(SUPPORT_DIR, _FULLGATHER_FILE)
+    GATHER_SCRIPT = os.path.join(TMP_SUPPORT_DIR, _GATHER_SCRIPT)
+    LOCAL_GATHER_SCRIPT = os.path.join(TMP_SUPPORT_DIR, _LOCAL_GATHER_SCRIPT)
+    PACKAGE_INFO = os.path.join(TMP_SUPPORT_DIR, _PACKAGE_INFO)
+    SAVED_COMMAND_LINE = os.path.join(TMP_SUPPORT_DIR, _SAVED_COMMAND_LINE)
+    LOCAL_TMP_SUPPORT_DIR = os.path.join(TMP_SUPPORT_DIR, _LOCAL_TMP_SUPPORT_DIR)
+
+    # Make sure the dirs exist locally first
+    makeDir(SUPPORT_DIR)
+    makeDir(TMP_SUPPORT_DIR)
+    makeDir(LOCAL_TMP_SUPPORT_DIR)
+    makeDir(PKG_SUPPORT_DIR)
+
+
+# this routine creates a local_gather script that is invoked locally on the stack.
+# run_utils should be a list of the names of utilities in the UTILITIES dict.
+def generate_scripts(run_utils):
+
+    # rackhd always needs sudo to run
+    rackhd_state = 1
+    try:
+        flags = os.O_RDWR | os.O_CREAT | os.O_TRUNC
+        header = "#!/bin/bash\nHOST=`hostname`\n"
+        if rackhd_state == 0:
+            pass
+        else:
+            header += "SUDO='sudo '\n"
+            # print "Sudo header:", header
+
+        localfd = os.open(LOCAL_GATHER_SCRIPT, flags, 0755)
+        os.write(localfd, header)
+
+        for util in run_utils:
+            exe, cmd, name = UTILITIES.get(util)
+            if exe == 'local_tar' or exe == 'tar':
+                line = "%s;/bin/tar cf %sstack/%s 1>/dev/null 2>&1" % \
+                    (cmd, TMP_SUPPORT_DIR, name.lstrip())
+            elif exe == 'local_exe' or exe == 'exe':
+                line = "%s 1> %sstack/%s 2>&1" % \
+                    (cmd, TMP_SUPPORT_DIR, name.lstrip())
+            else:
+                line = ''
+
+            line += "\n"
+
+            # write the script file for the local stack
+            os.write(localfd, line)
+
+        # script must exit cleanly
+        footer = "exit 0\n"
+
+        os.write(localfd, footer)
+        os.close(localfd)
+
+    except OSError, (errno, strerror):
+        error("OS error: %s" % os.strerror(errno))
+
+
+# assumptions:
+#   the server has enough free space to store the temporary info in /tmp in
+#   files and the final compressed package (about 100MB needed, usually
+#   determined by the size of /var/log/).
+#
+def main():
+    global stack, options, log, re_upload
+
+    # print "GATHER_STATUS_PATH:", GATHER_STATUS_PATH
+    log = Logger(GATHER_STATUS_PATH)
+
+    #
+    # don't treat ^C special
+    # and ignore the HUP signal
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    signal.signal(signal.SIGHUP, signal.SIG_IGN)
+
+    # internal correctness check
+    validateUtils()
+
+    stack.name = None
+    stack.hostname = None
+    stack.user = None
+    stack.password = None
+    stack.nodes = []
+
+    options.gather_script = []
+    options.gather_expr = []
+
+    options.includes = []
+    options.noconfig = True
+    options.local_only = True
+    options.tardir = None
+    options.tarfile = None
+    options.tempdir = None
+    options.no_exempt_logs = False
+    options.debug = False
+    options.verbose = False
+    options.group = []
+    options.group_utils = []
+
+    # Allow all directory and data creation to be accessed by the group users
+    os.umask(0002)
+
+    # parse options
+    get_options()
+
+    if stack.password:
+        print "\nNote: A password is only required with -T.  Ignoring."
+
+    # update paths
+    update_support_dirs(options)
+
+    # Get the stack name
+    stack.name, stack.hostname = getHostname()
+
+    saveCommandLine()
+
+    # Convert -f filenames to UTILITIES commands; Add to UTILITIES
+    # Convert gather_script/_expr to UTILITIES commands; Add to UTILITIES
+    # Create include_list using the final updated UTILITIES.
+    if "all" in options.includes:
+        include_list = UTILITIES.keys()
+    else:
+        include_list = options.includes
+
+    # write the temp script that contains the instructions for information
+    # gathering.  we're going to write this in TMP_SUPPORT_DIR,
+    # so we need to 1) see if that dir already exists, and 2) create it
+    # (and any parents) if it doesn't exist.
+    #
+    # note that the gathered information from the stack is temporary
+    # and will be removed at the end of the script.  however, the final
+    # package file (stored in PKG_SUPPORT_DIR, or specified tarfile path)
+    # will be uniquely preserved.
+    #
+    # NOTE: The paths created here for the nodes MUST match those
+    #       utilized in the generate_scripts routine.
+    dirs = [SUPPORT_DIR, TMP_SUPPORT_DIR, PKG_SUPPORT_DIR,
+            LOCAL_TMP_SUPPORT_DIR]
+
+    count = makeDirs(dirs)
+    if count:
+        error("FAILED to make required directories on %d nodes." % count)
+
+    try:
+        last_full_gather = int(os.stat(FULLGATHER_FILE).st_mtime)
+    except:
+        last_full_gather = 0
+
+    # build the gather script, based on the known information gathering
+    # utilities, and the utilities the user is wishing to include
+    run_utils = buildRunUtils(include_list)
+    if len(run_utils) == 0:
+        error("No commands or info found to gather")
+
+    generate_scripts(run_utils)
+
+    # run everything.
+    start_time = int(time.time())
+    exit_status = 0
+
+    print "Running gather script."
+    print "This may take several minutes.  Please do not interrupt the script."
+    print
+
+    log.write("Gather In Progress on stack. Running.")
+    task = "Running gather script on stack"
+    (exit, output) = get_cmd_output("bash " + LOCAL_GATHER_SCRIPT)
+    if exit:
+        print "ERROR %s" % task
+        log.write("Gather Failed. %s" % output)
+        for line in output:
+            print line
+
+    # Save package xml metadata
+    pkginfo = {
+        "gather_date": start_time,
+        "last_full": last_full_gather,
+    }
+
+    # if this generation fails, we can continue, but dump traceback info
+    try:
+        savePackageInfo(pkginfo, PACKAGE_INFO)
+    except Exception, e:
+        try:
+            traceback.print_exc(file=open(PACKAGE_INFO, 'a'))
+        except:
+            pass
+
+    # put everything into one tarball
+    log.write("Gather Succeeded.")
+    print "Information gathering completed... creating compressed package."
+    pkg_path_name = makePkgName()
+
+    try:
+        tar_command = "/bin/tar czf %s . 2>&1" % pkg_path_name
+        os.chdir(TMP_SUPPORT_DIR)
+        (exit, output) = get_cmd_output(tar_command)
+        if exit:
+            print "ERROR tar returned %d" % (exit >> 8),
+            log.write("Gather Failed")
+            if output:
+                print ", output follows:"
+                for line in output:
+                    print line
+            else:
+                print ""
+            error("Could not create compressed package.")
+            log.write("Gather Failed. Could not create compressed package.")
+    except OSError, (errno, strerror):
+        error("FAILED system call (tar): %s" % (os.strerror(errno)))
+        log.write("Gather Failed %s" % (os.strerror(errno)))
+
+    print "Packaging complete..."
+    print "Package: %s" % pkg_path_name
+    log.write("Package: %s" % pkg_path_name)
+
+    # If we don't have the exit_status set, then the log gathered
+    # completely
+    if not exit_status:
+        if not os.path.exists(FULLGATHER_FILE):
+            try:
+                fullgather = open(FULLGATHER_FILE, 'w')
+                fullgather.write('This space intentionally left blank.\n')
+                fullgather.close()
+            except:
+                sys.stderr.write('WARNING: Full Gather run data not recorded.\n')
+
+        try:
+            os.utime(FULLGATHER_FILE, (start_time, start_time))
+        except Exception, e:
+            sys.stderr.write('WARNING: Full Gather run data update failed. %s\n' % str(e))
+            log.write("Gather Failed. WARNING: Full Gather run data update failed.")
+
+    print "Cleaning up temporary data...",
+    if clean_tmp_dir(TMP_SUPPORT_DIR) == 0:
+        print "done."
+
+    verbose("\nCleaning up core/dumps")
+
+    log.join()
+    sys.exit(exit_status)
+
+
+#  ########################### end main ###########################################
+def osw_fix(error):
+    # Make compatible with os.W*, since the callers all expect that.
+    if error > 0:               # Exited without a signal
+        return error << 8
+    else:                       # Exited because of a signal
+        return 0 - error
+
+
+def get_popen(cmd, include_stderr=True, stdin=None):
+    if include_stderr:
+        stderr_pipe = subprocess.STDOUT
+    else:
+        stderr_pipe = subprocess.PIPE
+
+    try:
+        return subprocess.Popen(cmd, stdin=stdin, stderr=stderr_pipe,
+                                stdout=subprocess.PIPE, close_fds=True,
+                                shell=True)
+    except OSError:
+        print "While running", cmd
+        raise
+
+
+def get_popen_output(p, raw, strip=True):
+    if raw:
+        out = p.stdout.read()
+    else:
+        out = p.stdout.readlines()
+
+    # Need to restart on EINTR.
+    while True:
+        try:
+            error = p.wait()
+            break
+        except EnvironmentError, (error, strerror):
+            if error == errno.EINTR:
+                continue
+            else:
+                raise
+    error = osw_fix(error)
+    if strip and not raw:
+        for i in range(len(out)):
+            out[i] = out[i].rstrip()
+    return (error, out)
+
+
+# get_cmd_output
+def get_cmd_output(cmd, include_stderr=True, raw=False, strip=True):
+    '''
+    Returns the exit status and output of the given command as a tuple.
+
+    If raw evaluates to True, the output is returned unprocessed
+    as a single string, otherwise it's returned as a list of rstrip()'d
+    strings.
+
+    If include_stderr evaluates to True, both stdout and stderr are
+    included in the output, otherwise only stdout is included. In
+    both cases, stderr is captured and not sent to the console.
+
+    This function also has an advantage over os.system() in that
+
+    it allows you to still catch KeyboardInterrupt exceptions. In detail:
+    - If ^C is pressed during an os.system() call, the process being
+      executed will be terminated, but no KeyboardInterrupt exception will
+      be raised. Thus your script will continue executing as normal.
+    - If ^C is pressed during a get_cmd_output() call, the process being
+      executed will be terminated *and* a KeyboardInterrupt exception
+      will be raised. Thus you can terminate your application appropriately,
+      which is probably what the user was interested in doing. Hot damn.
+    '''
+    p = get_popen(cmd, include_stderr)
+    if p:
+        return get_popen_output(p, raw, strip)
+    else:
+        return (None, None)
+
+
+def saveCommandLine():
+    try:
+        mode = os.O_RDWR | os.O_CREAT | os.O_TRUNC
+        fd = os.open(SAVED_COMMAND_LINE, mode, 0666)
+        os.write(fd, " ".join(sys.argv) + "\n")
+        os.close(fd)
+    except OSError:
+        error("Failed saving command-line output")
+
+
+def savePackageInfo(pkginfo, fname):
+    # this saves to the package information about the package
+    contents = []
+    if options.no_exempt_logs:
+        contents.append('none')
+    else:
+        contents.append('full')
+
+    for group in options.group:
+        contents.append("group:%s" % group)
+
+    revision = re.findall(r"\d+", REVISION)[0]
+
+    # generate our xml
+    pkg = etree.Element("package")
+    pkg.attrib["version"] = "1"
+
+    etree.SubElement(pkg, "command").text = " ".join(sys.argv)
+    etree.SubElement(pkg, "contents").text = ", ".join(contents)
+    etree.SubElement(pkg, "gather_date").text = str(pkginfo["gather_date"])
+    etree.SubElement(pkg, "revision").text = revision
+
+    logs = etree.Element("logs")
+    etree.SubElement(logs, "last_full").text = str(pkginfo["last_full"])
+    pkg.append(logs)
+
+    f = open(fname, 'w')
+    f.write(etree.tostring(pkg))
+    f.close()
+
+
+def waitForPid(pid):
+    while True:
+        pid, status = os.waitpid(pid, 0)
+        if os.WIFEXITED(status):
+            return os.WEXITSTATUS(status)
+        elif os.WIFSIGNALED(status):
+            return 1
+
+
+def waitForChildren(children):
+    # NOTE using max(exit_results) could miss potential negative returns,
+    # masked by (greater than) 0 success results.  This code will still
+    # get max, ignoring all 0s, returning negatives if caught and "max".
+    exit_results = [waitForPid(child) for child in children]
+    exit_errors = filter(lambda x: x != 0, exit_results)
+    error_count = len(exit_errors)
+    exit_status = error_count and reduce(max, exit_errors) or 0
+    return(exit_status, error_count, exit_results)
+
+
+def makeDir(path):
+    if not os.path.exists(path):
+        try:
+            os.makedirs(path, 0775)
+        except OSError, (errno, strerror):
+            error("couldn't make %s directory: %s" % (path, os.strerror(errno)))
+
+
+def getHostname():
+    try:
+        f = os.popen("/bin/hostname", "r")
+        host_name = f.readline()
+    except OSError, (errno, strerror):
+        error("error running hostname: %s" % os.strerror(errno))
+    f.close()
+
+    host_name = host_name.strip()
+    names = host_name.split('-')
+    # this code does :
+    # host_name      len(names) final names:
+    # something      1          something
+    # something-2    2          something
+    # some-thing-2   3          some-thing
+    # some-th-ing-2  4          some-th-ing
+    if len(names) > 1:
+        names.pop()
+    stack_name = '-'.join(names)
+
+    return stack_name, host_name
+
+
+def makePkgName():
+    if options.tarfile is not None:
+        pkg_path_name = fixTarfileName(options.tarfile)
+        if pkg_path_name is not None:
+            return(pkg_path_name)
+
+    time_string = time.strftime("%Y%m%d-%H%M%S")
+    pkg_name = "RackHDLogs-%s-%s.tgz" % (stack.name, time_string)
+    pkg_path_name = os.path.join(PKG_SUPPORT_DIR, pkg_name)
+
+    return(pkg_path_name)
+
+
+def makeDirs(dirs):
+    '''Returns count of nodes that failed mkdir command.'''
+    for dir in dirs:
+        makeDir(dir)
+    return(0)
+
+
+def listGroups():
+    print "\nKnown groups (included with the --group option): \n"
+    groups = GROUPS.keys()
+    groups.sort()
+    for g in groups:
+        print "  %s" % g
+    print
+
+
+def listUtils():
+    print
+    print "Known utilities (included with the -i option): \n"
+    utils = UTILITIES.keys()
+    utils.sort()
+    for u in utils:
+        if u not in EXEMPT:
+            print "  %s" % u
+    print
+
+
+# this routine is simply here to print the warning message, and alert
+# the user they munged the name.
+# we skip removing the unknown name from the include array, since it won't
+# hurt anything being in there (since the keys of the UTILITIES dict
+# is what's searched).
+def pruneUtils(requested):
+    ulist = UTILITIES.keys()
+    nlist = []
+    for r in requested:
+        if r not in ulist:
+            print "WARNING: unknown utility (%s), ignored..." % r
+        else:
+            nlist.append(r)
+
+    return(nlist)
+
+
+# An internal correctness check to verify that everything in GROUPS and
+# EXEMPT actually exists.
+def validateUtils():
+    util_errors = 0
+    for (group, utils) in GROUPS.items():
+        for util in utils:
+            # if not UTILITIES.has_key(util):
+            if util not in UTILITIES:
+                util_errors += 1
+                print "Unknown utility '%s' in group '%s'!" % (util, group)
+    for util in EXEMPT:
+        # if not UTILITIES.has_key(util):
+        if util not in UTILITIES:
+            print "Unknown utility '%s' in default group!" % util
+    if util_errors:
+        print "%d utility errors." % util_errors
+        sys.exit(1)
+
+
+# the logic: anything (valid) in the include list automatically means
+# all other utilities are excluded (except for things in EXEMPT).
+# (unless user specified '--nologs', which skips EXEMPT)
+def buildRunUtils(ilist):
+    if ilist is not None:
+        list = pruneUtils(ilist)
+    else:
+        list = []
+    if options.group_utils:
+        list.extend(options.group_utils)
+    if options.no_exempt_logs is False:
+        list.extend(EXEMPT)
+    return(list)
+
+
+# Given a user-supplied tarfile, fix it to ensure:
+# o If full path specified, use that path
+# o If no full path given, use original PKG_SUPPORT_DIR path
+# o Check extension: if usual tarfile extension, make sure we
+#   don't "double up" with additional .tgz; otherwise keep intact.
+# o Also check for special case '/' (root) specified
+# Returns None for any problems (such as '/' case)
+def fixTarfileName(tarfile):
+    tarfile = os.path.normpath(tarfile.strip())
+    # Note this verifies we were not given only '/'
+    if len(tarfile) and not (tarfile[0] == '/' and len(tarfile) == 1):
+        # Is it a full path or not? If not, supply default path.
+        if tarfile[0] != '/':
+            tarfile = PKG_SUPPORT_DIR + tarfile
+        # Does it have an extension already?
+        root, ext = os.path.splitext(tarfile)
+        if ext in ['.tar', '.tgz']:
+            tarfile = root
+        elif ext in ['.gz']:
+            root2, ext2 = os.path.splitext(root)
+            if ext2 in ['.tar']:
+                tarfile = root2
+            else:
+                tarfile = root
+        else:
+            # Note we'll just keep original extensions...
+            pass
+        tarfile = tarfile + ".tgz"
+        return(tarfile)
+    else:
+        return(None)
+
+
+def getPathFile(pathfile):
+    # NOTE we need this rstrip mod for reliable dirname/basename!
+    x = pathfile.rstrip('/')
+    return(os.path.dirname(x), os.path.basename(x))
+
+
+def getUtilityGatherCmd(name, path, base):
+    # Avoid gathering duplicate data from all the nodes.
+    # If path starts with /ifs, than gather data from only one node (local node)
+    # e.g. path=/ifs/data or path=/ifs
+    c = ('tar', "cd %s" % (path), "%s.tar %s" % (name, base))
+    return(c)
+
+
+# 'cmd' better be executable - either fullpath or in PATH
+def getUtilityExecuteCmd(name, cmd, args):
+    c = ('exe', "%s %s" % (cmd, args), "%s" % (name))
+    return(c)
+
+
+def makeUniqueDictKeyName(name, dict):
+    new_name, count = name, 0
+    while new_name in dict.keys():
+        count += 1
+        new_name = '%s-%d' % (name, count)
+    return new_name
+
+
+def verbose(str):
+    if options.verbose:
+        print >> sys.stdout, str
+
+
+def error(str):
+    print >> sys.stderr, PROGNAME + ':', str
+    sys.exit(1)
+
+
+def clean_tmp_dir(dir=TMP_SUPPORT_DIR):
+    '''Function cleans up all temporary data on all nodes.  Returns the number
+        of failures returned from executing rm.'''
+    error_count = 0
+    cmd_args = ["/bin/rm", "-rf", dir]
+    cmd = " ".join(cmd_args)
+    (exit, output) = get_cmd_output(cmd)
+    if exit:
+        error_count += 1
+        print "\nERROR cleaning up %s, output follows:\n%s" % (dir, "\n".join(output))
+    if error_count:
+        print "You may wish to delete these files manually."
+    return error_count
+
+
+class MyLock(object):
+    """class to handle .lock files
+        """
+    def __init__(self, path=GATHER_STATUS_LOCK, verbose=False):
+        self.lockFD = ''
+        self.lockfile = path
+        self.pid = os.getpid()
+        self.verbose = verbose
+
+    def isPidRunning(self, pid):
+        """checks if a given isi_gather_info is an active process"""
+        cmd = """ps -o command= -p %d """
+        try:
+            (exit, output) = get_cmd_output(cmd % pid)
+            if exit:
+                return False
+            if output and len(output):
+                # if we get an output, it'll be just one element -> pid
+                return 'isi_gather_info' in output[0]
+            return False
+        except:
+            return False
+
+    def _readlock(self):
+        """reads the contents of a lock file. ie pid of the owner"""
+        try:
+            self.lockFD = os.open(self.lockfile, os.O_RDONLY)
+            pid = os.read(self.lockFD, 100)
+            os.close(self.lockFD)
+            if pid != '':
+                pid = int(pid)
+            else:
+                pid = 10**8
+            return pid
+        except:
+            return False
+
+    def _lock(self):
+        """helper to lock()"""
+        try:
+            self.lockFD = os.open(self.lockfile, os.O_EXCL | os.O_CREAT | os.O_RDWR, 0400)
+            os.write(self.lockFD, str(self.pid))
+            os.close(self.lockFD)
+            return True
+        except OSError, e:
+            if e.errno == 17:   # file exists!
+                return False
+            return False
+        except:                 # any others
+            return False
+
+    def ownlock(self):
+        """do i own lock"""
+        try:
+            lock = self._readlock()
+            if lock:
+                return self.pid == lock
+            return False
+        except:
+            return False
+
+    def lock(self):
+        """locks. writes own pid to lock file"""
+        # print "Locking self"
+        # is gather-status unlocked? try locking
+        if not os.path.exists(self.lockfile):
+            return self._lock()
+        else:
+            pid = self._readlock()
+            # is gather-status.lock owner running? ie lock expired?
+            if not self.isPidRunning(pid):
+                # print "Unlocking gather-status"
+                self.unlock()
+                return self._lock()
+            else:
+                print "%s is currently locked. Status Updates will not be written to file." % (self.lockfile)
+        return False
+
+    def unlock(self):
+        """ unlocks lockfile """
+        if os.path.exists(self.lockfile):
+            print "Gather-status unlocked"
+            try:
+                os.remove(self.lockfile)
+            except Exception:
+                print "Error unlocking lockfile"
+                return False
+            return True
+        else:
+            print ("Gather-status lock does not exit")
+            return False
+
+
+class Logger(threading.Thread):
+    """runs logging to file as a thread. timestamps the log file every
+        self.updateInterval seconds. also allows async writes, as used
+        to update program status.
+    """
+    def __init__(self, name="Logger", filename=GATHER_STATUS_PATH):
+        self._stopevent = threading.Event()
+        self.updateInterval = 3
+        self.lastLogTime = 0
+        self.filename = filename
+        self.disable = False
+        self.flock = MyLock()
+
+        self.flock.owner = self.flock.lock()
+        if self.flock.owner:
+            try:
+                self.fileFD = open(self.filename, 'w')
+            except IOError:
+                print "Could not open gather-status file. "
+                self.disable = True
+        else:
+            self.disable = True
+        threading.Thread.__init__(self, name=name)
+        self.start()
+
+    def run(self):
+        """timestamps the file as long as the thread is active"""
+        while (not self._stopevent.isSet()) and (not self.disable):
+            self.write()
+            time.sleep(self.updateInterval)
+
+    def write(self, msg="", priority=False):
+        """priority write. update with msg"""
+        if (not self._stopevent.isSet()) and (not self.disable):
+            try:
+                self.lastLogTime = time.time()
+                timestamp = "[%s] " % time.strftime("%Y-%m-%d %H:%M:%S")
+                self.fileFD.writelines(timestamp + msg + '\n')
+                self.fileFD.flush()
+            except IOError:
+                # this is to escape any errors generated by a closed terminal
+                self.join(None)
+                pass
+
+    def join(self, timeout=None):
+        self._stopevent.set()
+        if self.flock.owner:
+            try:
+                self.fileFD.close()
+                self.flock.unlock()
+                threading.Thread.join(self, timeout)
+            except Exception:
+                print "Error unlocking gather log"
+                pass
+
+
+def get_options():
+    global stack, options, log, re_upload
+
+    try:
+        opts, args = getopt.getopt(sys.argv[1:], 'hvlu:p:x:t:T:',
+                                   ['help', 'version', 'list', 'user=', 'password=',
+                                    'tarfile=', 'temp=', 'nologs', 'debug',
+                                    'verbose', 'varlog_all', 'varlog_recent',
+                                    'no-config', 'group=', 'noconfig', 'tardir='])
+
+        for o, a in opts:
+            if o in ['-h', '--help']:
+                usage(0)
+            elif o in ['-v', '--version']:
+                version()
+            elif o in ['-l', '--list']:
+                listUtils()
+                listGroups()
+                sys.exit(0)
+            elif o in ['--noconfig']:
+                pass     # nothing to do here; handled above
+            elif o in ['-u', '--user']:
+                stack.user = a
+            elif o in ['-p', '--password']:
+                stack.password = a
+            elif o in ['-x']:
+                for each in a.split(', '):
+                    try:
+                        EXEMPT.remove(each)
+                    except ValueError, e:
+                        error("Utility %s does not exist to be excluded." % (each))
+            elif o in ['-t', '--tarfile']:
+                options.tarfile = a
+            elif o in ['--tardir']:
+                # this is a lot like -T, except -T still creates a 'pkg'
+                # directory underneath the specified directory, which is
+                # not always desirable.  I'd replace -T but I have no
+                # idea if its being used.
+                if not a.startswith('/'):
+                    print "Tar directory %s invalid; it must begin with /"
+                    sys.exit(1)
+                options.tardir = a
+            elif o in ['-T', '--temp']:
+                options.tempdir = a.lstrip()
+            elif o in ['--nologs']:
+                options.no_exempt_logs = True
+            elif o in ['--debug']:
+                options.debug = True
+            elif o in ['--verbose']:
+                options.verbose = True
+            elif o in ['--varlog_all']:
+                # This is the default
+                EXEMPT[0] = 'varlog_all'
+            elif o in ['--varlog_recent']:
+                EXEMPT[0] = 'varlog_recent'
+            elif o in ['--group']:
+                try:
+                    options.group_utils.extend(GROUPS[a])
+                    options.group.append(a)
+                except KeyError, e:
+                    print "Invalid group specified: %s" % a
+                    listGroups()
+                    sys.exit(1)
+            else:
+                print "Unknown argument: %s" % o
+                usage(1)
+
+    except getopt.GetoptError, e:
+        error(str(e.msg))
+
+
+def usage(exitCode):
+    sys.stderr.write('''
+Usage: %s [OPTION]...
+
+Options:
+  -h                  Print this message and exit.
+  -v                  Print version info and exit.
+  -u USER             Login as USER instead of default onrack.
+  -p PASSWORD         Use PASSWORD.
+  -t TARFILE          Save all results to TARFILE instead of default tar file.
+  -T TEMPDIR          Save all results to TEMPDIR instead of default dir.
+  --tardir <dir>      Place the final package directly into <dir>.
+
+  Default temporary directory is %s
+  (change with -T)
+
+''' % (PROGNAME, VAR_SUPPORT_DIR))
+    sys.exit(exitCode)
+
+
+def version():
+    print '%s version: %s' % (PROGNAME, REVISION)
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/tools/save-logs/rackhd_gather_info.py
+++ b/test/tools/save-logs/rackhd_gather_info.py
@@ -242,7 +242,7 @@ def generate_scripts(run_utils):
             header += "SUDO='sudo '\n"
             # print "Sudo header:", header
 
-        localfd = os.open(LOCAL_GATHER_SCRIPT, flags, 0755)
+        localfd = os.open(LOCAL_GATHER_SCRIPT, flags, 0o755)
         os.write(localfd, header)
 
         for util in run_utils:
@@ -279,7 +279,6 @@ def generate_scripts(run_utils):
 def main():
     global stack, options, log, re_upload
 
-    # print "GATHER_STATUS_PATH:", GATHER_STATUS_PATH
     log = Logger(GATHER_STATUS_PATH)
 
     #
@@ -319,7 +318,7 @@ def main():
     get_options()
 
     if stack.password:
-        print "\nNote: A password is only required with -T.  Ignoring."
+        print("\nNote: A password is only required with -T.  Ignoring.")
 
     # update paths
     update_support_dirs(options)
@@ -373,18 +372,18 @@ def main():
     start_time = int(time.time())
     exit_status = 0
 
-    print "Running gather script."
-    print "This may take several minutes.  Please do not interrupt the script."
-    print
+    print("Running gather script.")
+    print("This may take several minutes.  Please do not interrupt the script.")
+    print(" ")
 
     log.write("Gather In Progress on stack. Running.")
     task = "Running gather script on stack"
     (exit, output) = get_cmd_output("bash " + LOCAL_GATHER_SCRIPT)
     if exit:
-        print "ERROR %s" % task
+        print("ERROR %s" % task)
         log.write("Gather Failed. %s" % output)
         for line in output:
-            print line
+            print(line)
 
     # Save package xml metadata
     pkginfo = {
@@ -403,7 +402,7 @@ def main():
 
     # put everything into one tarball
     log.write("Gather Succeeded.")
-    print "Information gathering completed... creating compressed package."
+    print("Information gathering completed... creating compressed package.")
     pkg_path_name = makePkgName()
 
     try:
@@ -411,22 +410,22 @@ def main():
         os.chdir(TMP_SUPPORT_DIR)
         (exit, output) = get_cmd_output(tar_command)
         if exit:
-            print "ERROR tar returned %d" % (exit >> 8),
+            print("ERROR tar returned %d" % (exit >> 8)),
             log.write("Gather Failed")
             if output:
-                print ", output follows:"
+                print(" output follows:")
                 for line in output:
-                    print line
+                    print(line)
             else:
-                print ""
+                print(" ")
             error("Could not create compressed package.")
             log.write("Gather Failed. Could not create compressed package.")
     except OSError, (errno, strerror):
         error("FAILED system call (tar): %s" % (os.strerror(errno)))
         log.write("Gather Failed %s" % (os.strerror(errno)))
 
-    print "Packaging complete..."
-    print "Package: %s" % pkg_path_name
+    print("Packaging complete...")
+    print("Package: %s" % pkg_path_name)
     log.write("Package: %s" % pkg_path_name)
 
     # If we don't have the exit_status set, then the log gathered
@@ -446,9 +445,9 @@ def main():
             sys.stderr.write('WARNING: Full Gather run data update failed. %s\n' % str(e))
             log.write("Gather Failed. WARNING: Full Gather run data update failed.")
 
-    print "Cleaning up temporary data...",
+    print("Cleaning up temporary data..."),
     if clean_tmp_dir(TMP_SUPPORT_DIR) == 0:
-        print "done."
+        print("done.")
 
     verbose("\nCleaning up core/dumps")
 
@@ -476,7 +475,7 @@ def get_popen(cmd, include_stderr=True, stdin=None):
                                 stdout=subprocess.PIPE, close_fds=True,
                                 shell=True)
     except OSError:
-        print "While running", cmd
+        print("While runnin {}".format(cmd))
         raise
 
 
@@ -647,23 +646,23 @@ def makeDirs(dirs):
 
 
 def listGroups():
-    print "\nKnown groups (included with the --group option): \n"
+    print("\nKnown groups (included with the --group option): \n")
     groups = GROUPS.keys()
     groups.sort()
     for g in groups:
-        print "  %s" % g
-    print
+        print("  %s" % g)
+    print("")
 
 
 def listUtils():
-    print
-    print "Known utilities (included with the -i option): \n"
+    print("")
+    print("Known utilities (included with the -i option): \n")
     utils = UTILITIES.keys()
     utils.sort()
     for u in utils:
         if u not in EXEMPT:
-            print "  %s" % u
-    print
+            print("  %s" % u)
+    print("")
 
 
 # this routine is simply here to print the warning message, and alert
@@ -676,7 +675,7 @@ def pruneUtils(requested):
     nlist = []
     for r in requested:
         if r not in ulist:
-            print "WARNING: unknown utility (%s), ignored..." % r
+            print("WARNING: unknown utility (%s), ignored..." % r)
         else:
             nlist.append(r)
 
@@ -692,13 +691,13 @@ def validateUtils():
             # if not UTILITIES.has_key(util):
             if util not in UTILITIES:
                 util_errors += 1
-                print "Unknown utility '%s' in group '%s'!" % (util, group)
+                print("Unknown utility '%s' in group '%s'!" % (util, group))
     for util in EXEMPT:
         # if not UTILITIES.has_key(util):
         if util not in UTILITIES:
-            print "Unknown utility '%s' in default group!" % util
+            print("Unknown utility '%s' in default group!" % util)
     if util_errors:
-        print "%d utility errors." % util_errors
+        print("%d utility errors." % util_errors)
         sys.exit(1)
 
 
@@ -797,9 +796,9 @@ def clean_tmp_dir(dir=TMP_SUPPORT_DIR):
     (exit, output) = get_cmd_output(cmd)
     if exit:
         error_count += 1
-        print "\nERROR cleaning up %s, output follows:\n%s" % (dir, "\n".join(output))
+        print("\nERROR cleaning up %s, output follows:\n%s" % (dir, "\n".join(output)))
     if error_count:
-        print "You may wish to delete these files manually."
+        print("You may wish to delete these files manually.")
     return error_count
 
 
@@ -878,21 +877,21 @@ class MyLock(object):
                 self.unlock()
                 return self._lock()
             else:
-                print "%s is currently locked. Status Updates will not be written to file." % (self.lockfile)
+                print("%s is currently locked. Status Updates will not be written to file." % (self.lockfile))
         return False
 
     def unlock(self):
         """ unlocks lockfile """
         if os.path.exists(self.lockfile):
-            print "Gather-status unlocked"
+            print("Gather-status unlocked")
             try:
                 os.remove(self.lockfile)
             except Exception:
-                print "Error unlocking lockfile"
+                print("Error unlocking lockfile")
                 return False
             return True
         else:
-            print ("Gather-status lock does not exit")
+            print("Gather-status lock does not exit")
             return False
 
 
@@ -914,7 +913,7 @@ class Logger(threading.Thread):
             try:
                 self.fileFD = open(self.filename, 'w')
             except IOError:
-                print "Could not open gather-status file. "
+                print("Could not open gather-status file. ")
                 self.disable = True
         else:
             self.disable = True
@@ -948,7 +947,7 @@ class Logger(threading.Thread):
                 self.flock.unlock()
                 threading.Thread.join(self, timeout)
             except Exception:
-                print "Error unlocking gather log"
+                print("Error unlocking gather log")
                 pass
 
 
@@ -991,7 +990,7 @@ def get_options():
                 # not always desirable.  I'd replace -T but I have no
                 # idea if its being used.
                 if not a.startswith('/'):
-                    print "Tar directory %s invalid; it must begin with /"
+                    print("Tar directory %s invalid; it must begin with /")
                     sys.exit(1)
                 options.tardir = a
             elif o in ['-T', '--temp']:
@@ -1012,11 +1011,11 @@ def get_options():
                     options.group_utils.extend(GROUPS[a])
                     options.group.append(a)
                 except KeyError, e:
-                    print "Invalid group specified: %s" % a
+                    print("Invalid group specified: %s" % a)
                     listGroups()
                     sys.exit(1)
             else:
-                print "Unknown argument: %s" % o
+                print("Unknown argument: %s" % o)
                 usage(1)
 
     except getopt.GetoptError, e:
@@ -1044,7 +1043,7 @@ Options:
 
 
 def version():
-    print '%s version: %s' % (PROGNAME, REVISION)
+    print('%s version: %s' % (PROGNAME, REVISION))
     sys.exit(0)
 
 

--- a/test/tools/save-logs/save_logs.py
+++ b/test/tools/save-logs/save_logs.py
@@ -13,7 +13,7 @@ The script will create the target directory
 A configuration file 'save_logs_conf.json' can be setup to provide the following information.
   user, password, webserver, local directory to store files
 '''
-
+from __future__ import print_function
 import json
 import argparse
 import subprocess
@@ -47,7 +47,7 @@ def main():
     ARG_PARSER = argparse.ArgumentParser(description="Command Help")
     ARG_PARSER.add_argument("-v", action='store_true',
                             help="Turn on verbose mode")
-    ARG_PARSER.add_argument("-ip", default="0.0.0.0",
+    ARG_PARSER.add_argument("-ip", default="None",
                             help="Appliance IP address or hostname")
     ARG_PARSER.add_argument("-port", default="",
                             help="Optional port argument for scp/ssh")
@@ -96,7 +96,7 @@ def main():
                 print("Usage: ./save_logs.py -ip <ip> -user <username> -pwd <password>")
             sys.exit(-1)
 
-    if ARGS_LIST.ip == "0.0.0.0":
+    if ARGS_LIST.ip == "None":
         try:
             ARGS_LIST.ip = CONFIG["ip"]
         except:

--- a/test/tools/save-logs/save_logs.py
+++ b/test/tools/save-logs/save_logs.py
@@ -25,16 +25,18 @@ import socket
 try:
     import pexpect
 except IOError:
-    print "Python 'pexpect' package required for this script." \
-          "\nUse: 'pip install pexpect'\nExiting...\n"
+    print("Python 'pexpect' package required for this script.")
+    print("Use: 'pip install pexpect'\nExiting...\n")
 try:
     import extract_logs
 except IOError:
-    print "Python \'extract_logs\' package required for this script, check for errors."
+    print("Python \'extract_logs\' script required for this script, check for errors.")
     exit(1)
 
 # Default gather script
 gather_script = "rackhd_gather_info.py"
+
+real_raw_input = vars(__builtins__).get('raw_input', input)
 
 
 def main():
@@ -64,10 +66,10 @@ def main():
     ARGS_LIST = ARG_PARSER.parse_args()
     try:
         CONFIG = json.loads(open("save_logs_conf.json").read())
-        print "save_logs: Using configuration from \"save_logs_conf.json\"."
+        print("save_logs: Using configuration from \"save_logs_conf.json\".")
         config = True
     except:
-        print "save_logs: No config file found"
+        print("save_logs: No config file found")
         config = False
 
     if ARGS_LIST.user == "None":
@@ -75,11 +77,11 @@ def main():
             ARGS_LIST.user = CONFIG["username"]
         except:
             if config is True:
-                print "Username required"
-                print "Usage: {0} -user <username>".format(myfile)
+                print("Username required")
+                print("Usage: {0} -user <username>".format(myfile))
             else:
-                print "Missing Required Parameters"
-                print "Usage: ./save_logs.py -ip <ip> -user <username> -pwd <password>"
+                print("Missing Required Parameters")
+                print("Usage: ./save_logs.py -ip <ip> -user <username> -pwd <password>")
             sys.exit(-1)
 
     if ARGS_LIST.pwd == "None":
@@ -87,11 +89,11 @@ def main():
             ARGS_LIST.pwd = CONFIG["password"]
         except:
             if config is True:
-                print "Password required"
-                print "Usage: {0} -pwd <password>".format(myfile)
+                print("Password required")
+                print("Usage: {0} -pwd <password>".format(myfile))
             else:
-                print "Missing Required Parameters"
-                print "Usage: ./save_logs.py -ip <ip> -user <username> -pwd <password>"
+                print("Missing Required Parameters")
+                print("Usage: ./save_logs.py -ip <ip> -user <username> -pwd <password>")
             sys.exit(-1)
 
     if ARGS_LIST.ip == "0.0.0.0":
@@ -99,11 +101,11 @@ def main():
             ARGS_LIST.ip = CONFIG["ip"]
         except:
             if config is True:
-                print "Stack IP address or hostname required."
-                print "Usage: {0} -ip <ip or hostname>".format(myfile)
+                print("Stack IP address or hostname required.")
+                print("Usage: {0} -ip <ip or hostname>".format(myfile))
             else:
-                print "Missing Required Parematers"
-                print "Usage: ./save_logs.py -ip <ip> -user <username> -pwd <password>"
+                print("Missing Required Parematers")
+                print("Usage: ./save_logs.py -ip <ip> -user <username> -pwd <password>")
             sys.exit(-1)
 
     # scp requires a capital P, ssh requires a lowercase p, for port. Setting up the string format here.
@@ -120,20 +122,21 @@ def main():
             ARGS_LIST.log_path = CONFIG["log_directory_path"]
             # check if value from config file is valid
             if not os.path.isdir(ARGS_LIST.log_path):
-                print 'Output directory path is not present on this system: {0}'.format(ARGS_LIST.log_path)
-                print "Saving logs in current directory: {}".format(cur_dir)
+                print('Output directory path is not present on this system: {0}'.format(ARGS_LIST.log_path))
+                print("Saving logs in current directory: {}".format(cur_dir))
                 ARGS_LIST.log_path = cur_dir
             else:
-                print 'Saving logs in directory path: {}'.format(ARGS_LIST.log_path)
+                print('Saving logs in directory path: {}'.format(ARGS_LIST.log_path))
         except:
-            print "Saving logs in current directory: {}".format(cur_dir)
+            print("Saving logs in current directory: {}".format(cur_dir))
             ARGS_LIST.log_path = cur_dir
     else:
-        print 'Saving logs in directory path: {}'.format(ARGS_LIST.log_path)
+        print('Saving logs in directory path: {}'.format(ARGS_LIST.log_path))
 
     # Get the target directory name, will get appended to the log path and created
     if ARGS_LIST.target_dir == "None":
-        ARGS_LIST.name = raw_input("Enter name of target directory, will be created: ")
+        ARGS_LIST.name = real_raw_input("Enter name of target directory, will be created: ")
+        print("Directory: {} ".format(ARGS_LIST.name))
     else:
         ARGS_LIST.name = ARGS_LIST.target_dir
 
@@ -142,13 +145,13 @@ def main():
 
     # Run the save logs function
     save_logs(ARGS_LIST)
-    # If log server used, print log location
+    # If log server used, print(log location)
     try:
         if ARGS_LIST.log_path == CONFIG["log_directory_path"]:
-            print "Webserver: {0}{1}".format(CONFIG["webserver"], ARGS_LIST.name)
+            print("Webserver: {0}{1}".format(CONFIG["webserver"], ARGS_LIST.name))
     except:
         pass
-    print "\n----Done----"
+    print("\n----Done----")
 
 
 def save_logs(args):
@@ -158,27 +161,27 @@ def save_logs(args):
     This is outside of main in order to allow other scripts acess to this utility
     :param args: command line arguments
     '''
-    print "This utility will attempt to gather log files and data from your appliance for debugging."
+    print("This utility will attempt to gather log files and data from your appliance for debugging.")
 
     teststack = args.ip
-    print "Pushing gather script to stack...."
+    print("Pushing gather script to stack....")
     if copy_loggather_script_to_stack(teststack, args) is True:
         if args.log_path[-1] != "/":
             args.log_path = args.log_path + "/"
         logdir = args.log_path + args.name
         # make the log directory
         if extract_logs.mk_datadir(logdir, args.name) is True:
-            print "Running gather logs script, please wait....."
+            print("Running gather logs script, please wait.....")
             pkg = run_gather_logs(teststack, args)
             if pkg != "none":
-                print "Saved logs on stack in ", pkg
-                print "Copying from stack...."
+                print("Saved logs on stack in {}".format(pkg))
+                print("Copying from stack....")
                 if scp_tgz_to_logserver(teststack, pkg, logdir, args) is True:
                     if args.no_extract is False:
                         extract_logs.extract_tgz_file_to_datadir(pkg, logdir)
-                print "\nLog directory: " + logdir
+                print("Log directory: {}".format(logdir))
         else:
-            print "Could not create Log directory \"" + logdir + "\""
+            print("Could not create Log directory \"" + logdir + "\"")
 
     # Attempt to clean up gather script from stack regardless
     remove_gather_script(teststack, args)
@@ -238,8 +241,8 @@ def remove_gather_script(testhost, args):
 
     remote_ssh_res = remote_shell(str_remove_cmd, args)
     if remote_ssh_res['exitcode'] != 0:
-        print "Error in remove command from " + testhost
-        print "Please clean up /tmp directory on stack"
+        print("Error in remove command from " + testhost)
+        print("Please clean up /tmp directory on stack")
 
 
 def run_gather_logs(testhost, args):
@@ -261,7 +264,7 @@ def run_gather_logs(testhost, args):
 
     remote_ssh_res = remote_shell(str_gather_cmd, args)
     if remote_ssh_res['exitcode'] != 0:
-        print "Error in executing " + gather_script + " on " + testhost
+        print("Error in executing " + gather_script + " on " + testhost)
     else:
         pstr = remote_ssh_res['stdout']
         # the rackhd_gather_info.py script returns the package name in the output
@@ -295,18 +298,18 @@ def scp_tgz_to_logserver(testhost, pkginfo, logdir, args):
         time.sleep(10)
         status = True
     else:
-        print child.before
-        print "ERROR: Expecting password for SCP timed out."
-        print "SCP of log files failed due to password error."
-        print "Please manually scp " + pkginfo + " to desired location."
+        print(child.before)
+        print("ERROR: Expecting password for SCP timed out.")
+        print("SCP of log files failed due to password error.")
+        print("Please manually scp " + pkginfo + " to desired location.")
 
     child.close()
     return status
 
 
 def handle_pexpect_error(child, errstr):
-    print errstr
-    print child.before, child.after
+    print(errstr)
+    print(child.before, child.after)
     child.terminate()
 
 
@@ -324,7 +327,7 @@ def remote_shell(shell_cmd, args, expect_receive="", expect_send=""):
     logfile_redirect = None
     shell_cmd.replace("'", "\\\'")
     if args.v is True:
-        print "remote_shell: Shell Command: ", shell_cmd
+        print("remote_shell: Shell Command: {}".format(shell_cmd))
         logfile_redirect = sys.stdout
     if expect_receive == "" or expect_send == "":
         (command_output, exitstatus) = \
@@ -342,7 +345,8 @@ def remote_shell(shell_cmd, args, expect_receive="", expect_send=""):
                                 expect_receive: expect_send + "\n"},
                         timeout=600, logfile=logfile_redirect)
     if args.v is True:
-        print shell_cmd, "\nremote_shell: Exit Code:", exitstatus
+        print("Shell cmd: {}".format(shell_cmd))
+        print("Exit Code: {}".format(exitstatus))
     return {'stdout': command_output, 'exitcode': exitstatus}
 
 
@@ -373,7 +377,7 @@ def setup_connection(args):
         elif i == 3:   # Connected to the host
             break
         else:
-            print "ERROR: Unable to access host exiting..."
+            print("ERROR: Unable to access host exiting...")
             exit(-1)
 
 

--- a/test/tools/save-logs/save_logs.py
+++ b/test/tools/save-logs/save_logs.py
@@ -1,0 +1,381 @@
+#!/usr/bin/python
+'''
+Copyright 2016-2017, DELL EMC
+
+ScriptName:  save_logs.py
+Author(s): Erika Hohenstein, Brent Higgins
+Initial date: 07/10/15
+
+Purpose:
+Remotely run the rackhd_gather_info.py on a stack (or appliance, vagrant instances) and copy log
+files to a target directory off box.
+The script will create the target directory
+A configuration file 'save_logs_conf.json' can be setup to provide the following information.
+  user, password, webserver, local directory to store files
+'''
+
+import json
+import argparse
+import subprocess
+import time
+import sys
+import os
+import socket
+
+try:
+    import pexpect
+except IOError:
+    print "Python 'pexpect' package required for this script." \
+          "\nUse: 'pip install pexpect'\nExiting...\n"
+try:
+    import extract_logs
+except IOError:
+    print "Python \'extract_logs\' package required for this script, check for errors."
+    exit(1)
+
+# Default gather script
+gather_script = "rackhd_gather_info.py"
+
+
+def main():
+    myfile = os.path.basename(__file__)
+    path = os.path.realpath(myfile)
+    cur_dir = os.path.dirname(path)
+
+    ARG_PARSER = argparse.ArgumentParser(description="Command Help")
+    ARG_PARSER.add_argument("-v", action='store_true',
+                            help="Turn on verbose mode")
+    ARG_PARSER.add_argument("-ip", default="0.0.0.0",
+                            help="Appliance IP address or hostname")
+    ARG_PARSER.add_argument("-port", default="",
+                            help="Optional port argument for scp/ssh")
+    ARG_PARSER.add_argument("-user", default="None",
+                            help="Appliance username")
+    ARG_PARSER.add_argument("-pwd", default="None",
+                            help="Appliance password")
+    ARG_PARSER.add_argument("-no_extract", action='store_true',
+                            help="Do not extract the tarball, default to extract")
+    ARG_PARSER.add_argument("-log_path", default="None",
+                            help="Logging Directory Path")
+    ARG_PARSER.add_argument("-target_dir", default="None",
+                            help="Target directory name to store logs")
+
+    # parse arguments to ARGS_LIST dict
+    ARGS_LIST = ARG_PARSER.parse_args()
+    try:
+        CONFIG = json.loads(open("save_logs_conf.json").read())
+        print "save_logs: Using configuration from \"save_logs_conf.json\"."
+        config = True
+    except:
+        print "save_logs: No config file found"
+        config = False
+
+    if ARGS_LIST.user == "None":
+        try:
+            ARGS_LIST.user = CONFIG["username"]
+        except:
+            if config is True:
+                print "Username required"
+                print "Usage: {0} -user <username>".format(myfile)
+            else:
+                print "Missing Required Parameters"
+                print "Usage: ./save_logs.py -ip <ip> -user <username> -pwd <password>"
+            sys.exit(-1)
+
+    if ARGS_LIST.pwd == "None":
+        try:
+            ARGS_LIST.pwd = CONFIG["password"]
+        except:
+            if config is True:
+                print "Password required"
+                print "Usage: {0} -pwd <password>".format(myfile)
+            else:
+                print "Missing Required Parameters"
+                print "Usage: ./save_logs.py -ip <ip> -user <username> -pwd <password>"
+            sys.exit(-1)
+
+    if ARGS_LIST.ip == "0.0.0.0":
+        try:
+            ARGS_LIST.ip = CONFIG["ip"]
+        except:
+            if config is True:
+                print "Stack IP address or hostname required."
+                print "Usage: {0} -ip <ip or hostname>".format(myfile)
+            else:
+                print "Missing Required Parematers"
+                print "Usage: ./save_logs.py -ip <ip> -user <username> -pwd <password>"
+            sys.exit(-1)
+
+    # scp requires a capital P, ssh requires a lowercase p, for port. Setting up the string format here.
+    # necessary for vagrant instance log gathering.
+    if ARGS_LIST.port != "":
+        ARGS_LIST.port2 = "-P " + ARGS_LIST.port
+        ARGS_LIST.port = "-p " + ARGS_LIST.port
+    else:
+        ARGS_LIST.port2 = ""
+
+    # Check the log directory path exists, may be using a logserver so ensure it is there
+    if not os.path.isdir(ARGS_LIST.log_path):
+        try:
+            ARGS_LIST.log_path = CONFIG["log_directory_path"]
+            # check if value from config file is valid
+            if not os.path.isdir(ARGS_LIST.log_path):
+                print 'Output directory path is not present on this system: {0}'.format(ARGS_LIST.log_path)
+                print "Saving logs in current directory: {}".format(cur_dir)
+                ARGS_LIST.log_path = cur_dir
+            else:
+                print 'Saving logs in directory path: {}'.format(ARGS_LIST.log_path)
+        except:
+            print "Saving logs in current directory: {}".format(cur_dir)
+            ARGS_LIST.log_path = cur_dir
+    else:
+        print 'Saving logs in directory path: {}'.format(ARGS_LIST.log_path)
+
+    # Get the target directory name, will get appended to the log path and created
+    if ARGS_LIST.target_dir == "None":
+        ARGS_LIST.name = raw_input("Enter name of target directory, will be created: ")
+    else:
+        ARGS_LIST.name = ARGS_LIST.target_dir
+
+    # setup connection to the stack/server
+    setup_connection(ARGS_LIST)
+
+    # Run the save logs function
+    save_logs(ARGS_LIST)
+    # If log server used, print log location
+    try:
+        if ARGS_LIST.log_path == CONFIG["log_directory_path"]:
+            print "Webserver: {0}{1}".format(CONFIG["webserver"], ARGS_LIST.name)
+    except:
+        pass
+    print "\n----Done----"
+
+
+def save_logs(args):
+    '''
+    Function that runs the overall processs of gathering and retrieving
+    all of the log information.
+    This is outside of main in order to allow other scripts acess to this utility
+    :param args: command line arguments
+    '''
+    print "This utility will attempt to gather log files and data from your appliance for debugging."
+
+    teststack = args.ip
+    print "Pushing gather script to stack...."
+    if copy_loggather_script_to_stack(teststack, args) is True:
+        if args.log_path[-1] != "/":
+            args.log_path = args.log_path + "/"
+        logdir = args.log_path + args.name
+        # make the log directory
+        if extract_logs.mk_datadir(logdir, args.name) is True:
+            print "Running gather logs script, please wait....."
+            pkg = run_gather_logs(teststack, args)
+            if pkg != "none":
+                print "Saved logs on stack in ", pkg
+                print "Copying from stack...."
+                if scp_tgz_to_logserver(teststack, pkg, logdir, args) is True:
+                    if args.no_extract is False:
+                        extract_logs.extract_tgz_file_to_datadir(pkg, logdir)
+                print "\nLog directory: " + logdir
+        else:
+            print "Could not create Log directory \"" + logdir + "\""
+
+    # Attempt to clean up gather script from stack regardless
+    remove_gather_script(teststack, args)
+
+
+def copy_loggather_script_to_stack(testhost, args):
+    '''
+    Copies the script rackhd_gather_info.py from the tools/loggather directory to
+    the stack in /tmp using pexpect.
+    :param testhost: ip address of stack
+    :param args: command line arguments
+    :return:
+        True on successful scp
+        False on any error
+    '''
+    status = False
+    # get there from here
+    my_dir = os.path.dirname(os.path.abspath(__file__))
+
+    command = "scp " + args.port2 + " " + "\"" + my_dir + "/" + gather_script \
+              + "\"" + " " + args.user + "@" + testhost + ":/tmp/."
+    child = pexpect.spawn(command)
+    child.timeout = 10
+    while True:
+        i = child.expect(['assword: ', pexpect.TIMEOUT, pexpect.EOF])
+        if i == 0:
+            child.sendline(args.pwd)
+            time.sleep(2)
+            data = child.read()
+            if "No such file" in data:
+                print("ERROR: Failed to push " + gather_script +
+                      " script to stack.\nCheck your repository contains " + my_dir + "/" + gather_script)
+                status = False
+                break
+            else:
+                status = True
+                break
+        elif i == 2 or i == 3:
+            handle_pexpect_error(child, "ERROR: Failed to push gather script to stack.\nCheck access to stack.")
+            status = False
+            break
+    child.close()
+    return status
+
+
+# cleanup, remove the script from the stack /tmp directory
+def remove_gather_script(testhost, args):
+    '''
+    This function will remove the gather script from the stack to clean up
+    It is a best effort to remove, so if it fails, will generate an message
+    to the user to clean up manually
+    :param testhost: ip address of stack
+    :param args: command line arguments
+    '''
+    remote_ssh_res = {'stdout': "", 'exitcode': 0}
+    str_remove_cmd = "rm /tmp/" + gather_script
+
+    remote_ssh_res = remote_shell(str_remove_cmd, args)
+    if remote_ssh_res['exitcode'] != 0:
+        print "Error in remove command from " + testhost
+        print "Please clean up /tmp directory on stack"
+
+
+def run_gather_logs(testhost, args):
+    '''
+    This function will run the rackhd_gather_info.py script on the stack via remote ssh.
+    If the script runs successfully, the stdout of the script produces a message that
+    we check for that includes the package name, in this form:
+    Package: /tmp/rackhd/pkg/RackHDLogs-ora-20150715-232238.tgz
+    :param testhost: ip address of rackhd server
+    :param args: command line arguments
+    :return:
+        none as the package name on any failure
+        package name in the form of /tmp/rackhd/.....tgz on success
+    '''
+
+    pkgfile = "none"
+    remote_ssh_res = {'stdout': "", 'exitcode': 0}
+    str_gather_cmd = "/tmp/" + gather_script
+
+    remote_ssh_res = remote_shell(str_gather_cmd, args)
+    if remote_ssh_res['exitcode'] != 0:
+        print "Error in executing " + gather_script + " on " + testhost
+    else:
+        pstr = remote_ssh_res['stdout']
+        # the rackhd_gather_info.py script returns the package name in the output
+        for row in pstr.split('\n'):
+            if 'Package:' in row:
+                pkgfile = row.split(': ')[1]
+    return pkgfile
+
+
+def scp_tgz_to_logserver(testhost, pkginfo, logdir, args):
+    '''
+    Using pexpect, this function will scp the tarfile specified in pkginfo from the
+    testhost stack to the log directory.  The pkginfo contains the full path on the stack.
+    :param testhost: ip address of rackhd server
+    :param pkginfo: string returned from gather script
+    :param logdir: full local path to bug directory
+    :param args: command line arguments
+    :return:
+        True if scpcommanddoes not return an error
+        False if an error in the scpcommandfailed
+    '''
+    status = False
+
+    command = "scp " + args.port2 + " " + args.user + "@" + testhost + ":" + pkginfo + " " + logdir
+    child = pexpect.spawn(command)
+    child.timeout = 60
+    i = child.expect(['assword: ', pexpect.TIMEOUT])
+    if i == 0:
+        child.sendline(args.pwd)
+        # wait for scp to copy file
+        time.sleep(10)
+        status = True
+    else:
+        print child.before
+        print "ERROR: Expecting password for SCP timed out."
+        print "SCP of log files failed due to password error."
+        print "Please manually scp " + pkginfo + " to desired location."
+
+    child.close()
+    return status
+
+
+def handle_pexpect_error(child, errstr):
+    print errstr
+    print child.before, child.after
+    child.terminate()
+
+
+def remote_shell(shell_cmd, args, expect_receive="", expect_send=""):
+    '''
+    Run ssh based shellcommandon a remote machine at args.ip
+    :param shell_cmd: string based command
+    :param expect_receive:
+    :param expect_send:
+    :param args: all command line arguments
+    :return: dict = {'stdout': str:ouput, 'exitcode': return code}
+    '''
+    cmd_args = vars(args)
+
+    logfile_redirect = None
+    shell_cmd.replace("'", "\\\'")
+    if args.v is True:
+        print "remote_shell: Shell Command: ", shell_cmd
+        logfile_redirect = sys.stdout
+    if expect_receive == "" or expect_send == "":
+        (command_output, exitstatus) = \
+            pexpect.run("ssh -q -o StrictHostKeyChecking=no -t " + args.port + " " + cmd_args['user'] +
+                        "@" + cmd_args['ip'] + " sudo sh -c \\\"" + shell_cmd + "\\\"",
+                        withexitstatus=1,
+                        events={"assword": cmd_args['pwd'] + "\n"},
+                        timeout=600, logfile=logfile_redirect)
+    else:
+        (command_output, exitstatus) = \
+            pexpect.run("ssh -q -o StrictHostKeyChecking=no -t " + args.port + " " + cmd_args['user'] +
+                        "@" + cmd_args['ip'] + " sudo sh -c \\\"" + shell_cmd + "\\\"",
+                        withexitstatus=1,
+                        events={"assword": cmd_args['pwd'] + "\n",
+                                expect_receive: expect_send + "\n"},
+                        timeout=600, logfile=logfile_redirect)
+    if args.v is True:
+        print shell_cmd, "\nremote_shell: Exit Code:", exitstatus
+    return {'stdout': command_output, 'exitcode': exitstatus}
+
+
+def setup_connection(args):
+    '''
+    This function will clear the stored ssh keys and check the connection to the host specified.
+    If there is an issue connecting to the host the program will exit.
+    :param args: all command line arguments
+    '''
+    subprocess.call(["touch ~/.ssh/known_hosts;ssh-keygen -R " + args.ip +
+                     " -f ~/.ssh/known_hosts > /dev/null 2>&1"], shell=True)
+    # if ip parameter is a hostname clear key associated with the ip as well as name
+    try:
+        subprocess.call(["touch ~/.ssh/known_hosts;ssh-keygen -R " +
+                         socket.gethostbyname(args.ip) + " -f ~/.ssh/known_hosts > /dev/null 2>&1"], shell=True)
+    except:
+        pass
+    command = 'ssh -t {0} {1}@{2} "echo connected"'.format(args.port, args.user, args.ip)
+    child = pexpect.spawn(command)
+    child.timeout = 5
+    while True:
+        i = child.expect(['yes/no', 'assword:', 'Permission denied', "connected",
+                          'Could not resolve', 'no route', 'Invalid', pexpect.EOF, pexpect.TIMEOUT])
+        if i == 0:     # Continue with new ssh key
+            child.sendline('yes')
+        elif i == 1:   # Asking for password
+            child.sendline(args.pwd)
+        elif i == 3:   # Connected to the host
+            break
+        else:
+            print "ERROR: Unable to access host exiting..."
+            exit(-1)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/tools/save-logs/save_logs_conf.json.template
+++ b/test/tools/save-logs/save_logs_conf.json.template
@@ -1,0 +1,7 @@
+{
+	"ip": "1.2.3.4",
+	"username": "abc",
+	"password": "abc",
+	"webserver": "https://web.hwimo.lab.emc.com/qa/log/bug_logs/",
+	"log_directory_path": "/mnt/cilogserver/bug_logs/"
+}


### PR DESCRIPTION
This utility will grab log files and status information from a rackhd server. 
The data is returned in the form of a gzipped tarball and can be extracted to a specified directory path and target directory.
We can add commands to run against the server and specify files to grab into the rackhd_gather_info.py script as we find more things we want.
This has been tested against rackhd servers installed via vagrant and installed on physical stacks source/package install.
To run against vagrant, I use:   python save_logs.py -ip 127.0.0.1 -user vagrant -pwd vagrant -port 2222 -target_dir mylog1
@johren @larry-dean @jimturnquist @panpan0000 @PengTian0 @gpaulos 