### PR TITLE
Rac 4181 apiv20 converts - nodes_tests.py, obm_settings.py, obm_tests.py

### DIFF
--- a/test/tests/api/fit-staging/v2_0/nodes_tests.py
+++ b/test/tests/api/fit-staging/v2_0/nodes_tests.py
@@ -134,7 +134,7 @@ class NodesTests(fit_common.unittest.TestCase):
                 rsp = self.__client.last_response
                 if rsp.status != 204:
                     codes.append(rsp)
-                    logs.info(' Failed to delete node {} - {}'.format(uuid, name))
+                    logs.info(' Failed to delete node %s - %s', uuid, name)
         return len(codes)
 
     # @test(groups=['nodes.api2.discovery.test'])
@@ -266,7 +266,6 @@ class NodesTests(fit_common.unittest.TestCase):
     def test_node_delete(self):
         # Testing DELETE:/api/2.0/nodes/:id
         codes = []
-        # test_names = []    todo: this  is not used
         Api().nodes_get_all()
         nodes = self.__get_data()
         test_names = [t.get('name') for t in self.__test_nodes]
@@ -326,60 +325,6 @@ class NodesTests(fit_common.unittest.TestCase):
                 resps.append(self.__get_data())
         for resp in resps:
             self.assertNotEqual(0, len(resp), msg='No Workflows found for Node')
-#        Api().nodes_get_workflow_by_id('fooey')
-
-#        try:
-#            Api().nodes_get_workflow_by_id('fooey')
-#            self.fail(mmg='did not raise exception for nodes_get_workflow_by_id with bad id')
-#        except rest.ApiException as e:
-#            self.assertEqual(404, e.status,
-#                msg='unexpected response {0}, expected 404 for bad nodeId'.format(e.status))
-
-    # @test(groups=['node_post_workflows-api2'], depends_on_groups=['node_workflows-api2'])
-#    @depends(after='test_node_workflows_get')
-#    def test_node_workflows_post(self):
-#        # Testing POST:/api/2.0/nodes/:id/workflows
-#        resps = []
-#        Api().nodes_get_all()
-#        nodes = self.__get_data()
-#        for n in nodes:
-#            if n.get('type') == 'compute':
-#                id = n.get('id')
-#                timeout = self.__post_workflow(id, 'Graph.Discovery')
-#                # todo: this has to be examined because data may have incorrect value if timeout == 0
-#                if timeout > 0:
-#                    data = self.__get_data()
-#                resps.append({'data': data, 'id': id})
-#        for resp in resps:
-#            self.assertNotEqual(0, len(resp['data']),
-#                                msg='No Workflows found for Node {0}'.format(resp['id']))
-#        self.assertRaises(ApiException, Api().nodes_post_workflow_by_id, 'fooey', name='Graph.Discovery', body={})
-
-    # @test(groups=['node_workflows_del_active-api2'], depends_on_groups=['node_post_workflows-api2'])
-#    @depends(after='test_node_workflows_post')
-#    def test_workflows_action(self):
-#        # Testing PUT:/api/2.0/nodes/:id/workflows/action
-#        # This test posts a workflow against a compute node and then verifies
-#        # the workflow can be cancelled
-#        Api().nodes_get_all()
-#        nodes = self.__get_data()
-#        for n in nodes:
-#            if n.get('type') == 'compute':
-#                id = n.get('id')
-#                timeout = 5
-#                done = False
-#                while timeout > 0 and not done:
-#                    if 0 == self.__post_workflow(id, 'Graph.Discovery'):
-#                        self.fail('Timed out waiting for graph to start!')
-#                    try:
-#                        Api().nodes_workflow_action_by_id(id, {'command': 'cancel'})
-#                        done = True
-#                    except ApiException as e:
-#                        if e.status != 404:
-#                            raise e
-#                        timeout -= 1
-#                self.assertNotEqual(timeout, 0, msg='Failed to delete an active workflow')
-#        self.assertRaises(ApiException, Api().nodes_workflow_action_by_id, 'fooey', {'command': 'test'})
 
     # @test(groups=['node_tags_patch'], depends_on_groups=['node_workflows_del_active-api2'])
     # @depends(after='test_workflows_action')
@@ -485,6 +430,7 @@ class NodesTests(fit_common.unittest.TestCase):
         for n in nodes:
             if n.get('name') == 'test_compute_node':
                 logs.info(" Node to put obm: %s %s ", n.get('id'), n.get('name'))
+                self.__test_obm["nodeId"] = str(n.get('id'))
                 logs.debug(json.dumps(n, indent=4))
                 Api().nodes_put_obms_by_node_id(identifier=n.get('id'), body=self.__test_obm)
                 logs.info(' Creating obm: %s ', str(self.__test_obm))

--- a/test/tests/api/fit-staging/v2_0/nodes_tests.py
+++ b/test/tests/api/fit-staging/v2_0/nodes_tests.py
@@ -1,29 +1,33 @@
-from config.api2_0_config import config
-from config.amqp import *
-from modules.logger import Log
+'''
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+Author(s):
+'''
+import fit_path  # NOQA: unused import
+import json
+import fit_common
+import flogging
+
+from config.amqp import QUEUE_GRAPH_FINISH, defaults
 from modules.amqp import AMQPWorker
 from modules.worker import WorkerThread, WorkerTasks
 from on_http_api2_0 import ApiApi as Api
-from on_http_api2_0 import rest
+from on_http_api2_0.rest import ApiException
+from config.api2_0_config import config
 from datetime import datetime
-from proboscis.asserts import assert_equal
-from proboscis.asserts import assert_false
-from proboscis.asserts import assert_raises
-from proboscis.asserts import assert_not_equal
-from proboscis.asserts import assert_is_not_none
-from proboscis.asserts import assert_true
-from proboscis.asserts import fail
-from proboscis import SkipTest
-from proboscis import test
 from json import loads
 from time import sleep
+from nosedep import depends
+from nose.plugins.attrib import attr
 
-LOG = Log(__name__)
+logs = flogging.get_loggers()
 
