### PR TITLE
RAC-4793 connect fit deployed amqp ports into amqp stream monitor

### DIFF
--- a/test/common/fit_common.py
+++ b/test/common/fit_common.py
@@ -1088,7 +1088,12 @@ def run_nose(nosepath=None):
 
     exitcode = 0
     # set nose options
-    noseopts = ['--exe', '--with-nosedep', '--with-stream-monitor']
+    noseopts = ['--exe', '--with-nosedep', '--with-stream-monitor',
+                '--sm-amqp-url', 'generate:{}'.format(fitports()['amqp_ssl']),
+                '--sm-dut-ssh-user', fitcreds()['rackhd_host'][0]['username'],
+                '--sm-dut-ssh-password', fitcreds()['rackhd_host'][0]['password'],
+                '--sm-dut-ssh-port', str(fitports()['ssh']),
+                '--sm-dut-ssh-host', fitargs()['rackhd_host']]
     if fitargs()['group'] != 'all' and fitargs()['group'] != '':
         noseopts.append('-a')
         noseopts.append(str(fitargs()['group']))

--- a/test/stream-monitor/requirements.txt
+++ b/test/stream-monitor/requirements.txt
@@ -3,3 +3,4 @@ greenlet==0.4.10
 nose==1.3.7
 docker-py==1.10.6
 kombu==4.0.2
+pexpect==3.3

--- a/test/stream-monitor/sm_plugin/stream_monitor.py
+++ b/test/stream-monitor/sm_plugin/stream_monitor.py
@@ -4,7 +4,7 @@ Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 import logging
 import os
 from nose.plugins import Plugin
-from stream_sources import LoggingMarker, SelfTestStreamMonitor, AMQPStreamMonitor
+from stream_sources import LoggingMarker, SelfTestStreamMonitor, AMQPStreamMonitor, SSHHelper
 import sys
 from nose.pyversion import format_exception
 from nose.plugins.xunit import Tee
@@ -60,6 +60,7 @@ class StreamMonitorPlugin(Plugin):
         self.__log = logging.getLogger('nose.plugins.streammonitor')
         self.__flogger_opts_helper = LoggerArgParseHelper(parser)
         AMQPStreamMonitor.add_nose_parser_opts(parser)
+        SSHHelper.add_nose_parser_opts(parser)
         super(StreamMonitorPlugin, self).options(parser, env=env)
 
     def configure(self, options, conf):
@@ -73,6 +74,7 @@ class StreamMonitorPlugin(Plugin):
 
     def finalize(self, result):
         self.__take_step('finalize', result=result)
+        self.__call_all_plugin_by_attr('handle_finalize')
         self.__log.info('Stream Monitor Report Complete')
 
     def __call_all_plugin_by_attr(self, attr_name, *args, **kwargs):
@@ -84,6 +86,7 @@ class StreamMonitorPlugin(Plugin):
     def begin(self):
         self.__take_step('begin')
         # tood: check class "enabled_for_nose()"
+        SSHHelper.set_options(self.conf.options)
         if len(self.__stream_plugins) == 0:
             self.__stream_plugins['logging'] = LoggingMarker()
             self.__stream_plugins['self-test'] = SelfTestStreamMonitor()

--- a/test/stream-monitor/stream_sources/__init__.py
+++ b/test/stream-monitor/stream_sources/__init__.py
@@ -4,5 +4,6 @@ Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 from log_type import LoggingMarker
 from self_test_source import SelfTestStreamMonitor
 from amqp_source import AMQPStreamMonitor
+from ssh_helper import SSHHelper
 
-__all__ = [LoggingMarker, SelfTestStreamMonitor, AMQPStreamMonitor]
+__all__ = [LoggingMarker, SelfTestStreamMonitor, AMQPStreamMonitor, SSHHelper]

