### PR TITLE
RAC-4796 first stab of actual amqp matcher

### DIFF
--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -12,6 +12,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # RackHD SERVER (Install and start RackHD server)
     config.vm.define "dev" do |target|
         target.vm.box = "bento/ubuntu-16.04"
+        if Vagrant.has_plugin?("vagrant-cachier")
+          config.cache.scope = :box
+        end
+
         target.vm.provider "virtualbox" do |v|
             v.memory = 4096
             v.cpus = 4
@@ -58,6 +62,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # RackHD SERVER TEMPLATE (RackHD installer downloaded but not installed)
     config.vm.define "template", autostart: false do |target|
         target.vm.box = "bento/ubuntu-16.04"
+        if Vagrant.has_plugin?("vagrant-cachier")
+          config.cache.scope = :box
+        end
+
         target.vm.provider "virtualbox" do |v|
             v.memory = 4096
             v.cpus = 4

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,7 +2,7 @@ amqp==1.4.8
 ansible==1.8.4
 anyjson==0.3.3
 docker-py==1.10.6
-flake8==3.2.1
+flake8==3.3.0
 gevent==1.1.2
 greenlet==0.4.10
 jsonmerge==1.2.1

--- a/test/stream-monitor/requirements.txt
+++ b/test/stream-monitor/requirements.txt
@@ -4,3 +4,4 @@ nose==1.3.7
 docker-py==1.10.6
 kombu==4.0.2
 pexpect==3.3
+flake8==3.3.0

--- a/test/stream-monitor/stream_sources/amqp_od/rackhd_amqp_od.py
+++ b/test/stream-monitor/stream_sources/amqp_od/rackhd_amqp_od.py
@@ -38,8 +38,6 @@ class RackHDAMQPOnDemand(AMQPOnDemand):
         self.__assure_named_queue(con, on_events, 'graph.finished')
         self.__assure_named_queue(con, on_events, 'polleralert.sel.updated', '#')
 
-        self.__assure_exchange(con, 'on.heartbeat', 'topic')
-
     def __assure_exchange(self, connection, exchange_name, exchange_type):
         exchange = Exchange(exchange_name, type=exchange_type)
         bound_exchange = exchange(connection)

--- a/test/stream-monitor/stream_sources/ssh_helper.py
+++ b/test/stream-monitor/stream_sources/ssh_helper.py
@@ -121,5 +121,9 @@ class SSHHelper(pxssh):
             help="Hostname of DUT.")
 
     @classmethod
+    def get_parser_options_sm_dut_ssh_host(cls):
+        return cls._parser_options.sm_dut_ssh_host
+
+    @classmethod
     def set_options(cls, parser_options):
         cls._parser_options = parser_options

--- a/test/stream-monitor/stream_sources/stream_matchers_base.py
+++ b/test/stream-monitor/stream_sources/stream_matchers_base.py
@@ -92,6 +92,13 @@ class _MatcherBatcher(object):
             yield is_error, is_ok
 
     @property
+    def is_empty(self):
+        """
+        True if there are no results in batch
+        """
+        return len(self.__results_seen) == 0
+
+    @property
     def has_error(self):
         """
         Returns the composite "is_error" for the entire batch. If there

--- a/test/stream-monitor/test/test_amqp_matchers.py
+++ b/test/stream-monitor/test/test_amqp_matchers.py
@@ -220,8 +220,8 @@ class TestMatcherGroups(plugin_test_helper.resolve_no_verify_helper_class()):
                 makeSuite will put this test in the list, then the name-matched one, thus allowing
                 pre-setup of the recorder mode
                 """
-                qp1 = self.__amqp_sm.get_tracker_processor(self._on_events_tracker)
-                qp1.match_any(min=5, max=10)
+                qp1 = self.__amqp_sm.get_tracker_queue_processor(self._on_events_tracker)
+                qp1.match_any_event(min=5, max=10)
                 self.__amqp_sm.inject('on.events', 'on.events.tests', self.__test_payloads[0])
                 self.__amqp_sm.inject('on.events', 'on.events.tests', self.__test_payloads[1])
                 self.__amqp_sm.inject('on.events', 'on.events.tests', self.__test_payloads[2])
