### PR TITLE
docker: add dns for ubuntu os install, 

### DIFF
--- a/docker/dhcp/config/dhcpd.conf
+++ b/docker/dhcp/config/dhcpd.conf
@@ -9,6 +9,9 @@ max-lease-time 7200;
 ignore-client-uids true;
 deny duplicates;
 
+option domain-name-servers 172.31.128.250;
+option routers 172.31.128.254;
+
 subnet 172.31.128.0 netmask 255.255.240.0 {
   range 172.31.128.2 172.31.143.254;
   option vendor-class-identifier "PXEClient";


### PR DESCRIPTION
1. ubuntu os installation need dns-server configuration.

2. change INTERFACES to em1 for test stack.

This PR just fix this issue in our CD system.
However, how to do this configuration for users is still a issue.
@panpan0000 