### PR TITLE
RAC-4794-wiring-match-all-amqp-matcher-engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ example/bin/pxe*
 *.box
 packer_cache
 .bundle
+.vscode
 .DS_Store
 test/benchmark/utils/ansible/group_vars/benchmark.json
 

--- a/test/stream-monitor/flogging/infra_logging.py
+++ b/test/stream-monitor/flogging/infra_logging.py
@@ -56,7 +56,7 @@ class _GeventInfoFilter(logging.Filter):
         if cur == self._main_greenlet:
             gname = 'gl-main'
         else:
-            gname = getattr(cur, 'log_facility', str(cur))
+            gname = getattr(cur, 'greenlet_name', str(cur))
         record.greenlet = '{0!s}'.format(gname)
         record.test_name = self.__current_test_name
         record.test_case_number = self.__current_test_case_number

--- a/test/stream-monitor/sm_plugin/stream_monitor.py
+++ b/test/stream-monitor/sm_plugin/stream_monitor.py
@@ -11,7 +11,7 @@ from nose.plugins.xunit import Tee
 from nose import SkipTest
 from StringIO import StringIO
 from logging import ERROR, WARNING
-from flogging import LoggerArgParseHelper
+from flogging import LoggerArgParseHelper, get_loggers
 
 
 class StreamMonitorPlugin(Plugin):
@@ -100,6 +100,7 @@ class StreamMonitorPlugin(Plugin):
         self.__flogger_opts_helper.process_parsed(self.conf.options)
         self.__stream_plugins['amqp'].set_options(self.conf.options)
 
+        self.__call_all_plugin_by_attr('handle_set_flogging', get_loggers())
         self.__call_all_plugin_by_attr('handle_begin')
 
     def beforeTest(self, test):
@@ -114,8 +115,6 @@ class StreamMonitorPlugin(Plugin):
         self.__end_capture()
         self.__current_stdout = None
         self.__current_stderr = None
-        for pg in self.__stream_plugins.values():
-            pg.handle_after_test(test)
 
     def startTest(self, test):
         self.__take_step('startTest', test=test)