--- a/test/stream-monitor/stream_sources/ssh_helper.py
+++ b/test/stream-monitor/stream_sources/ssh_helper.py
@@ -1,0 +1,125 @@
+"""
+Copyright (c) 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+"""
+import optparse
+import re
+from pexpect.pxssh import pxssh
+
+
+class StreamToLogger(object):
+    def __init__(self, logger, prefix):
+        """
+        This is a fake stream-ish device to allow us to turn raw
+        stream data into logger calls to the passed in logger.
+
+        Buffers output to new-line boundaries (to allow catching:
+        "running test foo ... ok" as one entry.
+        """
+        self.__use_logger = logger
+        self.__prefix = prefix
+        self.__buffer = ''
+
+    def write(self, data):
+        self.__buffer += data
+        while '\n' in self.__buffer:
+            line, rest = self.__buffer.split('\n', 1)
+            line = line.replace('\r', '')
+            self.__use_logger.debug('%s%s', self.__prefix, line)
+            self.__buffer = rest
+
+    def flush(self):
+        """
+        We don't actually want to flush, since we could be mid-line
+        """
+        pass
+
+    def real_flush(self):
+        if len(self.__buffer) > 0:
+            self.__use_logger.debug('%s%s', self.__prefix, self.__buffer)
+            self.__buffer = ''
+
+
+class SSHHelper(pxssh):
+    _parser_options = None
+
+    def __init__(self, device='dut', why='ssh:', *args, **kwargs):
+        # differed import of flogging since we are inside the plugin
+        # structure:
+        from flogging import get_loggers
+        self.__logs = get_loggers()
+        self.__stream_to_log = None
+        if 'logfile' not in kwargs:
+            stream_to_log = StreamToLogger(self.__logs.idl, why)
+            kwargs['logfile'] = stream_to_log
+            self.__stream_to_log = stream_to_log
+
+        super(SSHHelper, self).__init__(*args, **kwargs)
+        assert device == 'dut', \
+            'multiple targets not supported yet'
+        assert self._parser_options is not None, \
+            'attempt to create ssh helper before nose-plugin-begin step called'
+        host = self._parser_options.sm_dut_ssh_host
+        port = self._parser_options.sm_dut_ssh_port
+        user = self._parser_options.sm_dut_ssh_user
+        password = self._parser_options.sm_dut_ssh_password
+        self.login(host, user, password, port=port)
+        self.sendline('sudo su -')
+        index = self.expect(['assword', '#'])
+        if index == 0:
+            self.sendline(password)
+            self.expect(['#'])
+        self.set_unique_prompt()
+        self.dut_ssh_host = host
+        self.dut_ssh_port = port
+
+    def logout(self):
+        self.sendline('exit')
+        super(SSHHelper, self).logout()
+        if self.__stream_to_log is not None:
+            self.__stream_to_log.real_flush()
+
+    def sendline_and_stat(self, cmd, must_be_0=False):
+        self.sendline(cmd)
+        self.prompt()
+        cmd_out = self.before
+        self.__logs.idl.debug("Going to execute remote command '%s'", cmd)
+        self.sendline('echo xx $? xx')
+        self.prompt()
+        echo_data = self.before
+        res_match = re.search(r'''xx\s(?P<ecode>\d+)\sxx''', echo_data)
+        assert res_match is not None, \
+            'unable to find output of just executed echo command {}'.format(echo_data)
+        ecode = int(res_match.group('ecode'))
+        if must_be_0:
+            assert ecode == 0, \
+                "failed command '{}' ecode={}, output={}".format(cmd, ecode, cmd_out)
+        return cmd, ecode, cmd_out
+
+    @classmethod
+    def add_nose_parser_opts(cls, parser):
+        """
+        If the plugin needs to go and "talk" with the dut, we will
+        need contact information. Primary use is setting up a test-AMQP
+        user, but this is also needed to implement 'tail -f xxx.log' ON
+        box at a later point.
+
+        note: needs to be extended for HA (i.e., multiple ssh targets)
+        """
+        dut_ssh_group = optparse.OptionGroup(parser, 'DUT ssh options')
+        parser.add_option_group(dut_ssh_group)
+        dut_ssh_group.add_option(
+            '--sm-dut-ssh-user', dest='sm_dut_ssh_user', default='vagrant',
+            help="User to ssh into DUT using.")
+        dut_ssh_group.add_option(
+            '--sm-dut-ssh-password', dest='sm_dut_ssh_password', default='vagrant',
+            help="Password to ssh into DUT using.")
+        dut_ssh_group.add_option(
+            '--sm-dut-ssh-port', dest='sm_dut_ssh_port', default=2222,
+            help="Port of ssh server on DUT.")
+        dut_ssh_group.add_option(
+            '--sm-dut-ssh-host', dest='sm_dut_ssh_host', default='localhost',
+            help="Hostname of DUT.")
+
+    @classmethod
+    def set_options(cls, parser_options):
+        cls._parser_options = parser_options

--- a/test/tests/framework_tsts/test_amqp_stream_monitor.py
+++ b/test/tests/framework_tsts/test_amqp_stream_monitor.py
@@ -27,6 +27,8 @@ from nose.plugins.attrib import attr
 
 # Import the logging feature
 import flogging
+
+# Get access to the stream-monitor singleton
 from sm_plugin import AMQPStreamMonitor
 
 # set up the logging


### PR DESCRIPTION
* Added ssh-helper inside plugin to be able to go on-box and add an amqp user.
* Wired handle_finalize call-all-sources and added a handler in amqp stream monitor to cause delete of amqp user
* Altered ports in install_default.json and stack_config.json get the amql_ssl port and ssh port correct for both on box (vagrant) and offbox (vagrant_remote) stack types.
* Altered nose-invoke in fit-common to add all the required ssh and amqp configure information to be passed into plugin.

Signed-off-by: Erika Hohenstein <Erika.Hohenstein@dell.com>

Note: the port names may have gotten stale, but if the PR gate passes, we can merge and rebase into the story Erika and I are on right now and fix there worse case. (i.e., no impact for anyone other than us)

@hohene @johren 