### PR TITLE
RAC-4994-amqp-rediscovery-conversion

### DIFF
--- a/test/common/env_ip_helpers.py
+++ b/test/common/env_ip_helpers.py
@@ -1,0 +1,116 @@
+"""
+Copyright 2017 Dell Inc. or its subsidiaries.  All Rights Reserved.
+
+Module to hold helper classes and functions to determine run-time test IP
+information. Currently,
+"""
+import flogging
+import ipaddress
+import netifaces
+import socket
+import fit_common
+
+logs = flogging.get_loggers()
+
+
+class TestHostInterfacer(object):
+    _cached = None
+
+    @classmethod
+    def get_testhost_ip(cls):
+        if cls._cached is None:
+            cls._cached = cls()
+            logs.info('The IP address of %s has been selected as the most likely testhost IP address reachable from the DUT',
+                      cls._cached.__alleged_testhost_ip)
+        return cls._cached.__alleged_testhost_ip
+
+    def __init__(self):
+        self.__alleged_testhost_ip = None
+
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        ip = fit_common.fitargs()['rackhd_host']
+        monip = fit_common.fitcfg()["rackhd-config"]["apiServerAddress"]
+        monip_obj = ipaddress.ip_address(monip)
+        logs.irl.debug('Trying to determine testhost IP address. Hitting rackhd_host value %s first', ip)
+        s.connect((ip, 0))
+        logs.debug('  ip used to generate connection to %s was %s: ', ip, s.getsockname()[0])
+        alleged_testhost_ip_str = s.getsockname()[0]
+        # python2/3 flake handling. The 'unicode' keyword is gone from p3. However, although
+        # our code is p2, hound uses p3. We can cover both by using the -type- of a unicode string!
+        ucode_type = type(u'unicode_string_to_type')
+        alleged_testhost_ip = ipaddress.ip_address(ucode_type(alleged_testhost_ip_str))
+        if not alleged_testhost_ip.is_loopback:
+            # A non-loopback address is about the best guess we can get. Use it.
+            logs.irl.debug('  ip used to generate connection to %s is non-loopback. Using %s', ip, alleged_testhost_ip_str)
+            self.__alleged_testhost_ip = alleged_testhost_ip_str
+            return
+
+        # Localhost. Great. We are either running on the DUT or are on a test-host.
+        # In either case, grabbing pretty much any ip interface that isn't a loop back
+        # should do the trick.
+        docker_net = []
+        mono_net = []
+        eform_net = []
+        vbox_net = []
+        veth_net = []
+        extras_net = []
+        int_list = netifaces.interfaces()
+        for interface in int_list:
+            logs.irl.debug('  checking interface %s', interface)
+            ifaddrs = netifaces.ifaddresses(interface)
+            if netifaces.AF_INET not in ifaddrs:
+                logs.irl.debug('   -- no ifaddrs on it, skipping')
+            else:
+                for net in ifaddrs[netifaces.AF_INET]:
+                    logs.irl.debug('    checking %s on %s', net, interface)
+                    addr = net['addr']
+                    mask = net['netmask']
+                    inet_form = u'{}/{}'.format(addr, mask)
+                    this_iface = ipaddress.ip_interface(inet_form)
+                    this_iface.on_name = interface
+                    dispo = None
+                    if this_iface.is_loopback:
+                        dispo = 'loopback-skip'
+                    elif monip_obj in this_iface.network:
+                        # really the last choice, all things considered!
+                        dispo = 'added to control-network-list'
+                        mono_net.append(this_iface)
+                    elif 'docker' in interface:
+                        dispo = 'added to docker list'
+                        docker_net.append(this_iface)
+                    elif interface.startswith('vbox'):
+                        dispo = 'added to vbox list'
+                        vbox_net.append(this_iface)
+                    elif interface.startswith('veth'):
+                        dispo = 'added to veth list'
+                        veth_net.append(this_iface)
+                    elif interface.startswith('eth') or interface.startswith('en'):
+                        dispo = 'added to en/eth list'
+                        eform_net.append(this_iface)
+                    else:
+                        logs.irl.debug('unknown interface type-ish %s seen', interface)
+                        dispo = 'added to extras list'
+                        extras_net.append(this_iface)
+                    logs.irl.debug('     -> %s', dispo)
+
+        ordered_list = []
+        ordered_list.extend(eform_net)
+        ordered_list.extend(docker_net)
+        ordered_list.extend(vbox_net)
+        ordered_list.extend(veth_net)
+        ordered_list.extend(extras_net)
+        ordered_list.extend(mono_net)
+        logs.irl.debug('  Final list of possible addresses: %s', ordered_list)
+        # note: we could go and ssh over and ping back to check these. For now, just
+        # grab the first.
+        if len(ordered_list) == 0:
+            logs.warning('could not find the test-host ip address and fell back on localhost')
+            self.__alleged_testhost_ip = '127.0.1.1'
+            return
+        picked = ordered_list[0]
+        logs.irl.debug('picked %s on %s', picked.ip, picked.on_name)
+        self.__alleged_testhost_ip = str(picked.ip)
+
+
+def get_testhost_ip():
+    return TestHostInterfacer.get_testhost_ip()