--- a/test/stream-monitor/stream_sources/amqp_od/amqp_on_demand.py
+++ b/test/stream-monitor/stream_sources/amqp_od/amqp_on_demand.py
@@ -78,6 +78,7 @@ class AMQPOnDemand(object):
         # todo: hashify or randomize port ids so more than one of these can
         #  run at once.
         host_config = self.__main_client.create_host_config(
+            dns=[],
             port_bindings={
                 4369: ('127.0.0.1',),
                 5671: ('127.0.0.1',),

--- a/test/stream-monitor/stream_sources/amqp_od/rackhd_amqp_od.py
+++ b/test/stream-monitor/stream_sources/amqp_od/rackhd_amqp_od.py
@@ -1,3 +1,4 @@
+import time
 from amqp_on_demand import AMQPOnDemand
 from kombu import Exchange, Connection, Queue
 
@@ -13,7 +14,21 @@ class RackHDAMQPOnDemand(AMQPOnDemand):
         Need to make exchanges and named queus to make this
         look like a RackHD instance amqp.
         """
-        con = Connection(hostname=self.host, port=self.ssl_port, ssl=False)
+        # A freshly spun up on-demand docker likes to say it's there, but will
+        # then reset the connection. So, catch that scenario w/ a few retries.
+        con = None
+        done_time = time.time() + 30.0
+        while con is None:
+            con = Connection(hostname=self.host, port=self.ssl_port, ssl=False)
+            try:
+                con.connect()
+            except Exception as ex:
+                if time.time() > done_time:
+                    raise ex
+                con = None
+            if con is None:
+                time.sleep(0.1)
+
         on_task = self.__assure_exchange(con, 'on.task', 'topic')
         self.__assure_named_queue(con, on_task, 'ipmi.command.sel.result')
         self.__assure_named_queue(con, on_task, 'ipmi.command.sdr.result')

--- a/test/stream-monitor/stream_sources/amqp_source.py
+++ b/test/stream-monitor/stream_sources/amqp_source.py
@@ -3,6 +3,11 @@ Copyright (c) 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 
 A set of super-simple matchers to use to self-test the matching framework.
 """
+from gevent import monkey
+monkey.patch_dns()
+monkey.patch_time()
+monkey.patch_builtins()
+monkey.patch_select()
 import sys
 import time
 import optparse
@@ -10,51 +15,62 @@ import uuid
 import gevent
 import gevent.queue
 from pexpect import EOF
+from datetime import datetime
 from .monitor_abc import StreamMonitorBaseClass
 from .stream_matchers_base import StreamMatchBase
+from .stream_matchers_results import StreamRunResults
 from .amqp_od import RackHDAMQPOnDemand
 from .ssh_helper import SSHHelper
 from kombu import Connection, Producer, Queue, Exchange, Consumer
 
 
 class _AMQPServerWrapper(object):
-    def __init__(self, amqp_url):
+    def __init__(self, amqp_url, logs):
+        self.__logs = logs
         self.__connection = Connection(amqp_url)
         self.__connection.connect()
         self.__monitors = {}
         self.__running = True
-        self.__consumer = Consumer(self.__connection, on_message=self.__on_message)
+        self.__consumer = Consumer(self.__connection)
         self.__consumer_gl = gevent.spawn(self.__consumer_greenlet_main)
+        self.__consumer_gl.greenlet_name = 'amqp-consumer-gl'  # allowing flogging to print a nice name
+        gevent.sleep(0.0)
 
     def __consumer_greenlet_main(self):
         gevent.sleep(0)
+        self.__consumer.consume()
         while self.__running:
-            self.__consumer.consume()
             try:
-                self.__connection.drain_events(timeout=0.1)
+                self.__connection.drain_events(timeout=0.5)
             except Exception as ex:     # NOQA: assigned but not used (left in for super-duper-low-level-debug)
                 # print("was woken because {}".format(ex))
                 pass
-            gevent.sleep(0)
+            gevent.sleep(0.1)  # make -sure- to yield cpu...
             # print("---loop")
 
-    def __on_message(self, msg):
+    def __on_message_cb(self, msg):
+        self.__logs.idl.debug('Inbound AMQP msg: %s', msg)
         ct = msg.delivery_info['consumer_tag']
         assert ct in self.__monitors, \
             "Message from consumer '{}', but we are not monitoring that (list={})".format(
                 msg.delivery_info['consumer_tag'], self.__monitors.keys())
         mon = self.__monitors[ct]
-        mon['event_cb'](msg, msg.body)
+        for event_cb in mon['event_cb']:
+            event_cb(msg, msg.body)
+
+    def stop_greenlet(self):
+        self.__running = False
 
     @property
     def connected(self):
         return self.__connection.connected
 
-    def create_add_monitor(self, exchange, routing_key, event_cb, queue_name=None):
+    def create_add_tracker(self, exchange, routing_key, event_cb, queue_name=None):
+        self.__logs.irl.debug("AMQPServerWrapper: create_add_trcker ex=%s, rk=%s, event_cb=%s", exchange, routing_key, event_cb)
         mname = "ex={} rk={} qn={}".format(exchange, routing_key, queue_name)
         if mname in self.__monitors:
             mon = self.__monitors[mname]
-            mon["event_cb"] = event_cb
+            mon["event_cb"].append(event_cb)
         else:
             if queue_name is None:
                 queue_name = ''
@@ -65,15 +81,18 @@ class _AMQPServerWrapper(object):
             queue = Queue(exchange=ex, routing_key=routing_key, exclusive=exclusive)
             bound_queue = queue.bind(self.__connection)
             self.__consumer.add_queue(bound_queue)
-            bound_queue.consume(mname, self.__on_message)
+            bound_queue.consume(mname, self.__on_message_cb)
             mon = {
-                "event_cb": event_cb,
+                "event_cb": [event_cb],
                 "exchange": ex
             }
             self.__monitors[mname] = mon
         return mon['exchange']
 
     def inject(self, exchange, routing_key, payload):
+        self.__logs.irl.debug("Injecting a test AMQP message: ex=%s, rk=%s, payload=%s", exchange, routing_key, payload)
+        if not isinstance(exchange, Exchange):
+            exchange = Exchange(exchange, 'topic')
         prod = Producer(self.__connection, exchange=exchange, routing_key=routing_key)
         prod.publish(payload)
 
@@ -90,7 +109,6 @@ class _AMQPServerWrapper(object):
             msg = queue.get()
             if msg is not None:
                 break
-            time.sleep(1)
         return msg
 
 
@@ -98,8 +116,8 @@ class _AMQPMatcher(StreamMatchBase):
     """
     Implementation of a StreamMatchBase matcher.
     """
-    def __init__(self, match_tbd, description, min=1, max=1):
-        self.__match_tbd = match_tbd
+    def __init__(self, route_key, description, min=1, max=sys.maxint):
+        self.__route_key = route_key
         super(_AMQPMatcher, self).__init__(description, min=min, max=max)
 
     def _match(self, other_event):
@@ -108,47 +126,165 @@ class _AMQPMatcher(StreamMatchBase):
     def dump(self, ofile=sys.stdout, indent=0):
         super(_AMQPMatcher, self).dump(ofile=ofile, indent=indent)
         ins = ' ' * indent
-        print >>ofile, "{0} match_tbd='{1}'".format(ins, self.__match_tbd)
+        print >>ofile, "{0} route_key='{1}'".format(ins, self.__route_key)
 
 
-class _AMQPQueueMonitor(StreamMonitorBaseClass):
-    def __init__(self, amqp_server, exchange, routing_key, queue_name=None):
-        super(_AMQPQueueMonitor, self).__init__()
-        # let base class catch up with us statewise (we get created from
-        # inside the entire amqp-stream-monitor after begin). We do this here
-        # so that nothing can wander in as the queues are set up, etc.
+class _AMQPProcessor(StreamMonitorBaseClass):
+    def __init__(self, logs, tracker, start_at=None, transient=True):
+        self._logs = logs
+        super(_AMQPProcessor, self).__init__()
         self.handle_begin()
+        self.transient = transient
+        self.__tracker = tracker
+        self.__inbound_queue = gevent.queue.Queue()
+        self.__run_till = None
+        self.__tail_wait = None
+        self.__complete_on_success = False
+        tracker.add_processor(self, start_at=start_at)
+        self.__match_greenlet = gevent.spawn(self.__match_greenlet_run)
+        self.__match_greenlet.greenlet_name = 'processor-match-loop-gl'
+
+    def __match_greenlet_run(self):
+        self._logs.irl.debug('Starting to watch for my events %s', self)
+        results = StreamRunResults()
+
+        self._logs.irl.debug("cp0")
+        while self.__run_till is not None and self.__run_till > time.time():
+            tail_waiting = self.__tail_wait
+            try:
+                # timeout on peek call is needed to allow us to "notice" if our run-till
+                # or tail-time has been exceeded.
+                tracked = self.__inbound_queue.peek(timeout=0.1)
+                self._logs.idl.debug('%s peeked and got %s', self, tracked)
+            except gevent.queue.Empty:
+                tracked = None
+
+            if tracked is None:
+                if tail_waiting is not None and time.time() > tail_waiting:
+                    self._logs.irl.debug(' tail-wait timed out.')
+                    break
+                continue
+
+            res = self._match_groups.check_event(tracked)
+            if res is not None:
+                # actually remove item from queue now that we know we have a "hit"
+                self.__inbound_queue.get()
+                results.add_result(res)
+
+            if self.__complete_on_success:
+                res = self._match_groups.check_ending()
+                # currently, it's either an error (so we keep trying) or None
+                if res is None:
+                    results.add_result(res)
+                    self._logs.irl.debug('  processor is currently evaluating as a success point, so we are bailing')
+                    return results
+
+        self._logs.irl.debug('---exiting because of time---: %s -> %s', self, results)
+        res = self._match_groups.check_ending()
+        results.add_result(res)
+        self._logs.irl.debug('  final results from %s is %s', self, results)
+        return results
+
+    def start_finish(self, timeout, tail_timeout=1.0):
+        self._logs.irl.debug('start finish on %s called. timeout=%s, tail-timeout=%s', self, timeout, tail_timeout)
+        self.__complete_on_success = True
+        self.__tail_wait = time.time() + tail_timeout
+        self.__run_till = time.time() + timeout + tail_timeout
+        return self.__match_greenlet
+
+    def process_tracked_record(self, tracked_record):
+        self._logs.irl.debug('Processing-tracked-record = %s', tracked_record)
+        self.__inbound_queue.put(tracked_record)
+
+    def match_any(self, description=None, min=1, max=1):
+        if description is None:
+            description = "match-any(rk={},min=%d,max=%d".format(None, min, max)
+        m = _AMQPMatcher(route_key=None, description=description, min=min, max=max)
+        self._add_matcher(m)
+
+
+class _AMQPTrackerRecord(object):
+    def __init__(self, in_test, prior_test, msg, body):
+        self.in_test = str(in_test)
+        self.prior_test = str(prior_test)
+        self.msg = msg
+        self.body = body
+        self.timestamp = datetime.now()
+
+
+class _AMQPQueueTracker(object):
+    def __init__(self, tracker_name, logs, amqp_server, exchange_name, routing_key=None):
+        self.tracker_name = tracker_name
+        self.exchange_name = exchange_name
+        self.routing_key = routing_key
+        self._logs = logs
+        # self.handle_begin()
         self.__server = amqp_server
         self.__routing_key = routing_key
-        self.__saved_messages = gevent.queue.Queue()
+        self.__recorded_data = []
+        self.__processors = []
 
-        ex = self.__server.create_add_monitor(exchange, routing_key, self.__got_one_cb)
+        ex = self.__server.create_add_tracker(exchange_name, routing_key, self.__got_amqp_message_cb)
         self.__exchange = ex
+        self.__in_test = None
+        self.__prior_test = None
 
-    def __got_one_cb(self, msg, body):
-        self.__saved_messages.put([msg, body])
+    def handle_set_flogging(self, logs):
+        self._logs = logs
 
-    def inject_test(self):
-        payload = {'test_uuid': str(uuid.uuid4())}
-        self.__server.inject(self.__exchange, self.__routing_key, payload)
-        what_sent = {'route_key': self.__routing_key, 'payload': payload}
-        return what_sent
+    def set_test(self, test):
+        if self.__in_test is not None:
+            self.__prior_test = self.__in_test
+            if test is None:
+                saved_processors = []
+                for processor in self.__processors:
+                    if not processor.transient:
+                        saved_processors = processor
+                    else:
+                        self._logs.irl.debug('Removed processor %s', processor)
+            self.__processors = saved_processors
+        self.__in_test = test
 
-    def wait_for_one_message(self, timeout=5):
+    def __got_amqp_message_cb(self, msg, body):
+        self._logs.irl.debug('%s received msg=%s, body=%s', self, msg, body)
+        track = _AMQPTrackerRecord(self.__in_test, self.__prior_test, msg, body)
+        self.__recorded_data.append(track)
+        for processor in self.__processors:
+            processor.process_tracked_record(track)
+
+    def add_processor(self, processor, start_at):
+        valid_start_ats = [None, 'now']
+        assert start_at in valid_start_ats, \
+            "start_at of '{}' not one of current valid start_ats {}".format(start_at, valid_start_ats)
+        self.__processors.append(processor)
+        if start_at is None:
+            for tracker_record in self.__recorded_data:
+                processor.process_tracked_record(tracker_record)
+
+    def start_finish(self, timeout):
+        greenlets = []
+        for processor in self.__processors:
+            self._logs.irl.debug("%s going to start finish on %s", self, processor)
+            gl = processor.start_finish(timeout)
+            greenlets.append(gl)
+        self._logs.irl.debug("  list of greenlets to finish %s", greenlets)
+        return greenlets
+
+    def test_helper_wait_for_one_message(self, timeout=5):
         sleep_till = time.time() + timeout
-        found = False
-        tries = 0
-        while time.time() < sleep_till:
-            try:
-                tries += 1
-                msg, body = self.__saved_messages.get(block=False)
-                found = True
-            except gevent.queue.Empty:
-                pass
-            if found:
-                return msg, body
+        self._logs.irl.debug('waiting for single message, timeout=%s', timeout)
+        while len(self.__recorded_data) == 0 and time.time() < sleep_till:
             gevent.sleep(0)
-        return None, None
+        if len(self.__recorded_data) > 0:
+            return self.__recorded_data[0]
+        return None
+
+    def __str__(self):
+        ns = 'tracker(name={}, ex={}, rk={}'.format(self.tracker_name, self.exchange_name, self.routing_key)
+        return ns
+
+    def __repr__(self):
+        return str(self)
 
 
 class AMQPStreamMonitor(StreamMonitorBaseClass):
@@ -159,13 +295,17 @@ class AMQPStreamMonitor(StreamMonitorBaseClass):
     * Create an AMQP-on-demand server if asked
     * Spin up an AMQP receiver greenlet to on-demand
     """
+    def handle_set_flogging(self, logs):
+        super(AMQPStreamMonitor, self).handle_set_flogging(logs)
+        self.__trackers = {}
+        self.__call_for_all_trackers('handle_set_flogging)', logs)
+
     def handle_begin(self):
         """
         Handles plugin 'begin' event. This means spinning up
         a greenlet to monitor the AMQP server.
         """
         super(AMQPStreamMonitor, self).handle_begin()
-        self.__monitors = []
         sm_amqp_url = getattr(self.__options, 'sm_amqp_url', None)
         self.__cleanup_user = None
         self.__amqp_on_demand = False
@@ -179,7 +319,39 @@ class AMQPStreamMonitor(StreamMonitorBaseClass):
         if sm_amqp_url is None:
             self.__amqp_server = None
         else:
-            self.__amqp_server = _AMQPServerWrapper(sm_amqp_url)
+            self.__amqp_server = _AMQPServerWrapper(sm_amqp_url, self._logs)
+
+    def __call_for_all_trackers(self, method_name, *args, **kwargs):
+        self._logs.irl.debug('relaying %s(%s) to all trackers %s', method_name, args, self.__trackers)
+        for tracker in self.__trackers.values():
+            method = getattr(tracker, method_name, None)
+            if method is not None:
+                self._logs.irl.debug_4('   method %s:%s found on monitor %s. calling', method_name, method, tracker)
+                method(*args, **kwargs)
+
+    def create_tracker(self, tracker_name, exchange_name, routing_key=None):
+        assert tracker_name not in self.__trackers, \
+            'you attempted to create a tracker by the name of {}(ex={},rk={}) but it already exists {}'.format(
+                tracker_name, exchange_name, routing_key, self.__trackers[tracker_name])
+        tracker = _AMQPQueueTracker(tracker_name, self._logs, self.__amqp_server, exchange_name, routing_key=routing_key)
+        self.__trackers[tracker_name] = tracker
+        self._logs.irl.debug('created tracker {}'.format(tracker))
+        return tracker
+
+    def get_tracker_processor(self, tracker, start_at=None):
+        assert tracker.tracker_name in self.__trackers, \
+            "you tried to use tracker {}, but it isn't in the list of registered trackers {}".format(
+                tracker.name, self.__trackers.keys())
+        proc = _AMQPProcessor(self._logs, tracker, start_at=start_at)
+        return proc
+
+    def handle_start_test(self, test):
+        self.__call_for_all_trackers('set_test', test)
+        super(AMQPStreamMonitor, self).handle_start_test(test)
+
+    def handle_after_test(self, test):
+        self.__call_for_all_trackers('set_test', None)
+        super(AMQPStreamMonitor, self).handle_after_test(test)
 
     def handle_finalize(self):
         """
@@ -191,6 +363,35 @@ class AMQPStreamMonitor(StreamMonitorBaseClass):
                 self.__cleanup_user))
             assert ecode == 0 or 'no_such_user' in output, \
                 "{} failed with something other than 'no_such_user':".format(cmd_text, output)
