### PR TITLE
Fix start_time bug in Linux OS Install

### DIFF
--- a/test/tests/bootstrap/test_api20_linux_bootstrap.py
+++ b/test/tests/bootstrap/test_api20_linux_bootstrap.py
@@ -53,7 +53,7 @@ if config:
 # this routine polls a workflow task ID for completion
 def wait_for_workflow_complete(instanceid, start_time, waittime=900, cycle=30):
     log.info_5(" Workflow started at time: " + str(start_time))
-    while start_time - time.time() < waittime:  # limit test to 30 minutes
+    while time.time() - start_time < waittime:  # limit test to waittime seconds
         result = fit_common.rackhdapi("/api/2.0/workflows/" + instanceid)
         if result['status'] != 200:
             log.error(" HTTP error: " + result['text'])


### PR DESCRIPTION
Found a math problem with the workflow timer in the Linux OS install test. We had the expression backwards and the timer wasn't timing out. 

Single line fix.

@hohene @johren 