### PR TITLE
modify some cases to support local rackhd

### DIFF
--- a/test/deploy/rackhd_stack_init.py
+++ b/test/deploy/rackhd_stack_init.py
@@ -36,16 +36,28 @@ MAX_CYCLES = 60
 
 class rackhd_stack_init(unittest.TestCase):
     def test01_set_auth_user(self):
-        fit_common.remote_shell('rm auth.json')
         auth_json = open('auth.json', 'w')
         auth_json.write('{"username":"' + fit_common.fitcreds()["api"][0]["admin_user"] + '", "password":"' +
                         fit_common.fitcreds()["api"][0]["admin_pass"] + '", "role":"Administrator"}')
         auth_json.close()
-        fit_common.scp_file_to_ora('auth.json')
-        rc = fit_common.remote_shell("curl -ks -X POST -H 'Content-Type:application/json' https://localhost:" +
-                                     str(fit_common.fitports()['https']) + "/api/2.0/users -d @auth.json")
-        if rc['exitcode'] != 0:
-            log.info_5("ALERT: Auth admin user not set! Please manually set the admin user account if required.")
+        try:
+            # add first user to remote rackhd directly
+            return_code = ""
+            rackhd_hostname = fit_common.fitargs()['rackhd_host']
+            set_auth_url = "https://" + rackhd_hostname + ":" + str(fit_common.fitports()['https']) + "/api/2.0/users"
+            rc = fit_common.restful(url_command=set_auth_url, rest_action="post", rest_payload=json.load(open('auth.json')))
+            return_code = str(rc['status'])
+        except Exception as e:
+            log.info_5("ALERT: RackHD is not in localhost, will set first user through ssh{0}".format(e))
+        if return_code != '201':
+            log.info_5("ALERT: Can't set first user to RackHD https port directly, will set it through ssh")
+            # ssh login to rackhd and add first user to localhost rackhd
+            fit_common.remote_shell('rm auth.json')
+            fit_common.scp_file_to_ora('auth.json')
+            rc = fit_common.remote_shell("curl -ks -X POST -H 'Content-Type:application/json' https://localhost:" +
+                                         str(fit_common.fitports()['https']) + "/api/2.0/users -d @auth.json")
+            if rc['exitcode'] != 0:
+                log.info_5("ALERT: Auth admin user not set! Please manually set the admin user account if required.")
 
     def test02_preload_sku_packs(self):
         log.info_5("**** Downloading SKU packs from GitHub")

--- a/test/modules/auth2_0.py
+++ b/test/modules/auth2_0.py
@@ -5,6 +5,7 @@ from logger import Log
 from json import loads, dumps
 import pexpect
 import pxssh
+import subprocess
 
 LOG = Log(__name__)
 
@@ -33,21 +34,36 @@ class Auth(object):
         param = dumps({'username': 'admin', 'password': 'admin123', 'role': 'Administrator'})
         user_add_cmd = "curl -k -X POST -w '%{http_code}' -H 'Content-Type: application/json' -d '"
         user_add_cmd += param
-        user_add_cmd += "' https://127.0.0.1:" + USER_AUTH_PORT + "/api/2.0/users"
 
-        term = pxssh.pxssh()
-        term.SSH_OPTS = (term.SSH_OPTS
-                         + " -o 'StrictHostKeyChecking=no'"
-                         + " -o 'UserKnownHostsFile=/dev/null' ")
-        term.force_password = True
-        term.login(HOST_IP, SSH_USER, SSH_PASSWORD, port=SSH_PORT)
-        term.sendline(user_add_cmd)
-        index = term.expect(['201', '401', '403'], 10)
+        # add first user to remote rackhd directly
+        remote_user_add_cmd = user_add_cmd + \
+            "' https://{0}:{1}/api/2.0/users".format(HOST_IP, USER_AUTH_PORT)
+        try:
+            return_code = "unknown"
+            return_str = subprocess.check_output([remote_user_add_cmd], shell=True)
+            return_code = return_str[-3:]
+        except Exception as e:
+            LOG.info("Can't connect to RackHD https port directly, will set first user through ssh\n{0}".format(e))
+        if return_code in ['201', '401', '403']:
+            index = ['201', '401', '403'].index(return_code)
+        else:
+            # ssh login to rackhd and add first user to localhost rackhd
+            local_user_add_cmd = user_add_cmd + \
+                "' https://127.0.0.1:" + USER_AUTH_PORT + "/api/2.0/users"
+            term = pxssh.pxssh()
+            term.SSH_OPTS = (term.SSH_OPTS +
+                             " -o 'StrictHostKeyChecking=no'" +
+                             " -o 'UserKnownHostsFile=/dev/null' ")
+            term.force_password = True
+            term.login(HOST_IP, SSH_USER, SSH_PASSWORD, port=SSH_PORT)
+            term.sendline(local_user_add_cmd)
+            index = term.expect(['201', '401', '403'], 10)
+            term.logout()
+
         if index == 0:
             LOG.info('Created default user')
         if index == 1 or index == 2:
             LOG.info('Local user already created')