+        if self.__amqp_server is not None:
+            self.__amqp_server.stop_greenlet()
+
+    def inject(self, exchange, routing_key, payload):
+        self.__amqp_server.inject(exchange, routing_key, payload)
+
+    def finish(self, timeout=5):
+        greenlets = []
+        self._logs.irl.debug("Entering finish for amqp-stream monitor with %d trackers", len(self.__trackers))
+        for tracker in self.__trackers.values():
+            ttgls = tracker.start_finish(timeout=timeout)
+            self._logs.irl.debug("  located %s greenlets (%s) in tracker %s", len(ttgls), tracker, ttgls)
+            greenlets.extend(ttgls)
+        self._logs.irl.debug("START wait for %d greenlets (%s)", len(greenlets), greenlets)
+        gevent.wait(greenlets)
+        reses = []
+        self._logs.irl.debug("END wait for %d greenlets (%s)", len(greenlets), greenlets)
+        for gr in greenlets:
+            assert gr.ready(), \
+                'all greenlets said they completed, but this one is not {}'.format(gr)
+            if not gr.successful():
+                raise gr.exception
+            assert gr.successful(), \
+                'a greenlet {} failed with {}.'.format(gr, gr.exception)
+            results = gr.value
+            reses.append(results)
+            self._logs.irl.debug("  added results %s for greenlet %s", results, gr)
+        self._logs.irl.debug("complete set of results for finish: %s", reses)
+        return reses
 
     def __setup_generated_amqp(self, generate_string):
         """
@@ -216,21 +417,12 @@ class AMQPStreamMonitor(StreamMonitorBaseClass):
             fixed.logout()
             return 'amqp://{}:{}@{}:{}'.format(auser, apw, fixed.dut_ssh_host, port), auser
         except EOF as ex:
-            # the PR in-queue behind with one sets up better logging in the sources.
-            # Rather than try to pull that forward, manually grab flogging and
-            # update this block in next merge.
-            from flogging import get_loggers
-            logs = get_loggers()
-            logs.irl.warning('unable to connect ot instance to setup AMQP user. AMQP monitors disabled: %s', ex)
-            logs.irl.warning('^^^^ this is -usually- caused by incorrect configuration, such as " + \
+            self._logs.irl.warning('unable to connect to instance to setup AMQP user. AMQP monitors disabled: %s', ex)
+            self._logs.irl.warning('^^^^ this is -usually- caused by incorrect configuration, such as " \
                 "the wrong host or ssh port for the given installation')
         except Exception as ex:
-            # same comment as EOF. Note, with next commit, I will drop this from warning to debug, since this is kind of
-            # normal in
-            from flogging import get_loggers
-            logs = get_loggers()
-            logs.irl.warning('unable to set up amqp user. AMQP monitors disabled: %s', ex)
-            logs.irl.warning('^^^^ if this is a deploy test, this is probably ok. If it is a real test, this is a problem.')
+            self._logs.irl.debug('unable to set up amqp user. AMQP monitors disabled: %s', ex)
+            self._logs.irl.debug('^^^^ if this is a deploy test, this is probably ok. If it is a real test, this is a problem.')
         return None, None
 
     @property
@@ -250,14 +442,6 @@ class AMQPStreamMonitor(StreamMonitorBaseClass):
 
     def test_helper_sync_recv_msg(self, queue):
         return self.__amqp_server.test_helper_sync_recv_msg(queue)
-
-    def get_queue_monitor(self, exchange, routing_key, queue_name=None):
-        assert queue_name is None, \
-            'named queues coming in another story. param is for api definition only currently'
-        monitor = _AMQPQueueMonitor(self.__amqp_server, exchange, routing_key)
-        self.__monitors.append(monitor)
-
-        return monitor
 
     @classmethod
     def enabled_for_nose(true):

--- a/test/stream-monitor/stream_sources/monitor_abc.py
+++ b/test/stream-monitor/stream_sources/monitor_abc.py
@@ -6,7 +6,9 @@ intended to provide life-cycle and common grouping methods. It works items
 derived from the classes in stream_matcher_base and stream_matchers_results to
 manage stream-based-pattern matching.
 """