@@ -231,8 +231,8 @@ class TestMatcherGroups(plugin_test_helper.resolve_no_verify_helper_class()):
                 return results
 
             def test_replay_of_five(self):
-                qp1 = self.__amqp_sm.get_tracker_processor(self._on_events_tracker)
-                qp1.match_any(min=5, max=10)
+                qp1 = self.__amqp_sm.get_tracker_queue_processor(self._on_events_tracker)
+                qp1.match_any_event(min=5, max=10)
                 fin_list = self.__amqp_sm.finish()
                 results = {
                     'on-events-tracker1': fin_list[0]
@@ -240,8 +240,8 @@ class TestMatcherGroups(plugin_test_helper.resolve_no_verify_helper_class()):
                 return results
 
             def test_replay_of_five_plus_one_after(self):
-                qp1 = self.__amqp_sm.get_tracker_processor(self._on_events_tracker)
-                qp1.match_any(min=6, max=10)
+                qp1 = self.__amqp_sm.get_tracker_queue_processor(self._on_events_tracker)
+                qp1.match_any_event(min=6, max=10)
                 self.__amqp_sm.inject('on.events', 'on.events.tests', self.__test_payloads[5])
                 fin_list = self.__amqp_sm.finish()
                 results = {
@@ -250,8 +250,8 @@ class TestMatcherGroups(plugin_test_helper.resolve_no_verify_helper_class()):
                 return results
 
             def test_dont_replay_of_five(self):
-                qp1 = self.__amqp_sm.get_tracker_processor(self._on_events_tracker, start_at='now')
-                qp1.match_any(min=0, max=0)
+                qp1 = self.__amqp_sm.get_tracker_queue_processor(self._on_events_tracker, start_at='now')
+                qp1.match_any_event(min=0, max=0)
                 fin_list = self.__amqp_sm.finish()
                 results = {
                     'on-events-tracker1': fin_list[0]
@@ -260,11 +260,11 @@ class TestMatcherGroups(plugin_test_helper.resolve_no_verify_helper_class()):
 
             def test_dual_match_single(self):
                 # create 1 processor that will consume the 5 existing items from the tracker plus a real one
-                qp1 = self.__amqp_sm.get_tracker_processor(self._on_events_tracker)
-                qp1.match_any(min=6, max=10)
+                qp1 = self.__amqp_sm.get_tracker_queue_processor(self._on_events_tracker)
+                qp1.match_any_event(min=6, max=10)
                 # create a 2nd processor on the same tracker that will ONLY consume the one new item
-                qp2 = self.__amqp_sm.get_tracker_processor(self._on_events_tracker, start_at='now')
-                qp2.match_any(min=1, max=1)
+                qp2 = self.__amqp_sm.get_tracker_queue_processor(self._on_events_tracker, start_at='now')
+                qp2.match_any_event(min=1, max=1)
 
                 self.__amqp_sm.inject('on.events', 'on.events.tests', self.__test_payloads[5])
                 fin_list = self.__amqp_sm.finish()

--- a/test/stream-monitor/test/test_amqp_tracker.py
+++ b/test/stream-monitor/test/test_amqp_tracker.py
@@ -104,7 +104,7 @@ class TestAMQPOnDemand(plugin_test_helper.resolve_no_verify_helper_class()):
         self.assertIsNotNone(got, "message never received")
         di = got.msg.delivery_info
         self.assertEqual(di['routing_key'], expected['route_key'])
-        body = json.loads(got.body)
+        body = got.body
         self.assertEqual(body['test_uuid'], expected['payload']['test_uuid'])
         print("di={}".format(di))
         print("body={}".format(body))

--- a/test/tests/amqp/test_amqp_heartbeat.py
+++ b/test/tests/amqp/test_amqp_heartbeat.py
@@ -1,92 +1,74 @@
 '''
 Copyright 2017 Dell Inc. or its subsidiaries.  All Rights Reserved.
 
-Author(s):
-Norton Luo
 This test will monitor amqp heartbeat message and validate the message format per latest notification event format
 '''
-from time import sleep
-import threading
-import pika
-import logging
 import flogging
 import fit_common
+import unittest
 from nose.plugins.attrib import attr
+from sm_plugin import smp_get_stream_monitor
 
-amqp_message_received = False
-routing_key = ""
-amqp_body = ""
 logs = flogging.get_loggers()
 
 
-class AmqpWorker(threading.Thread):
-    '''
-    This AMQP worker Class will creat another thread when initialized and runs asynchronously.
-    The externalcallback is the callback function entrance for user.
-    The callback function will be call when AMQP message is received.
-    Each test case can define its own callback and pass the function name to the AMQP class.
-    The timeout parameter specify how long the AMQP daemon will run. self.panic is called when timeout.
-    eg:
-    def callback(self, ch, method, properties, body):
-        logs.debug(" [x] %r:%r" % (method.routing_key, body))
-        logs.debug(" [x] %r:%r" % (method.routing_key, body))
+@attr(regression=False, smoke=False, amqp=True)
+class TestAMQPHeartbeat(unittest.TestCase):
+    longMessage = True
 
-    td = fit_amqp.AMQP_worker("node.added.#", callback)
-    td.setDaemon(True)
-    td.start()
-    '''
+    @classmethod
+    def setUpClass(cls):
+        # Get the stream-monitor plugin for AMQP
+        cls._amqp_sp = smp_get_stream_monitor('amqp')
+        # Create the "all events" tracker
+        cls._on_events_tracker = cls._amqp_sp.create_tracker('on-events-all', 'on.events', '#')
 
-    def __init__(self, exchange_name, topic_routing_key, external_callback, timeout=10):
-        threading.Thread.__init__(self)
-        pika_logger = logging.getLogger('pika')
-        if fit_common.VERBOSITY >= 8:
-            pika_logger.setLevel(logging.DEBUG)
-        elif fit_common.VERBOSITY >= 4:
-            pika_logger.setLevel(logging.WARNING)
-        else:
-            pika_logger.setLevel(logging.ERROR)
-        self.connection = pika.BlockingConnection(
-            pika.ConnectionParameters(
-                host=fit_common.fitargs()["rackhd_host"], port=fit_common.fitports()['amqp']))
-        self.channel = self.connection.channel()
-        self.channel.basic_qos(prefetch_count=1)
-        result = self.channel.queue_declare(exclusive=True)
-        queue_name = result.method.queue
-        self.channel.queue_bind(exchange=exchange_name, queue=queue_name, routing_key=topic_routing_key)
-        self.channel.basic_consume(external_callback, queue=queue_name)
-        self.connection.add_timeout(timeout, self.panic)
+    def setUp(self):
+        # attach a processor to the on-events-tracker amqp tracker. Then we can
+        # attach indiviual match-clauses to this in each test-case.
+        self.__proc = self._amqp_sp.get_tracker_queue_processor(self._on_events_tracker)
 
-    def panic(self):
-        self.channel.stop_consuming()
-        logs.debug_7('Pika connection timeout')
-        self.connection.close()
-        exit(0)
+    def __common_on_x_heartbeat(self, service_name):
+        rk = 'heartbeat.updated.information.#.{}'.format(service_name)
+        self.__proc.match_on_routekey(routing_key=rk, max=3)
+        results = self._amqp_sp.finish(timeout=20)
+        results[0].assert_errors(self)
+        first_event = self.__proc.get_raw_tracker_events()[0]
+        expected_payload = {
+            "type": "heartbeat",
+            "action": "updated",
+            "nodeId": 'null',
+            "severity": "information",
+            "version": "1.0"
+        }
+        self.__compare_heartbeat_message(first_event.body, expected_payload)
 
-    def run(self):
-        logs.debug_7('start consuming')
-        self.channel.start_consuming()
+    def test_for_on_tftp_heartbeat(self):
+        self.__common_on_x_heartbeat('on-tftp')
 
+    def test_for_on_http_heartbeat(self):
+        self.__common_on_x_heartbeat('on-http')
 
-@attr(all=True, regression=False, smoke=False)
-class amqp_heartbeat(fit_common.unittest.TestCase):
-    # clear the test environment
+    def test_for_on_task_graph_heartbeat(self):
+        self.__common_on_x_heartbeat('on-taskgraph')
 
-    def _compare_heartbeat_message(self, expected_key, expected_payload):
-        global routing_key, amqp_body
-        assert expected_key in routing_key, (expected_key, routing_key)
-        try:
-            amqp_body_json = fit_common.json.loads(amqp_body)
-        except:
-            logs.error("FAILURE - The message body is not json format!")
-            return False
+    def test_for_on_syslog_heartbeat(self):
+        self.__common_on_x_heartbeat('on-syslog')
+
+    def test_for_on_dhcp_proxy_heartbeat(self):
+        self.__common_on_x_heartbeat('on-dhcp-proxy')
+
+    def __compare_heartbeat_message(self, amqp_body_json, expected_payload):
         try:
             self.assertEquals(
                 amqp_body_json['version'], expected_payload['version'],
                 "version field not correct! expect {0}, get {1}"
                 .format(expected_payload['version'], amqp_body_json['version']))
 
-            typeId_fields = amqp_body_json['typeId'].split('.')
-            self.assertEquals(len(typeId_fields), 2, "The typeId of heartbeat should consists of <fqdn>.<service_name>")
+            typeId_fields = amqp_body_json['typeId'].rsplit('.', 1)
+            self.assertEquals(
+                len(typeId_fields), 2,
+                "The typeId '{}' of heartbeat should consists of <fqdn>.<service_name>".format(amqp_body_json['typeId']))
             service_name = typeId_fields[-1]
             self.assertIn(
                 service_name, ['on-tftp', 'on-http', 'on-dhcp-proxy', 'on-taskgraph', 'on-syslog'],
@@ -99,49 +81,8 @@ class amqp_heartbeat(fit_common.unittest.TestCase):
                 "serverity field not correct!" .format(expected_payload['severity'], amqp_body_json['severity']))
             self.assertNotEquals(amqp_body_json['createdAt'], {}, "createdAt field is empty!")
             self.assertNotEquals(amqp_body_json['data'], {}, "data field is empty!")
-        except ValueError:
-            logs.error("FAILURE - expected key is missing in the AMQP message!")
-            return False
-        return True
-
-    def amqp_callback(self, ch, method, properties, body):
-        logs.debug_3("Routing Key %r:" % method.routing_key)
-        logs.debug_3(body.__str__())
-        global amqp_message_received
-        global routing_key, amqp_body
-        amqp_message_received = True
-        amqp_body = body
-        routing_key = method.routing_key
-
-    def test_amqp_hearbeat_message(self):
-        # start amqp thread
-        global amqp_message_received
-        amqp_message_received = False
-        logs.debug('launch AMQP thread')
-
-        td = AmqpWorker(
-            exchange_name="on.events", topic_routing_key="heartbeat.updated.information.#",
-            external_callback=self.amqp_callback, timeout=10)
-        td.setDaemon(True)
-        td.start()
-        timecount = 0
-        while amqp_message_received is False and timecount < 10:
-            sleep(1)
-            timecount = timecount + 1
-            if amqp_message_received:
-                break
-            self.assertNotEquals(timecount, 10, "No AMQP message received")
-
-        expected_sub_key = "heartbeat.updated.information."
-        expected_payload = {
-            "type": "heartbeat",
-            "action": "updated",
-            "nodeId": 'null',
-            "severity": "information",
-            "version": "1.0"
-        }
-        self.assertEquals(
-            self._compare_heartbeat_message(expected_sub_key, expected_payload), True, "AMQP Message Check Error!")
+        except KeyError as ex:
+            self.fail("field '{}' missing from AMQP message".format(ex.args[0]))
 
 
 if __name__ == '__main__':

--- a/test/tests/framework_tsts/test_amqp_stream_monitor.py
+++ b/test/tests/framework_tsts/test_amqp_stream_monitor.py
@@ -66,7 +66,7 @@ class test_amqp_stream_monitor_framework(unittest.TestCase):
         track_record = on_events.test_helper_wait_for_one_message()
         self.assertIsNotNone(track_record, "message never received")
         di = track_record.msg.delivery_info
-        body = json.loads(track_record.body)
+        body = track_record.body
         self.assertEqual(di['routing_key'], 'on.events.tests')
         self.assertEqual(body['test_uuid'], payload['test_uuid'])
 
@@ -78,7 +78,7 @@ class test_amqp_stream_monitor_framework(unittest.TestCase):
         track_record = on_events.test_helper_wait_for_one_message()
         self.assertIsNotNone(track_record, "message never received")
         di = track_record.msg.delivery_info
-        body = json.loads(track_record.body)
+        body = track_record.body
         logs.data_log.info('delivery_info from message=%s', di)
         logs.data_log.info('body from message=%s', body)
 
@@ -87,7 +87,7 @@ class test_amqp_stream_monitor_framework(unittest.TestCase):
         track_record = on_hb.test_helper_wait_for_one_message(20)
         self.assertIsNotNone(track_record, "message never received")
         di = track_record.msg.delivery_info
-        body = json.loads(track_record.body)
+        body = track_record.body
         logs.data_log.info('RoutingKey: %s', di['routing_key'])
         logs.data_log.info('delivery_info from message=%s', di)
         logs.data_log.info('body from message=%s', body)
@@ -98,7 +98,7 @@ class test_amqp_stream_monitor_framework(unittest.TestCase):
             track_record = on_hb.test_helper_wait_for_one_message(20)
             self.assertIsNotNone(track_record, "message never received")
             di = track_record.msg.delivery_info
-            body = json.loads(track_record.body)
+            body = track_record.body
             logs.data_log.info('RoutingKey: %s', di['routing_key'])
             logs.data_log.info('delivery_info from message=%s', di)
             logs.data_log.info('body from message=%s', body)


### PR DESCRIPTION
* alterations to amqp_source.py to handle first real use-case
** have it decode body's json string
** rename get_tracker_processor to get_tracker_queue_processor (and change all references to it in test_amqp_matchers)
** rename "match_any" to match_any_event (and change all refs to it in test_amqp_matchers)
** add commandline options to allow test-writer to NOT have to wait through setting up and tearing down a test user each time: intended use time is DURING fast iterations used in test dev.
*** new option to created a user by name
*** new option to use an existing user by name
** changed failed delete of automatic test user to a warning (case in OVA install where rabbitmqctl goes -away- because of the "test")
** added route-key based match-clause to _AMQPMatcher
** fixed main match-greelnet-run logic:
*** once test declares they are finished adding matchers, start a tail-timeout (short timeout) and re-start it on each new event handled
*** when tail-timeout kicks over, check to see entire match-group would be able to end with success. If so, all done. If not, go back to waiting for an event to reset the tail-timeout again
*** OR when the longer overall timeout completes, all done.
** added HACK get_raw_tracker_events. Can be used until we get schema-based validation or at least callback based validation rather than after-the-fact every-coder-for-themselves post-processing.
** much improved logging.
* add concept of empty-result batch so amqp-source can check for if -anything- has gone by.
* change test_amqp_tracker to use decoded body instead of trying to re-decode it
* first-pass adaptation of test/tests/amqp/test_amqp_heartbeat.py
** removed all special server code, espesically the "toss in the air by one thread so the other can notice it with a global"
** created a test for each thing being tested.
** used the new tracker to allow redelivery of observed messages
** fixed incorrect use of ValueError (instead of KeyError)
* updated flake8 version in tests
* added flake8 to plugin-self-test requirements
* removed 'on.heartbeat' from amqp on demand rackhd faker.
* adapted framework test to use now decoded json
* adjusted Vagrant file to use "vagrant-cachier" if plugin is available. (DRAMATIC descrease in time to do subsequent vagrant operations)

Paired heavily with @hohene on this.
@RackHD/corecommitters @johren 