-        term.logout()
         return index
 
     @staticmethod

--- a/test/modules/redfish_auth.py
+++ b/test/modules/redfish_auth.py
@@ -5,6 +5,7 @@ from logger import Log
 from json import loads, dumps
 import pexpect
 import pxssh
+import subprocess
 
 LOG = Log(__name__)
 
@@ -31,21 +32,36 @@ class Auth(object):
         param = dumps({'username': 'admin', 'password': 'admin123', 'role': 'Administrator'})
         user_add_cmd = "curl -k -X POST -w '%{http_code}' -H 'Content-Type: application/json' -d '"
         user_add_cmd += param
-        user_add_cmd += "' https://127.0.0.1:" + USER_AUTH_PORT + "/api/2.0/users"
 
-        term = pxssh.pxssh()
-        term.SSH_OPTS = (term.SSH_OPTS
-                         + " -o 'StrictHostKeyChecking=no'"
-                         + " -o 'UserKnownHostsFile=/dev/null' ")
-        term.force_password = True
-        term.login(HOST_IP, SSH_USER, SSH_PASSWORD, port=SSH_PORT)
-        term.sendline(user_add_cmd)
-        index = term.expect(['201', '401', '403'], 10)
+        # add first user to remote rackhd directly
+        remote_user_add_cmd = user_add_cmd + \
+            "' https://{0}:{1}/api/2.0/users".format(HOST_IP, USER_AUTH_PORT)
+        try:
+            return_code = "unknown"
+            return_str = subprocess.check_output([remote_user_add_cmd], shell=True)
+            return_code = return_str[-3:]
+        except Exception as e:
+            LOG.info("Can't connect to RackHD https port directly, will set first user through ssh\n{0}".format(e))
+        if return_code in ['201', '401', '403']:
+            index = ['201', '401', '403'].index(return_code)
+        else:
+            # ssh login to rackhd and add first user to localhost rackhd
+            local_user_add_cmd = user_add_cmd + \
+                "' https://127.0.0.1:" + USER_AUTH_PORT + "/api/2.0/users"
+            term = pxssh.pxssh()
+            term.SSH_OPTS = (term.SSH_OPTS +
+                             " -o 'StrictHostKeyChecking=no'" +
+                             " -o 'UserKnownHostsFile=/dev/null' ")
+            term.force_password = True
+            term.login(HOST_IP, SSH_USER, SSH_PASSWORD, port=SSH_PORT)
+            term.sendline(local_user_add_cmd)
+            index = term.expect(['201', '401', '403'], 10)
+            term.logout()
+
         if index == 0:
             LOG.info('Created default user')
         if index == 1 or index == 2:
             LOG.info('Local user already created')
-        term.logout()
         return index
 
     @staticmethod

--- a/test/tests/api/redfish_1_0/event_service_tests.py
+++ b/test/tests/api/redfish_1_0/event_service_tests.py
@@ -86,19 +86,28 @@ class EventServiceTests(object):
     def test_submit_test_event(self):
         """ Testing POST /EventService/SubmitTestEvent  """
         global task
-        server = Httpd(port=int(HTTPD_PORT), handler_class=self.EventServiceHandler)
+        # Suppose rackhd and test stack have the same localhost
+        server = Httpd(port=int(self.__httpd_port), handler_class=self.EventServiceHandler)
         task = WorkerThread(server,'httpd')
         worker = WorkerTasks(tasks=[task], func=self.__httpd_start)
         worker.run()
-        
-        # forward port for services running on a guest host
-        session = open_ssh_forward(self.__httpd_port) 
-        
         redfish().test_event(body={})
         worker.wait_for_completion(timeout_sec=60)
-        session.logout()
+        if task.timeout:
+            # Else port forward rackhd -> localhost
+            server = Httpd(port=int(HTTPD_PORT), handler_class=self.EventServiceHandler)
+            task = WorkerThread(server, 'httpd')
+            worker = WorkerTasks(tasks=[task], func=self.__httpd_start)
+            worker.run()
+
+            # forward port for services running on a guest host
+            session = open_ssh_forward(self.__httpd_port)
+
+            redfish().test_event(body={})
+            worker.wait_for_completion(timeout_sec=60)
+            session.logout()
         assert_false(task.timeout, message='timeout waiting for task {0}'.format(task.id))
-   
+
     @test(groups=['redfish.subscriptions_collection'], \
           depends_on_groups=['redfish.submit_test_event'])
     def test_subscription_collection(self):


### PR DESCRIPTION
### Background
Some cases simulate the practical application scene,
it ssh login to rackhd and do something to localhost.
In pr gate, rackhd is hosted in vagrant box, so ssh login with user/password to rackhd is vaild.

However, rackhd and tests run in different machine is just one application scenario.
There may be other scenarios that rackhd and tests must run in one machine. and in this situation ssh is not necessary, user/password management will be complicated too.

### This PR
This PR modified some cases.
1st it will try to do things to rackhd directly.
if failed,
it will ssh login && do something.

@panpan0000 @PengTian0 @iceiilin 