-
+import gevent
+import gevent.queue
+import time
 from .stream_matchers_base import StreamGroupsRoot, StreamGroupsOrdered, StreamGroupsUnordered
 from .stream_matchers_results import StreamRunResults
 
@@ -19,10 +21,14 @@ class StreamMonitorBaseClass(object):
         times.
         """
         self.__in_test = None
-        self.__match_groups = None
+        self._match_groups = None
         self.__group_stack = None
-        self.__seen_before_test = []
-        self.__seen_during_test = []
+        self.__seen_before_test = gevent.queue.Queue()
+        self.__seen_during_test = gevent.queue.Queue()
+
+    def handle_set_flogging(self, logs):
+        self._logs = logs
+        self._logs.debug('handling pluggin progression for %s logs=%s', self, logs)
 
     def handle_begin(self):
         """
@@ -33,30 +39,40 @@ class StreamMonitorBaseClass(object):
         '__in_test' state was put in here to help me think about how to possibly
         structure things when/if phasing gets added.
         """
-        self.__match_groups = StreamGroupsRoot()
-        self.__group_stack = [self.__match_groups]
+        self._logs.debug('handle_begin pluggin progression for %s', self)
+        self._match_groups = StreamGroupsRoot()
+        self.__group_stack = [self._match_groups]
         self.__in_test = None
+
+    @property
+    def in_test(self):
+        """
+        Return a nose test case for being somewhere in this test, or None if outside
+        """
+        return self.__in_test
 
     def handle_start_test(self, test):
         """
         called at stream-monitor start-test. Pass on the start-test to the main
         group and clear the evens we have "seen".
         """
-        self.__match_groups.handle_start_test(test)
-        self.__seen_before_test = []
-        self.__seen_during_test = []
+        self._logs.debug('handle_start_test pluggin progression for %s test=%s', self, test)
+        self._match_groups.handle_start_test(test)
+        self.__seen_before_test = gevent.queue.Queue()
+        self.__seen_during_test = gevent.queue.Queue()
         self.__in_test = test
 
     def handle_stop_test(self, test):
         """
         called at stream-monitor stop-test.
         """
-        pass
+        self._logs.debug('handle_stop_test pluggin progression for %s test=%s', self, test)
 
     def handle_after_test(self, test):
         """
         called at stream-monitor after-test
         """
+        self._logs.debug('handle_after_test pluggin progression for %s test=%s', self, test)
         self.__in_test = None
 
     def _add_matcher(self, matcher):
@@ -70,10 +86,11 @@ class StreamMonitorBaseClass(object):
         """
         sub-class callable method to add an event to what we have "seen".
         """
+        self._logs.debug('adding event. in_test=%s, event_data=%s', self.__in_test, event_data)
         if self.__in_test:
-            self.__seen_during_test.append(event_data)
+            self.__seen_during_test.put(event_data)
         else:
-            self.__seen_before_test.append(event_data)
+            self.__seen_before_test.put(event_data)
 
     def push_group(self, ordered=False):
         """
@@ -103,7 +120,35 @@ class StreamMonitorBaseClass(object):
             'attempted to pop root group!'
         self.__group_stack = self.__group_stack[:-1]
 
