### PR TITLE
Add com console parameters for esxi

### DIFF
--- a/example/samples/install_esx_payload_full.json
+++ b/example/samples/install_esx_payload_full.json
@@ -57,6 +57,10 @@
                 }
             ],
             "installDisk": "t10.ATA_____SATADOM2DSH_TYPE_C_3SE___________________20151007AA8511725043",
+            "gdbPort": "default",
+            "logPort": "default",
+            "comport": "com1",
+            "debugLogToSerial": "1",
             "switchDevices": [
                 {
                     "switchName": "vSwitch0",


### PR DESCRIPTION
In many rack mount servers or customized servers, there is no monitor connected, UART port are usually used as console. VMware ESXi use VGA card as console. User need pass VM kernel To support this use, I add three options: "gdbPort","logPort","debugLogToSerial". 
And there is also "comport" options. I add it to this sample file.


Jenkins depends on https://github.com/RackHD/on-tasks/pull/443