### PR TITLE
modify packer script for vagrant 0.17

### DIFF
--- a/packer/ansible/rackhd_local.yml
+++ b/packer/ansible/rackhd_local.yml
@@ -15,6 +15,7 @@
     - ipmitool
     - foreman
     - pm2
+    - setuptools
     - remoterepos
     - images
     - swagger

--- a/packer/ansible/roles/mongodb/files/mongodb.conf
+++ b/packer/ansible/roles/mongodb/files/mongodb.conf
@@ -1,0 +1,100 @@
+# mongodb.conf
+
+# Where to store the data.
+dbpath=/var/lib/mongodb
+
+#where to log
+logpath=/var/log/mongodb/mongodb.log
+
+logappend=true
+
+#bind_ip = 127.0.0.1
+#port = 27017
+
+# Enable journaling, http://www.mongodb.org/display/DOCS/Journaling
+journal=true
+
+# Enables periodic logging of CPU utilization and I/O wait
+#cpu = true
+
+# Turn on/off security.  Off is currently the default
+#noauth = true
+#auth = true
+
+# Verbose logging output.
+#verbose = true
+
+# Inspect all client data for validity on receipt (useful for
+# developing drivers)
+#objcheck = true
+
+# Enable db quota management
+#quota = true
+
+# Set oplogging level where n is
+#   0=off (default)
+#   1=W
+#   2=R
+#   3=both
+#   7=W+some reads
+#oplog = 0
+
+# Diagnostic/debugging option
+#nocursors = true
+
+# Ignore query hints
+#nohints = true
+
+# Disable the HTTP interface (Defaults to localhost:27018).
+#nohttpinterface = true
+
+# Turns off server-side scripting.  This will result in greatly limited
+# functionality
+#noscripting = true
+
+# Turns off table scans.  Any query that would do a table scan fails.
+#notablescan = true
+
+# Disable data file preallocation.
+#noprealloc = true
+
+# Specify .ns file size for new databases.
+# nssize = <size>
+
+# Accout token for Mongo monitoring server.
+#mms-token = <token>
+
+# Server name for Mongo monitoring server.
+#mms-name = <server-name>
+
+# Ping interval for Mongo monitoring server.
+#mms-interval = <seconds>
+
+# Replication Options
+
+# in replicated mongo databases, specify here whether this is a slave or master
+#slave = true
+#source = master.example.com
+# Slave only: specify a single database to replicate
+#only = master.example.com
+# or
+#master = true
+#source = slave.example.com
+
+# Address of a server to pair with.
+#pairwith = <server:port>
+# Address of arbiter server.
+#arbiter = <server:port>
+# Automatically resync if slave data is stale
+#autoresync
+# Custom size for replication operation log.
+#oplogSize = <MB>
+# Size limit for in-memory storage of op ids.
+#opIdMem = <bytes>
+
+# SSL options
+# Enable SSL on normal ports
+#sslOnNormalPorts = true
+# SSL Key file and password
+#sslPEMKeyFile = /etc/ssl/mongodb.pem
+#sslPEMKeyPassword = pass

--- a/packer/ansible/roles/mongodb/tasks/main.yml
+++ b/packer/ansible/roles/mongodb/tasks/main.yml
@@ -2,5 +2,9 @@
 - name: Install MongoDB
   apt: pkg={{ item }} state=installed
   with_items:
-    - mongodb
+    - mongodb=1:2.4.9-1ubuntu2
+  sudo: yes
+
+- name: Copy mongodb config file to home directory
+  copy: src=mongodb.conf dest=/etc
   sudo: yes

--- a/packer/ansible/roles/remoterepos/tasks/main.yml
+++ b/packer/ansible/roles/remoterepos/tasks/main.yml
@@ -17,8 +17,6 @@
   args:
     chdir: "{{ ansible_env.HOME }}/src/{{ item }}"
   with_items:
-    - on-core
-    - on-tasks
     - on-http
     - on-tftp
     - on-dhcp-proxy
@@ -26,7 +24,7 @@
     - on-syslog
     - on-wss
     - on-tools
-    - on-imagebuilder
+    - ucs-service
 
 - name: Reset to the branch specified
   shell: git reset --hard {{ branch }}
@@ -34,8 +32,6 @@
   args:
     chdir: "{{ ansible_env.HOME }}/src/{{ item }}"
   with_items:
-    - on-core
-    - on-tasks
     - on-http
     - on-tftp
     - on-dhcp-proxy
@@ -44,6 +40,7 @@
     - on-wss
     - on-tools
     - on-imagebuilder
+    - ucs-service
 
 - name: Npm install Repos
   npm: path="{{ ansible_env.HOME }}/src/{{ item }}"
@@ -55,6 +52,13 @@
     - on-taskgraph
     - on-http
     - on-wss
+
+- name: Pip install Repos
+  sudo: yes
+  pip: 
+    requirements: "{{ ansible_env.HOME }}/src/{{ item }}/requirements.txt"
+  with_items:
+    - ucs-service
 
 - name: Make common static directory
   file: path="{{ ansible_env.HOME }}/src/on-http/static/http/common" state=directory


### PR DESCRIPTION
Move some actions in vagrant up to packer build.
1. Add pip install ucs-service/requirments.text
2. Add mongo conf.
3. Build with virtualbox 5.0.32