-    def finish(self):
+    def test_helper_get_all_events(self, timeout=5, end_event=None, max_grab=None):
+        """
+        Goes and pulls all data from the event-queue and returns them.
+        """
+        rl = []
+        sleep_till = time.time() + timeout
+        ct = time.time()
+        self._logs.irl.debug('going to try and get all events. timeout=%s, sleep_till=%s, max_grab=%s',
+                             timeout, sleep_till, max_grab)
+        while ct < sleep_till:
+            try:
+                self._logs.irl.debug_3('trying. ct=%s, left=%s, grabbed=%d', ct, sleep_till - ct, len(rl))
+                event_data = self.__seen_during_test.get(block=False)
+                self._logs.irl.debug_4('  end_event=%s, event=%s', end_event, event_data)
+                if end_event is not None and end_event == event_data:
+                    self._logs.irl.debug('  exiting loop because end-event %s seen', end_event)
+                    break
+                rl.append(event_data)
+            except gevent.queue.Empty:
+                pass
+            ct = time.time()
+            gevent.sleep(0)
+            if max_grab is not None:
+                if len(rl) >= max_grab:
+                    break
+        self._logs.irl.debug('return %d: %s', len(rl), rl)
+        return rl
+
+    def finish(self, timeout=5):
         """
         Called when data injection is complete and the events should be
         checked vs the matchers. This is primarily for self-tests.
@@ -112,11 +157,15 @@ class StreamMonitorBaseClass(object):
         assert len(self.__group_stack) == 1, \
             'did not pop all pushed groups: {0}'.format(self.__group_stack)
 
-        results = StreamRunResults()
-        for event_data in self.__seen_during_test:
-            res = self.__match_groups.check_event(event_data)
-            results.add_result(res)
+        end_event = self.test_helper_send_end_event()
 
-        res = self.__match_groups.check_ending()
+        results = StreamRunResults()
+
+        events = self.test_helper_get_all_events(timeout=timeout, end_event=end_event)
+        self._logs.irl.debug('get %d (%s) events.', len(events), events)
+        for event_data in events:
+            res = self._match_groups.check_event(event_data)
+            results.add_result(res)
+        res = self._match_groups.check_ending()
         results.add_result(res)
         return results

--- a/test/stream-monitor/stream_sources/self_test_source.py
+++ b/test/stream-monitor/stream_sources/self_test_source.py
@@ -4,6 +4,9 @@ Copyright (c) 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
 A set of super-simple matchers to use to self-test the matching framework.
 """
 import sys
+import gevent
+import gevent.queue
+import uuid
 from .monitor_abc import StreamMonitorBaseClass
 from .stream_matchers_base import StreamMatchBase
 
@@ -42,8 +45,45 @@ class SelfTestStreamMonitor(StreamMonitorBaseClass):
         m = _SelfTestMatcher(match_val, description, 1, 1)
         self._add_matcher(m)
 
+    def handle_start_test(self, test):
+        """
+        called at stream-monitor start-test. We need to create a little relay
+        greenlet so that calling our "inject" method can be async from
+        processing. Basically, other monitors will be calling _add_event from
+        a greenlet and if we don't, there are some queue drains that think
+        they will block forever.
+        """
+        self.__relay_queue = gevent.queue.Queue()
+        self.__relay_greenlet = gevent.spawn(self.__relay_greenlet_main)
+        self.__relay_greenlet.greenlet_name = 'self-test-sm-relay-gl'  # allow flogging to print nice name
+
+        super(SelfTestStreamMonitor, self).handle_start_test(test)
+
+    def handle_stop_test(self, test):
+        """
+        shutdown the little relay thing
+        """
+        self.__relay_queue.put('DONE-SPECIAL-MESSAGE')
+        gevent.wait([self.__relay_greenlet])
+
+    def __relay_greenlet_main(self):
+        gevent.sleep(0)
+        while True:
+            msg = self.__relay_queue.get()
+            self._add_event(msg)
+            if msg.startswith('DONE-SPECIAL-MESSAGE'):
+                break
+
     def inject(self, text):
         """
         Allows manual injections of 'events' (in this case, simple text)
         """
-        self._add_event(text)
+        self.__relay_queue.put(text)
+
+    def test_helper_send_end_event(self):
+        """
+        Sends a very specifc event to indicate an end-of-test.
+        """
+        msg = 'DONE-SPECIAL-MESSAGE-{}'.format(str(uuid.uuid4()))
+        self.inject(msg)
+        return msg

--- a/test/stream-monitor/stream_sources/stream_matchers_results.py
+++ b/test/stream-monitor/stream_sources/stream_matchers_results.py
@@ -29,7 +29,7 @@ class StreamRunResults(object):
 
     @property
     def is_ok(self):
-        return len(self.__ok_res_list) > 0 and len(self.__error_res_list) == 0
+        return len(self.__error_res_list) == 0
 
     @property
     def ok_count(self):
@@ -80,8 +80,7 @@ class MatcherResult(object):
           an overmatch (matched 4 times, but expected between 1 and 3) is terminal, since
           the event was "consumed" in generating the overmatch. A clean miss, however, is
           not terminal, since outside of an ordered group, more matches can attempted.