-@test(groups=['nodes_api2.tests'])
-class NodesTests(object):
 
-    def __init__(self):
+# @test(groups=['nodes_api2.tests'])
+@attr(regression=False, smoke=True, nodes_api2_tests=True)
+class NodesTests(fit_common.unittest.TestCase):
+
+    def setUp(self):
         self.__client = config.api_client
         self.__worker = None
         self.__discovery_duration = None
@@ -31,31 +35,31 @@ class NodesTests(object):
         self.__test_nodes = [
             {
                 'identifiers': ["FF:FF:FF:01"],
-                'autoDiscover': 'false',
+                'autoDiscover': False,
                 'name': 'test_switch_node',
                 'type': 'switch'
             },
             {
                 'identifiers': ["FF:FF:FF:02"],
-                'autoDiscover': 'false',
+                'autoDiscover': False,
                 'name': 'test_mgmt_node',
                 'type': 'mgmt'
             },
             {
                 'identifiers': ["FF:FF:FF:03"],
-                'autoDiscover': 'false',
+                'autoDiscover': False,
                 'name': 'test_pdu_node',
                 'type': 'pdu'
             },
             {
                 'identifiers': ["FF:FF:FF:04"],
-                'autoDiscover': 'false',
+                'autoDiscover': False,
                 'name': 'test_enclosure_node',
                 'type': 'enclosure'
             },
             {
                 'identifiers': ["FF:FF:FF:05"],
-                'autoDiscover': 'false',
+                'autoDiscover': False,
                 'name': 'test_compute_node',
                 'type': 'compute'
             }
@@ -72,25 +76,24 @@ class NodesTests(object):
             'service': 'noop-obm-service'
         }
 
-        
     def __get_data(self):
         return loads(self.__client.last_response.data)
 
-    def __get_workflow_status(self, id, query ):
-	Api().nodes_get_workflow_by_id(identifier=id, active=query )
-	data = self.__get_data()
-	if len(data) > 0:
-	    status = data[0].get('_status')
-	    return status
-	return 'not running'
-        
+    def __get_workflow_status(self, id, query):
+        Api().nodes_get_workflow_by_id(identifier=id, active=query)
+        data = self.__get_data()
+        if len(data) > 0:
+            status = data[0].get('_status')
+            return status
+        return 'not running'
+
     def __post_workflow(self, id, graph_name):
         status = self.__get_workflow_status(id, 'true')
         if status != 'pending' and status != 'running':
             Api().nodes_post_workflow_by_id(identifier=id, name=graph_name, body={'name': graph_name})
         timeout = 20
         while status != 'pending' and status != 'running' and timeout != 0:
-            LOG.warning('Workflow status for Node {0} (status={1},timeout={2})'.format(id,status,timeout))
+            logs.warning('Workflow status for Node %s (status=%s,timeout=%s)', id, str(status), str(timeout))
             status = self.__get_workflow_status(id, 'true')
             sleep(1)
             timeout -= 1
@@ -106,33 +109,63 @@ class NodesTests(object):
                 count += 1
         return count
 
-    @test(groups=['nodes.api2.discovery.test'])
+    def create_temp_nodes(self):
+        # utility to create a set of test nodes
+        for n in self.__test_nodes:
+            logs.info(' Creating test node (name=%s)', n.get('name'))
+            Api().nodes_post(identifiers=n)
+            rsp = self.__client.last_response
+            if rsp.status != 201:
+                logs.info(' Failed to create test node')
+            # self.assertEqual(201, rsp.status, msg=rsp.reason)
+
+    def delete_temp_nodes(self):
+        # utility to delete the set of test nodes
+        codes = []
+        Api().nodes_get_all()
+        nodes = self.__get_data()
+        test_names = [t.get('name') for t in self.__test_nodes]
+        for n in nodes:
+            name = n.get('name')
+            if name in test_names:
+                uuid = n.get('id')
+                logs.info(' Deleting node %s (name=%s)', uuid, name)
+                Api().nodes_del_by_id(identifier=uuid)
+                rsp = self.__client.last_response
+                if rsp.status != 204:
+                    codes.append(rsp)
+                    logs.info(' Failed to delete node {} - {}'.format(uuid, name))
+        return len(codes)
+
+    # @test(groups=['nodes.api2.discovery.test'])
     def test_nodes_discovery(self):
-        """ API 2.0 Testing Graph.Discovery completion """
+        # API 2.0 Testing Graph.Discovery completion
         count = defaults.get('RACKHD_NODE_COUNT', '')
         if (count.isdigit() and self.check_compute_count() == int(count)) or self.check_compute_count():
-            LOG.warning('Nodes already discovered!')
+            logs.warning('Nodes already discovered!')
             return
         self.__discovery_duration = datetime.now()