--- a/test/common/fit_common.py
+++ b/test/common/fit_common.py
@@ -475,19 +475,22 @@ def remote_shell(shell_cmd, expect_receive="", expect_send="", timeout=300,
         user = fitcreds()['rackhd_host'][0]['username']
     if not password:
         password = fitcreds()['rackhd_host'][0]['password']
+    port = fitports()['ssh']
 
     logfile_redirect = None
     if VERBOSITY >= 4:
         print "VM number: ", vmnum
+        print "remote_shell: User =", user
         print "remote_shell: Host =", address
+        print "remote_shell: Port =", port
         print "remote_shell: Command =", shell_cmd
 
     if VERBOSITY >= 9:
         print "remote_shell: STDOUT =\n"
         logfile_redirect = sys.stdout
 
-    # if localhost just run the command local
-    if fitargs()['rackhd_host'] == 'localhost':
+    # if localhost and not on a portfoward port just run the command local
+    if fitargs()['rackhd_host'] == 'localhost' and port == 22:
         (command_output, exitstatus) = \
             pexpect.run("sudo bash -c \"" + shell_cmd + "\"",
                         withexitstatus=1,
@@ -503,14 +506,14 @@ def remote_shell(shell_cmd, expect_receive="", expect_send="", timeout=300,
     if expect_receive == "" or expect_send == "":
         (command_output, exitstatus) = \
             pexpect.run("ssh -q -o StrictHostKeyChecking=no -t " + user + "@" +
-                        address + " sudo bash -c \\\"" + shell_cmd + "\\\"",
+                        address + " -p " + str(port) + " sudo bash -c \\\"" + shell_cmd + "\\\"",
                         withexitstatus=1,
                         events={"assword": password + "\n"},
                         timeout=timeout, logfile=logfile_redirect)
     else:
         (command_output, exitstatus) = \
             pexpect.run("ssh -q -o StrictHostKeyChecking=no -t " + user + "@" +
-                        address + " sudo bash -c \\\"" + shell_cmd + "\\\"",
+                        address + " -p " + str(port) + " sudo bash -c \\\"" + shell_cmd + "\\\"",
                         withexitstatus=1,
                         events={"assword": password + "\n",
                                 expect_receive: expect_send + "\n"},

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -5,23 +5,25 @@ docker-py==1.10.6
 flake8==3.3.0
 gevent==1.1.2
 greenlet==0.4.10
+ipaddress==1.0.18
 jsonmerge==1.2.1
 jsonschema==2.4.0
 kombu==3.0.30
-pika==0.10.0
 nose==1.3.7
 nosedep>=0.6
+netifaces==0.10.5
 on-http_api2_0>=1.0.2
 on_http_redfish_1_0>=1.0.0
 pexpect==3.3
+pika==0.10.0
 proboscis==1.2.6.0
+pymongo==3.4.0
 requests==2.9.0
 # there are problems with the 34.0.x setuptools and nosedeps. Pin for now.
 setuptools==33.1.1
 # urllib3 1.20 breaks CIT test, specify version as a temp solution
 urllib3==1.19.1
 ucsmsdk==0.9.2.0
-pymongo==3.4.0
 
 # WARNING: do not just replace this file with "pip freeze > requirements.txt".
 # You need to keep the following line as is! (freeze will turn it into

--- a/test/stream-monitor/stream_sources/self_test_source.py
+++ b/test/stream-monitor/stream_sources/self_test_source.py
@@ -15,9 +15,9 @@ class _SelfTestMatcher(StreamMatchBase):
     """
     Implementation of a StreamMatchBase matcher that checks for simple text equality.
     """
-    def __init__(self, match_text, description, min=1, max=1):
+    def __init__(self, logs, match_text, description, min=1, max=1):
         self.__match_text = match_text
-        super(_SelfTestMatcher, self).__init__(description, min=min, max=max)
+        super(_SelfTestMatcher, self).__init__(logs, description, min=min, max=max)
 
     def _match(self, other_text):
         return other_text == self.__match_text
@@ -42,7 +42,7 @@ class SelfTestStreamMonitor(StreamMonitorBaseClass):
         """
         if description is None:
             description = "match_single({0})".format(match_val)
-        m = _SelfTestMatcher(match_val, description, 1, 1)
+        m = _SelfTestMatcher(self._logs, match_val, description, 1, 1)
         self._add_matcher(m)
 
     def handle_start_test(self, test):

--- a/test/tests/amqp/test_amqp_heartbeat.py
+++ b/test/tests/amqp/test_amqp_heartbeat.py
@@ -30,7 +30,7 @@ class TestAMQPHeartbeat(unittest.TestCase):
 
     def __common_on_x_heartbeat(self, service_name):
         rk = 'heartbeat.updated.information.#.{}'.format(service_name)
-        self.__proc.match_on_routekey(routing_key=rk, max=3)
+        self.__proc.match_on_routekey('all-heartbeats', routing_key=rk, max=3)
         results = self._amqp_sp.finish(timeout=20)
         results[0].assert_errors(self)
         first_event = self.__proc.get_raw_tracker_events()[0]


### PR DESCRIPTION
* Common-changes:
** remote-shell was not honoring the ssh-port. Changed the code to do so AND include that in the check for a truly local command
* Added requirements.txt items:
** updated kombu to latest (matches plugin!)
** added ipaddress and netifaces to help making detection of actual test-host IP address even possible
* monitor base-class changes:
** threaded logging throughout
** threaded in "allow complete miss" logic
* stream_matchers_base and monitor_abc
** taught add_result recorder to understand lists
** enhanced is_empty to check -into- a list of results and call it empty if it is just a list of empties.
** threaded logging in
** added __str__ to a number of items to make diag easier
** added an _validate step. _match still handles "does this apply?" while _validate handles "and does it make sense..."
** taught entire check_event chain to handle lists of results returned (a list occurs when validation failuers happen)
** taught entire check_event chain to handle allow_complete_miss concept. The default is that NOT an event in an ordered grouping causes an out-of-order result to be attached to the next matcher. But sometimes we only care that x.y.z occur in order and don't care if anything else drops between x or y or z.
* test_amqp_node_rediscovery.py nows works with the stream monitor. Big changes:
** includes a sample class to determine the test-host IP address. I'll be writing up a story to move this to common and fully test across all known deploys.
** removed all use of globals etc etc.
** removed linear amqp-worker.
** made tests for each block-progress-step:
*** test_rediscover_pick_node
*** test_rediscover_check_obm
*** test_rediscover_reboot_kickoff
*** test_rediscover_reboot_graph_amqp_flow -- this is the core of graph progress tracking
*** test_rediscover_discover_rebooted_node
*** test_rediscover_discover_sku_assign
*** test_rediscover_discover_node_registration
*** test_rediscover_discover_hook -- this checks the rackhd post-back results
*** test_rediscover_discover_obm_settings
** moved validation into a common routine that can report multiple failures via _verify
** added nosedeps were sequencing was needed (a fair amount in this case)
** used a class-level run-context along with the nosedeps to handoff critical data
* stream-monitor test/test_matchers.py
** added a preceding whitespace to the match result type check (the addition of the __str__ diag code was causing an extra hit here)
** assert_errors in __assert_Basic_results when an ok is expected (ends up being way more useful than just the the assert saying 'ok' wasn't expected)
** added a test for the allow_complete_miss flag
** fixed a couple if in-text typeos
* stream_matchers_results.py:
** added a dump() to the stream-results for diag
** added __str__ to same
** added Validation matcher-results (Missmatch and MissingField)
* amqp_source got more changes than expected:
** Added a _KeyedConsumerHandler rather than having the ampq-server-wrapper keep track of all queues. Turns out you can either get everything on an unnamed consumer as a Kombu message (which you can ack) OR you can set the consumer-id... and get a raw amqplib message, which you CAN'T ack! Pulling this out gives the equiv of consumer-id to event callback lists w/o using the consumer-ids
** added a _validate method to the AMQP-matcher to check fields etc. This could be a template validation test-harness wide.
** we now wait till we move to finishing mode before even looking at a single message. There is other wiring that would have to happen to add matchers "on the fly" and this isn't the time for them!
** change from time.time to datetime.now and timedeltas (much pretties/readable time-deltas)
** lots more logging!

@hohene @johren 