-      is_ok : currently just !is_error, but groups of matchers can currently be
-          "blank" and thus be neither errors nor ok (yet). Keeping the api the same for now.
+      is_ok : currently just !is_error
     """
     def __init__(self, description, used_for, is_error, is_terminal):
         self.description = description

--- a/test/stream-monitor/test/log_stream_helper.py
+++ b/test/stream-monitor/test/log_stream_helper.py
@@ -61,6 +61,13 @@ class _TempLogfileObserver(object):
     def iter_on_line(self):
         fdata = self.__get_tail_chunk()
         for line in fdata.split('\n'):
+            # Note: we need to skip internal logging message. It might be better
+            # to hunt for the corect ones, but since there are other tests to
+            # cover formatting etc of each type, trying to track new internal logs
+            # doesn't gain us much and costs a lot.
+            if 'stream-monitor/stream_sources/' in line:
+                continue
+
             yield line
 
 
@@ -203,7 +210,7 @@ class TempLogfileChecker(object):
                 in_consume = False
             m = cre.match(line)
             test.assertIsNotNone(
-                m, "did not match '{0}' {1} of {2}".format(sob_re, found, exp_lines))
+                m, "'{0}' did not match '{1}' {2} of {3}".format(line, sob_re, found, exp_lines))
             found += 1
             if tcn is None:
                 tcn = m.group('block_number')
@@ -241,7 +248,7 @@ class TempLogfileChecker(object):
             line = line_iter.next()
             m = cre.match(line)
             test.assertIsNotNone(
-                m, "did not match '{0}' {1} of {2}".format(st_re, found, len(lg_names)))
+                m, "'{0}' did not match '{1}' {2} of {3}".format(line, st_re, found, len(lg_names)))
             found += 1
             found_tcn = m.group('tc_number')
             if tcn is None:

--- a/test/stream-monitor/test/test_amqp_matchers.py
+++ b/test/stream-monitor/test/test_amqp_matchers.py
@@ -1,0 +1,310 @@
+"""
+Copyright (c) 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+Self-test of the matcher infrastructure. This is less about individual matchers,
+and more about if the various sequences and groups work (and fail!) as expected.
+"""
+from __future__ import print_function
+import unittest
+import plugin_test_helper
+import inspect
+import uuid
+import traceback
+import re
+from sm_plugin import smp_get_stream_monitor
+
+
+class _InnerResults(object):
+    def __init__(self, results_obj, exception_str=None):
+        self.__exception_str = exception_str
+        self.results = results_obj
+
+    @property
+    def is_exception(self):
+        return isinstance(self.results, Exception)
+
+    def dump_exception(self):
+        if self.__exception_str is not None:
+            for line in self.__exception_str.split('\n'):
+                print(line)
+
+
+class TestMatcherGroups(plugin_test_helper.resolve_no_verify_helper_class()):
+    """
+    This is the test-container for the stream-monitor matchers.
+
+    This is a nose-plugin tester based test-container, which means that makeSuite is
+    called once for each "test_xxxx" method in this class and returns a list of
+    test-cases to run. Each of those is run _within_ the context of its own complete
+    nose environment (complete with the plugin(s) we are testing!) , and then the
+    "test_xxxx" method is called.
+
+    This, however, means one normally needs to make a complete class for each test case,
+    since if you don't, all the test-cases from makeSuite get called once for each
+    outer test-case. Also, errors from the makeSuite test cases are not reported
+    directly to the outer-context, which means test counts and such would be off.
+
+    To streamline this a little, makeSuite "peeks" at the outer test-name and only
+    returns a single test-case containing the inner-test-case for the exact same name.
+    It also passes the outer-test-case into the inner own so that it can set its
+    results into TestMatcherGroups.test_suite_result['test_name_xxxx'], allowing the
+    outer tests to do the work of looking at results, while the inner ones just do
+    the sequencing.
+    """
+    test_suite_results = {}
+    args = ['--sm-amqp-url', 'on-demand']
+    longMessage = True   # this turns on printing of arguments for unittest.assert*s
+
+    def __get_inner_results(self):
+        our_frame = inspect.currentframe()
+        # climb looking for the first thing starting with 'test_'. We
+        # could just pop one up, but that would make things like
+        # self.assertRaises() fail.
+        while our_frame is not None and not our_frame.f_code.co_name.startswith('test_'):
+            our_frame = our_frame.f_back
+        assert our_frame is not None, \
+            "alleged impossible situation where no 'test_' was found in stack"
+
+        # get our callers name
+        parent_name = our_frame.f_code.co_name
+
+        # now fetch results put there by the method with the same name
+        # inside a TC from makeSuite() below.
+        iresult = self.test_suite_results[parent_name]
+
+        # if it was an assertion, throw it again (allow self.Raises and such)
+        if iresult.is_exception:
+            # dump the traceback to stdout. If the exception is caught by the
+            # specific test, then it will show up nicely in capture.
+            iresult.dump_exception()
+            raise iresult.results
+        return iresult.results
+
+    def __get_prerun_results(self):
+        iresult = self.test_suite_results['test_pre_run']
+
+        # if it was an assertion, throw it again (allow self.Raises and such)
+        if iresult.is_exception:
+            # dump the traceback to stdout. If the exception is caught by the
+            # specific test, then it will show up nicely in capture.
+            iresult.dump_exception()
+            raise iresult.results
+        self.__assert_a_basic_result(iresult.results[0], True, 5, 0)
+        return iresult.results
+
+    def __assert_a_basic_result(self, run_result, ok, oks, errs):
+        if ok:
+            run_result.assert_errors(self)
+
+        self.assertEqual(run_result.is_ok, ok,
+                         'is_ok was {0} not expected {1}'.format(run_result.is_ok, ok))
+        self.assertEqual(
+            run_result.had_errors, (not ok),
+            'had_errors was {0} not expected {1}'.format(run_result.had_errors, not ok))
+        self.assertEqual(
+            run_result.ok_count, oks,
+            'ok_count was {0} not expected {1}'.format(run_result.ok_count, oks))
+        self.assertEqual(
+            run_result.error_count, errs,
+            'error_count was {0} not expected {1}'.format(run_result.error_count, errs))
+
+    def __assert_basic_results(self, ok, oks=1, errs=0):
+        iresult = self.__get_inner_results()
+        self.__assert_a_basic_result(iresult, ok, oks, errs)
+        return iresult
+
+    def __assert_basic_multi_results(self, check_map):
+        check_set = set(check_map.keys())
+        ires_dict = self.__get_inner_results()
+        ires_set = set(ires_dict.keys())
+        self.assertSetEqual(
+            check_set, ires_set,
+            'the list of monitor names {} does not match what test returned {}'.format(check_set, ires_set))
+        for check_name, cv in check_map.items():
+            self.__assert_a_basic_result(ires_dict[check_name],
+                                         cv['ok'], cv['oks'], cv['errs'])
+        return ires_dict
+
+    def __test_error_asserts(self, inner_results, fails, matchers, events, match_results):
+        """
+        Spot check of assert_errors from results:
+        * make sure an error is thrown
+        * make sure fails/matchers count is expected
+        * make sure events occured in right order
+        * make sure match-results types occured in right order
+        """
+        with self.assertRaises(AssertionError) as cm:
+            inner_results.assert_errors(self)
+
+        the_exception = cm.exception
+        tes = str(the_exception)
+        # Start by checking the failures and matchers counts were what we expected
+        count_match = 'Asynch stream matchers encountered {0} failures out of {1} matchers'.format(
+            fails, matchers)
+        self.assertRegexpMatches(tes, count_match, 'incorrect failures/matchers')
+        # Now make sure we had all the events in the right order
+        ere = re.compile(r'''Matched \d+ matchers on event:$\s+'(?P<event_txt>.*)'$''',
+                         re.MULTILINE)
+        found_events = []
+        for match in ere.finditer(tes):
+            found_events.append(match.group('event_txt'))
+        self.assertListEqual(events, found_events, 'events expected != found')
+
+        # And finally look for the 'Match result type' lines show up in the expected order
+        mrtre = re.compile('''Match result type '(?P<result_type>.*?)',''')
+        found_mrt = []
+        for match in mrtre.finditer(tes):
+            found_mrt.append(match.group('result_type'))
+        self.assertListEqual(match_results, found_mrt, 'expected match-types != found')
+
+    def test_replay_of_five(self):
+        self.__get_prerun_results()
+        check_set = {
+            'on-events-tracker1': {'ok': True, 'oks': 5, 'errs': 0},
+        }
+        self.__assert_basic_multi_results(check_set)
+
+    def test_replay_of_five_plus_one_after(self):
+        self.__get_prerun_results()
+        check_set = {
+            'on-events-tracker1': {'ok': True, 'oks': 6, 'errs': 0},
+        }
+        self.__assert_basic_multi_results(check_set)
+
+    def test_dont_replay_of_five(self):
+        check_set = {
+            'on-events-tracker1': {'ok': True, 'oks': 0, 'errs': 0},
+        }
+        self.__assert_basic_multi_results(check_set)
+
+    def test_dual_match_single(self):
+        """test two processesor pointing at the same tracker both report success"""
+        check_set = {
+            'on-events-tracker1': {'ok': True, 'oks': 6, 'errs': 0},
+            'on-events-tracker2': {'ok': True, 'oks': 1, 'errs': 0},
+        }
+        self.__assert_basic_multi_results(check_set)
+
+    def makeSuite(self):
+        class TC(unittest.TestCase):
+            """testme testme testme"""
+            def __init__(self, owner, test_method_name, *args, **kwargs):
+                self.__owner = owner
+                self.__this_method_this_time = test_method_name
+                super(TC, self).__init__(*args, **kwargs)
+
+            def shortDescription(self):
+                return self.__this_method_this_time
+
+            def __str__(self):
+                return '{0} ({1})'.format(
+                    self.__this_method_this_time,
+                    unittest.util.strclass(self.__class__))
+
+            @classmethod
+            def setUpClass(cls):
+                cls._amqp_sp = smp_get_stream_monitor('amqp')
+                cls._on_events_tracker = cls._amqp_sp.create_tracker('abc-tracker', 'on.events', 'on.events.tests')
+
+            def setUp(self):
+                """
+                Most of these tests use the self-test stream monitor, so get it now.
+                """
+                self.__amqp_sm = smp_get_stream_monitor('amqp')
+                self.__test_payloads = []
+                for inx in range(10):
+                    self.__test_payloads.append({'payload_index': inx, 'test_uuid': str(uuid.uuid4())})
+
+            def test_pre_run(self):
+                """
+                makeSuite will put this test in the list, then the name-matched one, thus allowing
+                pre-setup of the recorder mode
+                """
+                qp1 = self.__amqp_sm.get_tracker_processor(self._on_events_tracker)
+                qp1.match_any(min=5, max=10)
+                self.__amqp_sm.inject('on.events', 'on.events.tests', self.__test_payloads[0])
+                self.__amqp_sm.inject('on.events', 'on.events.tests', self.__test_payloads[1])
+                self.__amqp_sm.inject('on.events', 'on.events.tests', self.__test_payloads[2])
+                self.__amqp_sm.inject('on.events', 'on.events.tests', self.__test_payloads[3])
+                self.__amqp_sm.inject('on.events', 'on.events.tests', self.__test_payloads[4])
+                results = self.__amqp_sm.finish()
+                return results
+
+            def test_replay_of_five(self):
+                qp1 = self.__amqp_sm.get_tracker_processor(self._on_events_tracker)
+                qp1.match_any(min=5, max=10)
+                fin_list = self.__amqp_sm.finish()
+                results = {
+                    'on-events-tracker1': fin_list[0]
+                }
+                return results
+
+            def test_replay_of_five_plus_one_after(self):
+                qp1 = self.__amqp_sm.get_tracker_processor(self._on_events_tracker)
+                qp1.match_any(min=6, max=10)
+                self.__amqp_sm.inject('on.events', 'on.events.tests', self.__test_payloads[5])
+                fin_list = self.__amqp_sm.finish()
+                results = {
+                    'on-events-tracker1': fin_list[0]
+                }
+                return results
+
+            def test_dont_replay_of_five(self):
+                qp1 = self.__amqp_sm.get_tracker_processor(self._on_events_tracker, start_at='now')
+                qp1.match_any(min=0, max=0)
+                fin_list = self.__amqp_sm.finish()
+                results = {
+                    'on-events-tracker1': fin_list[0]
+                }
+                return results
+
+            def test_dual_match_single(self):
+                # create 1 processor that will consume the 5 existing items from the tracker plus a real one
+                qp1 = self.__amqp_sm.get_tracker_processor(self._on_events_tracker)
+                qp1.match_any(min=6, max=10)
+                # create a 2nd processor on the same tracker that will ONLY consume the one new item
+                qp2 = self.__amqp_sm.get_tracker_processor(self._on_events_tracker, start_at='now')
+                qp2.match_any(min=1, max=1)
+
+                self.__amqp_sm.inject('on.events', 'on.events.tests', self.__test_payloads[5])
+                fin_list = self.__amqp_sm.finish()
+                results = {
+                    'on-events-tracker1': fin_list[0],
+                    'on-events-tracker2': fin_list[1]
+                }
+                return results
+
+            def runTests(self):
+                method_set = inspect.getmembers(self, self.__check_for_usable_test)
+                ran_one = False
+                for method_name, method in method_set:
+                    if method_name == self.__this_method_this_time:
+                        self.__run_test(method_name, method)
+                        ran_one = True
+                        break
+                assert ran_one, \
+                    'Unable to find test-method matching {0}'.format(self.__this_method_this_time)
+
+            def __run_test(self, method_name, method):
+                results = None
+                exception_str = None
+                try:
+                    results = method()
+                except Exception as ex:
+                    results = ex
+                    exception_str = traceback.format_exc()
+
+                results = _InnerResults(results, exception_str)
+
+                self.__owner.test_suite_results[method_name] = results
+
+            def __check_for_usable_test(self, item):
+                if inspect.ismethod(item):
+                    # ok, it's at least a method.
+                    if item.__name__.startswith('test_'):
+                        return True
+                return False
+        return[
+            TC(self, "test_pre_run", 'runTests'),
+            TC(self, self._testMethodName, 'runTests')
+        ]

--- a/test/stream-monitor/test/test_amqp_tracker.py
+++ b/test/stream-monitor/test/test_amqp_tracker.py
@@ -31,7 +31,7 @@ class _InnerResults(object):
 
 class TestAMQPOnDemand(plugin_test_helper.resolve_no_verify_helper_class()):
     """