-        LOG.info('Wait start time: {0}'.format(self.__discovery_duration))
-        self.__task = WorkerThread(AMQPWorker(queue=QUEUE_GRAPH_FINISH, \
+        logs.info(' Wait start time: %s', str(self.__discovery_duration))
+        self.__task = WorkerThread(AMQPWorker(queue=QUEUE_GRAPH_FINISH,
                                               callbacks=[self.handle_graph_finish]), 'discovery')
-        def start(worker,id):
+
+        def start(worker, id):
             worker.start()
+
         tasks = WorkerTasks(tasks=[self.__task], func=start)
         tasks.run()
         tasks.wait_for_completion(timeout_sec=1200)
-        assert_false(self.__task.timeout, \
-            message='timeout waiting for task {0}'.format(self.__task.id))
+        self.assertFalse(self.__task.timeout,
+                         msg=('timeout waiting for task %s', self.__task.id))
 
-    def handle_graph_finish(self,body,message):
+    def handle_graph_finish(self, body, message):
         routeId = message.delivery_info.get('routing_key').split('graph.finished.')[1]
         Api().workflows_get()
         workflows = self.__get_data()
         for w in workflows:
             injectableName = w.get('injectableName')
             if injectableName == 'Graph.SKU.Discovery':
-                graphId = w.get('context',{}).get('graphId', {})
+                graphId = w.get('context', {}).get('graphId', {})
                 if graphId == routeId:
                     message.ack()
                     status = body.get('status')
@@ -145,10 +178,10 @@ class NodesTests(object):
                             'duration': str(duration)
                         }
                         if status == 'failed':
-                            msg['active_task'] = w.get('tasks',{})
-                            LOG.error(msg, json=True)
+                            msg['active_task'] = w.get('tasks', {})
+                            logs.error(json.dumps(msg, indent=4))
                         else:
-                            LOG.info(msg, json=True)
+                            logs.info(json.dumps(msg, indent=4))
                             self.__discovered += 1
                         break
         check = self.check_compute_count()
@@ -157,45 +190,53 @@ class NodesTests(object):
             self.__task.running = False
             self.__discovered = 0
 
-    @test(groups=['test-nodes-api2'], depends_on_groups=['nodes.api2.discovery.test'])
+    # @test(groups=['test-nodes-api2'], depends_on_groups=['nodes.api2.discovery.test'])
+    @depends(after='test_nodes_discovery')
     def test_nodes(self):
-        """ Testing GET:/api/2.0/nodes """
+        # Testing GET:/api/2.0/nodes
         Api().nodes_get_all()
         nodes = self.__get_data()
-        LOG.debug(nodes,json=True)
-        assert_not_equal(0, len(nodes), message='Node list was empty!')
+        logs.debug(json.dumps(nodes, indent=4))
+        for node in nodes:
+            logs.info(" Node: %s %s %s", node.get('id'), node.get('type'), node.get('name'))
+        self.assertNotEqual(0, len(nodes), msg='Node list was empty!')
 
-    @test(groups=['test-node-id-api2'], depends_on_groups=['test-nodes-api2'])
+    # @test(groups=['test-node-id-api2'], depends_on_groups=['test-nodes-api2'])
+    @depends(after='test_nodes')
     def test_node_id(self):
-        """ Testing GET:/api/2.0/nodes/:id """
+        # Testing GET:/api/2.0/nodes/:id
         Api().nodes_get_all()
         nodes = self.__get_data()
-        LOG.debug(nodes,json=True)
+        logs.debug(json.dumps(nodes, indent=4))
         codes = []
         for n in nodes:
-            LOG.info(n,json=True)
+            logs.info(" Node: %s %s %s", n.get('id'), n.get('type'), n.get('name'))
+            logs.debug(json.dumps(n, indent=4))
             if n.get('type') == 'compute':
                 uuid = n.get('id')
                 Api().nodes_get_by_id(identifier=uuid)
                 rsp = self.__client.last_response
                 codes.append(rsp)
-        assert_not_equal(0, len(codes), message='Failed to find compute node Ids')
+        self.assertNotEqual(0, len(codes), msg='Failed to find compute node Ids')
         for c in codes:
-            assert_equal(200, c.status, message=c.reason)
-        assert_raises(rest.ApiException, Api().nodes_get_by_id, 'fooey')
+            self.assertEqual(200, c.status, msg=c.reason)
+        self.assertRaises(ApiException, Api().nodes_get_by_id, 'fooey')
 
-    @test(groups=['create-node-api2'], depends_on_groups=['test-node-id-api2'])
+    # @test(groups=['create-node-api2'], depends_on_groups=['test-node-id-api2'])
+    @depends(after='test_node_id')
     def test_node_create(self):
-        """ Testing POST:/api/2.0/nodes/ """
+        # Testing POST:/api/2.0/nodes/
+        # This test uses the fake set of nodes __test_nodes
         for n in self.__test_nodes:
-            LOG.info('Creating node (name={0})'.format(n.get('name')))
+            logs.info(' Creating node (name=%s)', n.get('name'))
             Api().nodes_post(identifiers=n)
             rsp = self.__client.last_response
-            assert_equal(201, rsp.status, message=rsp.reason)
+            self.assertEqual(201, rsp.status, msg=rsp.reason)
 
-    @test(groups=['patch-node-api2'], depends_on_groups=['test-node-id-api2'])
+    # @test(groups=['patch-node-api2'], depends_on_groups=['test-node-id-api2'])
+    @depends(after='test_node_create')
     def test_node_patch(self):
-        """ Testing PATCH:/api/2.0/nodes/:id """
+        # Testing PATCH:/api/2.0/nodes/:id
         data = {"name": 'fake_name_test'}
         Api().nodes_get_all()
         nodes = self.__get_data()
@@ -203,28 +244,29 @@ class NodesTests(object):
         for n in nodes:
             if n.get('name') == 'test_compute_node':
                 uuid = n.get('id')
-                Api().nodes_patch_by_id(identifier=uuid,body=data)
+                Api().nodes_patch_by_id(identifier=uuid, body=data)
                 rsp = self.__client.last_response
                 test_nodes = self.__get_data()
-                assert_equal(test_nodes.get('name'), 'fake_name_test', 'Oops patch failed')
+                self.assertEqual(test_nodes.get('name'), 'fake_name_test', 'Oops patch failed')
                 codes.append(rsp)
-                LOG.info('Restoring name to "test_compute_node"')
+                logs.info(' Restoring name to "test_compute_node"')
                 correct_data = {"name": 'test_compute_node'}
-                Api().nodes_patch_by_id(identifier=uuid,body=correct_data)
+                Api().nodes_patch_by_id(identifier=uuid, body=correct_data)
                 rsp = self.__client.last_response
                 restored_nodes = self.__get_data()
-                assert_equal(restored_nodes.get('name'), 'test_compute_node', 'Oops restoring failed')
+                self.assertEqual(restored_nodes.get('name'), 'test_compute_node', 'Oops restoring failed')
                 codes.append(rsp)
-        assert_not_equal(0, len(codes), message='Failed to find compute node Ids')
+        self.assertNotEqual(0, len(codes), msg='Failed to find compute node Ids')
         for c in codes:
-            assert_equal(200, c.status, message=c.reason)
-        assert_raises(rest.ApiException, Api().nodes_patch_by_id, 'fooey', data)
+            self.assertEqual(200, c.status, msg=c.reason)
+        self.assertRaises(ApiException, Api().nodes_patch_by_id, 'fooey', data)
 
-    @test(groups=['delete-node-api2'], depends_on_groups=['patch-node-api2'])
+    # @test(groups=['delete-node-api2'], depends_on_groups=['patch-node-api2'])
+    @depends(after='test_node_patch')
     def test_node_delete(self):
-        """ Testing DELETE:/api/2.0/nodes/:id """
+        # Testing DELETE:/api/2.0/nodes/:id
         codes = []
-        test_names = []
+        # test_names = []    todo: this  is not used
         Api().nodes_get_all()
         nodes = self.__get_data()
         test_names = [t.get('name') for t in self.__test_nodes]
@@ -232,18 +274,19 @@ class NodesTests(object):
             name = n.get('name')
             if name in test_names:
                 uuid = n.get('id')
-                LOG.info('Deleting node {0} (name={1})'.format(uuid, name))
+                logs.info(' Deleting node %s (name=%s)', uuid, name)
                 Api().nodes_del_by_id(identifier=uuid)
                 codes.append(self.__client.last_response)
 
-        assert_not_equal(0, len(codes), message='Delete node list empty!')
+        self.assertNotEqual(0, len(codes), msg='Delete node list empty, should contain test nodes!')
         for c in codes:
-            assert_equal(204, c.status, message=c.reason)
-        assert_raises(rest.ApiException, Api().nodes_del_by_id, 'fooey')
+            self.assertEqual(204, c.status, msg=c.reason)
+        self.assertRaises(ApiException, Api().nodes_del_by_id, 'fooey')
 
-    @test(groups=['catalog_nodes-api2'], depends_on_groups=['delete-node-api2'])
+    # @test(groups=['catalog_nodes-api2'], depends_on_groups=['delete-node-api2'])
+    @depends(after='test_node_delete')
     def test_node_catalogs(self):
-        """ Testing GET:/api/2.0/nodes/:id/catalogs """
+        # Testing GET:/api/2.0/nodes/:id/catalogs
         resps = []
         Api().nodes_get_all()
         nodes = self.__get_data()
@@ -252,12 +295,13 @@ class NodesTests(object):
                 Api().nodes_get_catalog_by_id(identifier=n.get('id'))
                 resps.append(self.__get_data())
         for resp in resps:
-            assert_not_equal(0, len(resp), message='Node catalog is empty!')
-        assert_raises(rest.ApiException, Api().nodes_get_catalog_by_id, 'fooey')
+            self.assertNotEqual(0, len(resp), msg='Node catalog is empty!')
+        self.assertRaises(ApiException, Api().nodes_get_catalog_by_id, 'fooey')
 
-    @test(groups=['catalog_source-api2'], depends_on_groups=['catalog_nodes-api2'])
+    # @test(groups=['catalog_source-api2'], depends_on_groups=['catalog_nodes-api2'])
+    @depends(after='test_node_catalogs')
     def test_node_catalogs_bysource(self):
-        """ Testing GET:/api/2.0/nodes/:id/catalogs/source """
+        # Testing GET:/api/2.0/nodes/:id/catalogs/source
         resps = []
         Api().nodes_get_all()
         nodes = self.__get_data()
@@ -266,12 +310,13 @@ class NodesTests(object):
                 Api().nodes_get_catalog_source_by_id(identifier=n.get('id'), source='bmc')
                 resps.append(self.__client.last_response)
         for resp in resps:
-            assert_equal(200,resp.status, message=resp.reason)
-        assert_raises(rest.ApiException, Api().nodes_get_catalog_source_by_id, 'fooey','bmc')
+            self.assertEqual(200, resp.status, msg=resp.reason)
+        self.assertRaises(ApiException, Api().nodes_get_catalog_source_by_id, 'fooey', 'bmc')
 
-    @test(groups=['node_workflows-api2'], depends_on_groups=['catalog_source-api2'])
+    # @test(groups=['node_workflows-api2'], depends_on_groups=['catalog_source-api2'])
+    @depends(after='test_node_catalogs_bysource')
     def test_node_workflows_get(self):
-        """ Testing GET:/api/2.0/nodes/:id/workflows """
+        # Testing GET:/api/2.0/nodes/:id/workflows
         resps = []
         Api().nodes_get_all()
         nodes = self.__get_data()
@@ -279,36 +324,43 @@ class NodesTests(object):
             if n.get('type') == 'compute':
                 Api().nodes_get_workflow_by_id(identifier=n.get('id'))
                 resps.append(self.__get_data())
+        for resp in resps:
+            self.assertNotEqual(0, len(resp), msg='No Workflows found for Node')
 #        Api().nodes_get_workflow_by_id('fooey')
 
 #        try:
 #            Api().nodes_get_workflow_by_id('fooey')
-#            fail(message='did not raise exception for nodes_get_workflow_by_id with bad id')
+#            self.fail(mmg='did not raise exception for nodes_get_workflow_by_id with bad id')
 #        except rest.ApiException as e:
-#            assert_equal(404, e.status,
-#                message='unexpected response {0}, expected 404 for bad nodeId'.format(e.status))
+#            self.assertEqual(404, e.status,
+#                msg='unexpected response {0}, expected 404 for bad nodeId'.format(e.status))
 
-#    @test(groups=['node_post_workflows-api2'], depends_on_groups=['node_workflows-api2'])
+    # @test(groups=['node_post_workflows-api2'], depends_on_groups=['node_workflows-api2'])
+#    @depends(after='test_node_workflows_get')
 #    def test_node_workflows_post(self):
-#        """ Testing POST:/api/2.0/nodes/:id/workflows """
+#        # Testing POST:/api/2.0/nodes/:id/workflows
 #        resps = []
 #        Api().nodes_get_all()
 #        nodes = self.__get_data()
 #        for n in nodes:
 #            if n.get('type') == 'compute':
 #                id = n.get('id')
-#                timeout = self.__post_workflow(id,'Graph.Discovery')
+#                timeout = self.__post_workflow(id, 'Graph.Discovery')
+#                # todo: this has to be examined because data may have incorrect value if timeout == 0
 #                if timeout > 0:
 #                    data = self.__get_data()
-#                resps.append({'data': data, 'id':id})
+#                resps.append({'data': data, 'id': id})
 #        for resp in resps:
-#            assert_not_equal(0, len(resp['data']), 
-#                message='No Workflows found for Node {0}'.format(resp['id']))
-#        assert_raises(rest.ApiException, Api().nodes_post_workflow_by_id, 'fooey',name='Graph.Discovery',body={})
+#            self.assertNotEqual(0, len(resp['data']),
+#                                msg='No Workflows found for Node {0}'.format(resp['id']))
+#        self.assertRaises(ApiException, Api().nodes_post_workflow_by_id, 'fooey', name='Graph.Discovery', body={})
 
-#    @test(groups=['node_workflows_del_active-api2'], depends_on_groups=['node_post_workflows-api2'])
+    # @test(groups=['node_workflows_del_active-api2'], depends_on_groups=['node_post_workflows-api2'])
+#    @depends(after='test_node_workflows_post')
 #    def test_workflows_action(self):
-#        """ Testing PUT:/api/2.0/nodes/:id/workflows/action """
+#        # Testing PUT:/api/2.0/nodes/:id/workflows/action
+#        # This test posts a workflow against a compute node and then verifies
+#        # the workflow can be cancelled
 #        Api().nodes_get_all()
 #        nodes = self.__get_data()
 #        for n in nodes:
@@ -316,41 +368,44 @@ class NodesTests(object):
 #                id = n.get('id')
 #                timeout = 5
 #                done = False
-#                while timeout > 0 and done == False:
-#                    if 0 == self.__post_workflow(id,'Graph.Discovery'):
-#                        fail('Timed out waiting for graph to start!')
+#                while timeout > 0 and not done:
+#                    if 0 == self.__post_workflow(id, 'Graph.Discovery'):
+#                        self.fail('Timed out waiting for graph to start!')
 #                    try:
 #                        Api().nodes_workflow_action_by_id(id, {'command': 'cancel'})
 #                        done = True
-#                    except rest.ApiException as e:
+#                    except ApiException as e:
 #                        if e.status != 404:
 #                            raise e
 #                        timeout -= 1
-#                assert_not_equal(timeout, 0, message='Failed to delete an active workflow')
-#        assert_raises(rest.ApiException, Api().nodes_workflow_action_by_id, 'fooey', {'command': 'test'})
+#                self.assertNotEqual(timeout, 0, msg='Failed to delete an active workflow')
+#        self.assertRaises(ApiException, Api().nodes_workflow_action_by_id, 'fooey', {'command': 'test'})
 
-    @test(groups=['node_tags_patch'], depends_on_groups=['node_workflows-api2'])
+    # @test(groups=['node_tags_patch'], depends_on_groups=['node_workflows_del_active-api2'])
+    # @depends(after='test_workflows_action')
+    @depends(after='test_node_workflows_get')
     def test_node_tags_patch(self):
-        """ Testing PATCH:/api/2.0/nodes/:id/tags """
+        # Testing PATCH:/api/2.0/nodes/:id/tags
         codes = []
         Api().nodes_get_all()
         rsp = self.__client.last_response
         nodes = loads(rsp.data)
         codes.append(rsp)
         for n in nodes:
-            LOG.info(n, json=True)
+            logs.info(' node to tag %s', n.get('id'))
+            logs.debug(json.dumps(n, indent=4))
             Api().nodes_patch_tag_by_id(identifier=n.get('id'), body=self.__test_tags)
-            LOG.info('Creating tag (name={0})'.format(self.__test_tags))
+            logs.info(' Creating tag (name=%s)', self.__test_tags)
             rsp = self.__client.last_response
             codes.append(rsp)
-            LOG.info(n.get('id'));
         for c in codes:
-            assert_equal(200, c.status, message=c.reason)
-        assert_raises(rest.ApiException, Api().nodes_patch_tag_by_id, 'fooey',body=self.__test_tags)
+            self.assertEqual(200, c.status, msg=c.reason)
+        self.assertRaises(ApiException, Api().nodes_patch_tag_by_id, 'fooey', body=self.__test_tags)
 
-    @test(groups=['node_tags_get'], depends_on_groups=['node_tags_patch'])
+    # @test(groups=['node_tags_get'], depends_on_groups=['node_tags_patch'])
+    @depends(after='test_node_tags_patch')
     def test_node_tags_get(self):
-        """ Testing GET:api/2.0/nodes/:id/tags """
+        # Testing GET:api/2.0/nodes/:id/tags
         codes = []
         Api().nodes_get_all()
         rsp = self.__client.last_response
@@ -362,15 +417,17 @@ class NodesTests(object):
             tags = loads(rsp.data)
             codes.append(rsp)
             for t in self.__test_tags.get('tags'):
-                assert_true(t in tags, message= "cannot find new tag" )
+                self.assertTrue(t in tags, msg="cannot find new tag")
         for c in codes:
-            assert_equal(200, c.status, message=c.reason)
-        assert_raises(rest.ApiException, Api().nodes_patch_tag_by_id, 'fooey',body=self.__test_tags)
+            self.assertEqual(200, c.status, msg=c.reason)
+        self.assertRaises(ApiException, Api().nodes_patch_tag_by_id, 'fooey', body=self.__test_tags)
 
-
-    @test(groups=['node_tags_delete'], depends_on_groups=['node_tags_get'])
+    # @test(groups=['node_tags_delete'], depends_on_groups=['node_tags_get'])
+    @depends(after='test_node_tags_get')
     def test_node_tags_del(self):
-        """ Testing DELETE:api/2.0/nodes/:id/tags/:tagName """
+        # Testing DELETE:api/2.0/nodes/:id/tags/:tagName
+        # This workflow deletes the the tags off the nodes created by
+        # the test above test_node_tags_patch
         get_codes = []
         del_codes = []
         Api().nodes_get_all()
@@ -387,83 +444,113 @@ class NodesTests(object):
             get_codes.append(rsp)
             updated_node = loads(rsp.data)
             for t in self.__test_tags.get('tags'):
-                assert_true(t not in updated_node.get('tags'), message= "Tag " + t + " was not deleted" )
+                self.assertTrue(t not in updated_node.get('tags'), msg="Tag " + t + " was not deleted")
         for c in get_codes:
-            assert_equal(200, c.status, message=c.reason)
+            self.assertEqual(200, c.status, msg=c.reason)
         for c in del_codes:
-            assert_equal(204, c.status, message=c.reason)
-          
-        assert_raises(rest.ApiException, Api().nodes_del_tag_by_id, 'fooey',tag_name=['tag'])
+            self.assertEqual(204, c.status, msg=c.reason)
+        self.assertRaises(ApiException, Api().nodes_del_tag_by_id, 'fooey', tag_name=['tag'])
 
-
-    @test(groups=['nodes_tag_masterDelete'], depends_on_groups=['node_tags_delete'])
+    # @test(groups=['nodes_tag_masterDelete'], depends_on_groups=['node_tags_delete'])
+    @depends(after='test_node_tags_del')
     def test_node_tags_masterDel(self):
-        """ Testing DELETE:api/2.0/nodes/tags/:tagName """
+        # Testing DELETE:api/2.0/nodes/tags/:tagName
+        # negative test:  This workflow calls the test_node_tags_patch test above to
+        # get tags put back on the nodes, then verifies trying to delete an non-existing
+        # tag id doesn't cause a failure, then it deletes all the tags that were created
         codes = []
         self.test_node_tags_patch()
         t = 'tag3'
-        LOG.info("Check to make sure invalid tag is not deleted")
+        logs.info(" Check to make sure invalid tag is not deleted")
         Api().nodes_master_del_tag_by_id(tag_name=t)
         rsp = self.__client.last_response
         codes.append(rsp)
-        LOG.info("Test to check valid tags are deleted")
+        logs.info(" Test to check valid tags are deleted")
         for t in self.__test_tags.get('tags'):
             Api().nodes_master_del_tag_by_id(tag_name=t)
             rsp = self.__client.last_response
             codes.append(rsp)
         for c in codes:
-            assert_equal(204, c.status, message=c.reason)
+            self.assertEqual(204, c.status, msg=c.reason)
 
-    @test(groups=['node_put_obm_by_node_id'], depends_on_groups=['nodes_tag_masterDelete'])
+    # @test(groups=['node_put_obm_by_node_id'], depends_on_groups=['nodes_tag_masterDelete'])
+    @depends(after='test_node_tags_masterDel')
     def test_node_put_obm_by_node_id(self):
-        """Testing PUT:/api/2.0/nodes/:id/obm"""
+        # Testing PUT:/api/2.0/nodes/:id/obm
+        self.create_temp_nodes()
         Api().nodes_get_all()
         rsp = self.__client.last_response
         nodes = loads(rsp.data)
-        assert_equal(200, rsp.status, message=rsp.status)
+        self.assertEqual(200, rsp.status, msg=rsp.status)
         for n in nodes:
-            LOG.info(n, json=True)
-            Api().nodes_put_obms_by_node_id(identifier=n.get('id'), body=self.__test_obm)
-            LOG.info('Creating obm {0}'.format(self.__test_obm))
-            rsp = self.__client.last_response
-            LOG.info(n.get('id'));
-            assert_equal(201, rsp.status, message=rsp.status)
-
-    @test(groups=['node_get_obm_by_node_id'], depends_on_groups=['node_put_obm_by_node_id'])
-    def test_node_get_obm_by_node_id(self):
-        """Testing GET:/api/2.0/:id/obm"""
-        Api().nodes_get_all()
-        rsp = self.__client.last_response
-        nodes = loads(rsp.data)
-        assert_equal(200, rsp.status, message=rsp.status)
-        for n in nodes:
-            LOG.info(n, json=True)
-            Api().nodes_get_obms_by_node_id(identifier=n.get('id'))
-            LOG.info('getting OBMs for node {0}'.format(n.get('id')))
-            rsp = self.__client.last_response
-            assert_equal(200, rsp.status, message=rsp.status)
-            obms = loads(rsp.data)
-            assert_not_equal(0, len(obms), message='OBMs list was empty!')
-            for obm in obms:
-                id = obm.get('id')
-                Api().obms_delete_by_id(identifier=id)
+            if n.get('name') == 'test_compute_node':
+                logs.info(" Node to put obm: %s %s ", n.get('id'), n.get('name'))
+                logs.debug(json.dumps(n, indent=4))
+                Api().nodes_put_obms_by_node_id(identifier=n.get('id'), body=self.__test_obm)
+                logs.info(' Creating obm: %s ', str(self.__test_obm))
                 rsp = self.__client.last_response
-                assert_equal(204, rsp.status, message=rsp.status)
+                self.assertEqual(201, rsp.status, msg=rsp.status)
 
-    @test(groups=['node_put_obm_invalid'], depends_on_groups=['node_get_obm_by_node_id'])
+    # @test(groups=['node_get_obm_by_node_id'], depends_on_groups=['node_put_obm_by_node_id'])
+    @depends(after='test_node_put_obm_by_node_id')
+    def test_node_get_obm_by_node_id(self):
+        # Testing GET:/api/2.0/:id/obm
+        # FIX ME 12/21/16: This test deletes all OBM settings on the nodes
+        # If run before any other testing that relies on OBMs being set, you've messed
+        # up your test bed.  Restore the OBMS when this set is done or run against __test_nodes
+        # Or check somehow if we are only running against virtual nodes
+        Api().nodes_get_all()
+        rsp = self.__client.last_response
+        nodes = loads(rsp.data)
+        self.assertEqual(200, rsp.status, msg=rsp.status)
+        for n in nodes:
+            if n.get('name') == 'test_compute_node':
+                logs.debug(json.dumps(n, indent=4))
+                Api().nodes_get_obms_by_node_id(identifier=n.get('id'))
+                logs.info(' getting OBMs for node: %s', n.get('id'))
+                rsp = self.__client.last_response
+                self.assertEqual(200, rsp.status, msg=rsp.status)
+                obms = loads(rsp.data)
+                self.assertNotEqual(0, len(obms), msg='OBMs list was empty!')
+                for obm in obms:
+                    id = obm.get('id')
+                    Api().obms_delete_by_id(identifier=id)
+                    rsp = self.__client.last_response
+                    self.assertEqual(204, rsp.status, msg=rsp.status)
+
+    # @test(groups=['node_put_obm_invalid'], depends_on_groups=['node_get_obm_by_node_id'])
+    @depends(after='test_node_get_obm_by_node_id')
     def test_node_put_obm_invalid_node_id(self):
-        """Test that PUT:/api/2.0/:id/obm returns 404 with invalid node ID"""
-        try:
-            Api().nodes_put_obms_by_node_id(identifier='invalid_ID', body=self.__test_obm)
-            fail(message='did not raise exception')
-        except rest.ApiException as e:
-            assert_equal(404, e.status, message='unexpected response {0}, expected 404'.format(e.status))
+        # Testing that PUT:/api/2.0/:id/obm returns 404 with invalid node ID
+        Api().nodes_get_all()
+        rsp = self.__client.last_response
+        nodes = loads(rsp.data)
+        self.assertEqual(200, rsp.status, msg=rsp.status)
+        for n in nodes:
+            if n.get('name') == 'test_compute_node':
+                try:
+                    Api().nodes_put_obms_by_node_id(identifier='invalid_ID', body=self.__test_obm)
+                    self.fail(msg='did not raise exception')
+                except ApiException as e:
+                    self.assertEqual(404, e.status, msg='unexpected response {0}, expected 404'.format(e.status))
 
-    @test(groups=['node_get_obm_invalid'], depends_on_groups=['node_put_obm_invalid'])
+    # @test(groups=['node_get_obm_invalid'], depends_on_groups=['node_put_obm_invalid'])
+    @depends(after='test_node_put_obm_invalid_node_id')
     def test_node_get_obm_invalid_node_id(self):
-        """Test that PUT:/api/2.0/:id/obm returns 404 with invalid node ID"""
-        try:
-            Api().nodes_get_obms_by_node_id(identifier='invalid_ID')
-            fail(message='did not raise exception')
-        except rest.ApiException as e:
-            assert_equal(404, e.status, message='unexpected response {0}, expected 404'.format(e.status))
+        # Testing that PUT:/api/2.0/:id/obm returns 404 with invalid node ID
+        Api().nodes_get_all()
+        rsp = self.__client.last_response
+        nodes = loads(rsp.data)
+        self.assertEqual(200, rsp.status, msg=rsp.status)
+        for n in nodes:
+            if n.get('name') == 'test_compute_node':
+                try:
+                    Api().nodes_get_obms_by_node_id(identifier='invalid_ID')
+                    self.fail(msg='did not raise exception')
+                except ApiException as e:
+                    self.assertEqual(404, e.status, msg='unexpected response {0}, expected 404'.format(e.status))
+
+    @depends(after='test_node_get_obm_invalid_node_id')
+    def test_clean_up_test_nodes(self):
+        # Clean up the added test nodes
+        self.assertEqual(0, self.delete_temp_nodes(), msg="Failed to clean up test nodes from script")

--- a/test/tests/api/fit-staging/v2_0/obm_settings.py
+++ b/test/tests/api/fit-staging/v2_0/obm_settings.py
@@ -1,56 +1,67 @@
-from config.api2_0_config import *
+"""
+Copyright (c) 2016-2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+"""
+import fit_path  # NOQA: unused import
+import flogging
+
+from config.api2_0_config import config, get_bmc_cred
 from on_http_api2_0 import ApiApi as Api
-from on_http_api2_0 import rest
-from modules.logger import Log
-from json import dumps, loads
+from on_http_api2_0.rest import ApiException
+from json import loads
 
-LOG = Log(__name__)
+logs = flogging.get_loggers()
 
-"""
-Class to abstract the RackHD Out-of-Band settings 
-"""
+
 class obmSettings(object):
+    """
+    Class to abstract the RackHD Out-of-Band settings
+    """
+
     def __init__(self, *args, **kwargs):
         self.__client = config.api_client
 
     def _set_snmp(self, uid):
-        LOG.warning('_set_snmp() is currently a no-op function')
+        logs.warning('_set_snmp() is currently a no-op function')
         return True
 
     def _set_ipmi(self, uid):
         user, passwd = get_bmc_cred()
         mac = None
-        Api().nodes_get_catalog_source_by_id(uid,'bmc')
+        Api().nodes_get_catalog_source_by_id(uid, 'bmc')
         rsp = self.__client.last_response
         bmc = loads(rsp.data)
         if 'data' in bmc:
             mac = bmc['data'].get('MAC Address')
         else:
-            Api().nodes_get_catalog_source_by_id(uid,'rmm')
+            Api().nodes_get_catalog_source_by_id(uid, 'rmm')
             rsp = self.__client.last_response
             rmm = loads(rsp.data)
             if 'data' in rmm:
                 mac = bmc['data'].get('MAC Address')
         if mac is not None:
-            LOG.debug('BMC MAC {0} for {1}'.format(mac,uid))
+            logs.debug('BMC MAC {0} for {1}'.format(mac, uid))
+            logs.debug('BMC user {0} passowd {1}'.format(user, passwd))
             setting = {
                 'nodeId': uid,
-                'service':'ipmi-obm-service',
+                'service': 'ipmi-obm-service',
                 'config': {
-                    'user':user,
-                    'password':passwd,
+                    'user': user,
+                    'password': passwd,
                     'host': mac
                 }
             }
-            LOG.info('Creating ipmi obm-settings for node {0} \n {1}'.format(uid,setting))
+            logs.info('Creating ipmi obm-settings for node %s : %s', uid, setting)
             try:
                 Api().obms_put(setting)
-            except rest.ApiException as e:
-                LOG.error(e)
+                rsp = self.__client.last_response
+                logs.debug(" IPMI OBM Set response {}".format(rsp.status))
+            except ApiException as e:
+                logs.error(e)
                 return False
         else:
-            LOG.error('Error finding configurable IPMI MAC address for {0}'.format(uid))
+            logs.error('Error finding configurable IPMI MAC address for %s', uid)
             return False
+        return True
 
     def setup_nodes(self, service_type, uuid=None):
         err = []
@@ -62,18 +73,18 @@ class obmSettings(object):
             if uuid is None or uuid == uid:
                     if service_type == 'ipmi-obm-service' and node_type == 'compute':
                         if len(self.check_nodes('ipmi-obm-service', uuid=uuid)) > 0:
-                            if self._set_ipmi(uid) == False:
+                            if not self._set_ipmi(uid):
                                 err.append('Error setting IPMI OBM settings for node {0}'.format(uid))
                             else:
-                                LOG.info('Setting IPMI OBM settings successful')
-                    if service_type == 'snmp-obm-service' and node_type != 'enclosure':
+                                logs.info('Setting IPMI OBM settings successful')
+                    if service_type == 'snmp-obm-service' and node_type != 'enclosure' and node_type != 'compute':
                         if len(self.check_nodes('snmp-obm-service', uuid=uuid)) > 0:
-                            if self._set_snmp(uid) == False:
+                            if not self._set_snmp(uid):
                                 err.append('Error setting SNMP OBM settings for node {0}'.format(uid))
                             else:
-                                LOG.info('Setting SNMP OBM settings successful')
+                                logs.info('Setting SNMP OBM settings successful')
         for e in err:
-            LOG.error(e)
+            logs.error(e)
         return err
 
     def check_nodes(self, service_type, uuid=None):
@@ -84,7 +95,8 @@ class obmSettings(object):
             node_type = n.get('type')
             uid = n.get('id')
             if uuid is None or uuid == uid:
-                if node_type not in ['enclosure', 'switch', 'pdu']:
+                if node_type != 'enclosure':
+                    logs.info("Checking node: {} type {}".format(uid, node_type))
                     obm_obj = []
                     Api().obms_get()
                     all_obms = loads(self.__client.last_response.data)
@@ -92,15 +104,22 @@ class obmSettings(object):
                         node_ref = obm.get('node')
                         if node_ref == uid or node_ref.split('/')[-1] == uid:
                             obm_obj.append(obm)
-                    if (obm_obj is None) or (obm_obj is not None and len(obm_obj)== 0):
-                        LOG.warning('No OBM settings for node type {0} (id={1})'.format(node_type,uid))
-                        retval.append(False)
+                    if (obm_obj is None) or (obm_obj is not None and len(obm_obj) == 0):
+                        # need to check if the failure is real depending on the node type
+                        if service_type == 'snmp-obm-service' and node_type in ['switch', 'pdu']:
+                            logs.warning('snmp-obm-service - No OBM settings for node type %s (id=%s)', node_type, uid)
+                            retval.append(False)
+                        elif service_type == 'ipmi-obm-service' and node_type == 'compute':
+                            logs.warning('ipmi-obm-service - No OBM settings for node type %s (id=%s)', node_type, uid)
+                            retval.append(False)
                     else:
                         for obm in obm_obj:
                             service = obm.get('service')
                             if service_type not in service:
-                                LOG.warning('No OBM service type {0} (id={1})'.format(service_type,uid))
-                                retval.append(False)
+                                if service_type == 'snmp-obm-service' and node_type in ['switch', 'pdu']:
+                                    logs.warning('No OBM service type %s (id=%s, type=%s)', service_type, uid, node_type)
+                                    retval.append(False)
+                                elif service_type == 'ipmi-obm-service' and node_type in ['compute']:
+                                    logs.warning('No OBM service type %s (id=%s, type=%s)', service_type, uid, node_type)
+                                    retval.append(False)
         return retval
-
-

--- a/test/tests/api/fit-staging/v2_0/obm_settings.py
+++ b/test/tests/api/fit-staging/v2_0/obm_settings.py
@@ -39,8 +39,8 @@ class obmSettings(object):
             if 'data' in rmm:
                 mac = bmc['data'].get('MAC Address')
         if mac is not None:
-            logs.debug('BMC MAC {0} for {1}'.format(mac, uid))
-            logs.debug('BMC user {0} passowd {1}'.format(user, passwd))
+            logs.debug('BMC MAC %s for %s', mac, uid)
+            logs.debug('BMC user %s passowd %s', user, passwd)
             setting = {
                 'nodeId': uid,
                 'service': 'ipmi-obm-service',
@@ -54,7 +54,7 @@ class obmSettings(object):
             try:
                 Api().obms_put(setting)
                 rsp = self.__client.last_response
-                logs.debug(" IPMI OBM Set response {}".format(rsp.status))
+                logs.debug(" IPMI OBM Set response %s", str(rsp.status))
             except ApiException as e:
                 logs.error(e)
                 return False
@@ -96,7 +96,7 @@ class obmSettings(object):
             uid = n.get('id')
             if uuid is None or uuid == uid:
                 if node_type != 'enclosure':
-                    logs.info("Checking node: {} type {}".format(uid, node_type))
+                    logs.info("Checking node: %s type %s", uid, node_type)
                     obm_obj = []
                     Api().obms_get()
                     all_obms = loads(self.__client.last_response.data)


### PR DESCRIPTION
One set of converted cit to fit scripts 
Converted scripts include:
removing proboscis from the scripts and updating to the unittest format
updating the style to meet flake8 checks
fixed scripts to operate properly against specific node types -compute, switch, pdu
fixed scripts to clean up added test nodes

These tests won't run in smoke until we move then to api-cit directory. 
@johren @larry-dean @brianparry @dalebremner @keedya @srinia6 