-    This is the test-container for the stream-monitor matchers.
+    This is the test-container for the stream-monitor amqp trackers
 
     This is a nose-plugin tester based test-container, which means that makeSuite is
     called once for each "test_xxxx" method in this class and returns a list of
@@ -102,7 +102,7 @@ class TestAMQPOnDemand(plugin_test_helper.resolve_no_verify_helper_class()):
         expected = ires['expected']
         got = ires['got']
         self.assertIsNotNone(got, "message never received")
-        di = got.delivery_info
+        di = got.msg.delivery_info
         self.assertEqual(di['routing_key'], expected['route_key'])
         body = json.loads(got.body)
         self.assertEqual(body['test_uuid'], expected['payload']['test_uuid'])
@@ -151,12 +151,15 @@ class TestAMQPOnDemand(plugin_test_helper.resolve_no_verify_helper_class()):
 
             def test_send_receive_async_message(self):
                 self.__skip_no_amqp()
-                on_tasks = self.__asm.get_queue_monitor('on.events', 'on.events.tests')
-                sent_info = on_tasks.inject_test()
-                msg, body = on_tasks.wait_for_one_message()
+                on_events_tracker = self.__asm.create_tracker('on-events-tsram', 'on.events', 'on.events.tests')
+                payload = {'test_uuid': str(uuid.uuid4())}
+                self.__asm.inject('on.events', 'on.events.tests', payload)
+                what_sent = {'route_key': 'on.events.tests', 'payload': payload}
+
+                tracker_record = on_events_tracker.test_helper_wait_for_one_message(timeout=100)
                 expected = {
-                    'expected': sent_info,
-                    'got': msg
+                    'expected': what_sent,
+                    'got': tracker_record
                 }
                 return expected
 

--- a/test/tests/framework_tsts/test_amqp_stream_monitor.py
+++ b/test/tests/framework_tsts/test_amqp_stream_monitor.py
@@ -60,46 +60,48 @@ class test_amqp_stream_monitor_framework(unittest.TestCase):
 
     def test_amqp_sm_send_receive_async_message(self):
         """ Send an amqp message and check it was correctly received via greenlet """
-        on_events = self.__amqp_sm.get_queue_monitor('on.events', 'on.events.tests')
-        expected = on_events.inject_test()
-        got, body = on_events.wait_for_one_message()
-        self.assertIsNotNone(got, "message never received")
-        di = got.delivery_info
-        body = json.loads(body)
+        on_events = self.__amqp_sm.create_tracker('on-events-tsram', 'on.events', 'on.events.tests')
+        payload = {'test_uuid': str(uuid.uuid4())}
+        self.__amqp_sm.inject('on.events', 'on.events.tests', payload)
+        track_record = on_events.test_helper_wait_for_one_message()
+        self.assertIsNotNone(track_record, "message never received")
+        di = track_record.msg.delivery_info
+        body = json.loads(track_record.body)
         self.assertEqual(di['routing_key'], 'on.events.tests')
-        self.assertEqual(body['test_uuid'], expected['payload']['test_uuid'])
+        self.assertEqual(body['test_uuid'], payload['test_uuid'])
 
     def test_amqp_sm_display_async_message(self):
         """ Send, receive, and display an AMQP message """
-        on_events = self.__amqp_sm.get_queue_monitor('on.events', 'on.events.tests')
-        on_events.inject_test()
-        got, body = on_events.wait_for_one_message()
-        self.assertIsNotNone(got, "message never received")
-        di = got.delivery_info
-        body = json.loads(body)
+        on_events = self.__amqp_sm.create_tracker('on-events-tasdam', 'on.events', 'on.events.tests')
+        payload = {'test_uuid': str(uuid.uuid4())}
+        self.__amqp_sm.inject('on.events', 'on.events.tests', payload)
+        track_record = on_events.test_helper_wait_for_one_message()
+        self.assertIsNotNone(track_record, "message never received")
+        di = track_record.msg.delivery_info
+        body = json.loads(track_record.body)
         logs.data_log.info('delivery_info from message=%s', di)
         logs.data_log.info('body from message=%s', body)
 
     def test_amqp_heartbeats(self):
-        on_hb = self.__amqp_sm.get_queue_monitor('on.events', 'heartbeat.#')
-        got, body = on_hb.wait_for_one_message(20)
-        self.assertIsNotNone(got, "message never received")
-        di = got.delivery_info
-        body = json.loads(body)
+        on_hb = self.__amqp_sm.create_tracker('on-events-tah', 'on.events', 'heartbeat.#')
+        track_record = on_hb.test_helper_wait_for_one_message(20)
+        self.assertIsNotNone(track_record, "message never received")
+        di = track_record.msg.delivery_info
+        body = json.loads(track_record.body)
         logs.data_log.info('RoutingKey: %s', di['routing_key'])
         logs.data_log.info('delivery_info from message=%s', di)
         logs.data_log.info('body from message=%s', body)
 
     def test_amqp_heartbeats_events(self):
-        on_hb = self.__amqp_sm.get_queue_monitor('on.events', 'heartbeat.#')
+        on_hb = self.__amqp_sm.create_tracker('on-events-tahe', 'on.events', 'heartbeat.#')
         for x in range(6):
-            got, body = on_hb.wait_for_one_message(20)
-            self.assertIsNotNone(got, "message never received")
-            di = got.delivery_info
-            body = json.loads(body)
+            track_record = on_hb.test_helper_wait_for_one_message(20)
+            self.assertIsNotNone(track_record, "message never received")
+            di = track_record.msg.delivery_info
+            body = json.loads(track_record.body)
             logs.data_log.info('RoutingKey: %s', di['routing_key'])
             logs.data_log.info('delivery_info from message=%s', di)
-            logs.data_log.debug('body from message=%s', body)
+            logs.data_log.info('body from message=%s', body)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* pass in blank dns settings to rabbitmq docker instance (prevents timeouts if no dns available)
* added a retry loop in on-demand-amqp to allow container time to stabalize.
* changed 'log_facility' attribute as name of greenlet to 'greenlet_name' in flogging (log_facility was left over from orig code used as template)
* added mechanism ('handle_set_flogging') to allow sub-plugins to be updated with loggers
* removed 2nd call to handle_after_test on each sub-plugin. This was causing the test # to go up by two for each test.
* In log_stream_helper.py
** taught check code to ignore logs messages coming -from- the plugin infrastructure
** altered diag info in asserts to be more useful
* in monitor_abc.py:
** converted to gevent.queue.Queue for inject-to-finish transport (allows self-test stream-source to run asnych)
** added handle_set_flogging method and debug statements
* self_test_source.py
** added a relay greenlet to make async
* stream_matchers_results.py
** changed definition of "is_ok" from at least one ok and no errors to just no errors
* test_amqp_matchers.py:
** made tester-class to handle pre-setup test in makeSuite (allows the tests to check state from setUpClass in suite)
** tests for:
*** injecting and seeing 5 events on a tracker/processor pair
*** testing "re-seeing" of same 5 events in a second test (same tracker, new processor)
*** test re-seeing of prior-tracked events plus one "live" one
*** test NOT seeing 5 prior-tracked events when new processor created w/ "start-at" of "now"
*** test two side-by-side processor on single tracker.
* test_amqp_tracker.py
** renamed from test_amqp_mon.py
** adjusted to tracker-match records instead of old "hand coded" result dictionaries
* added .vscode to global .gitignore
* amqp_source.py -- main code for sourcing AMQP data into the matching engine
** re-did content of AMQPQueueMonitor to: (AMQPQueueMonitor is gone)
*** _AMQPQueueTracker that handles:
**** recording all messages to a exchange/routing-key
**** handles keeping track of processors (see below) attached to tracker
**** injects recorded messages into new processors (unless told not to by processor via 'start_at' param)
*** _AMQPProcessor that handles:
**** being a greenlet to watch for messages
**** dealing with timeouts for failure (waiting 10 seconds and never met criteria to complete matcher set)
**** dealing with tail-timeouts for success (waiting for 1 second after a message that allows the matcher set to complete)
*** Adjusted AMQPStreamMonitor to use trackers and processors
* updated "real test space" test to use new trackers.

Signed-off-by: Stuart Stanley <stuart.stanley@dell.com>

@hohene @johren @RackHD/corecommitters 