### PR TITLE
[Skip CI]Fix RAC-5160: when BUILD_STAGE=BUILD_ALL, build from scratch

### DIFF
--- a/packer/HWIMO-BUILD
+++ b/packer/HWIMO-BUILD
@@ -83,6 +83,12 @@ if [ ! -f "ansible/${ANSIBLE_PLAYBOOK}.yml" ]; then
     echo "${ERROR_HEADER} The target ansible playbook(ansible/${ANSIBLE_PLAYBOOK}.yml) does not exist. Aborting..."
     exit 3
 fi
+
+### For OVA Build, option is to build OVA directlly from VMX, or build a VMX (which includes all RackHD Prerequisite)
+if  [ ! -n "${BUILD_STAGE}" ];  then
+    BUILD_STAGE="BUILD_ALL"
+fi
+
 if [ "$BUILD_STAGE" == "BUILD_ALL" ] ; then
     echo "${INFO_HEADER} Full Build:  Install RackHD with (1) ansible playbook rackhd_prepare.yml, (2) ansible playbook ${ANSIBLE_PLAYBOOK}_mini.yml "
 else
@@ -92,7 +98,7 @@ else
         if [ "$BUILD_STAGE" == "BUILD_TEMPLATE" ] ; then
             echo "${INFO_HEADER} First Half Build: Prepare RackHD dependency with ansible :  rackhd_prepare.yml "
         else
-            echo "${ERROR_HEADER} Unrecongnized parameter BUILD_STAGE=$BUILD_STAGE. Abort ! "
+            echo "${ERROR_HEADER} Unrecongnized parameter BUILD_STAGE=$BUILD_STAGE,  Abort ! "
             exit 2
         fi
     fi
@@ -129,10 +135,6 @@ then
     fi
 fi
 
-### For OVA Build, option is to build OVA directlly from VMX, or build a VMX (which includes all RackHD Prerequisite)
-if  [ ! -n "${BUILD_STAGE}" ];  then
-    BUILD_STAGE="BUILD_ALL"
-fi
 
 
 
@@ -235,8 +237,8 @@ else
 
     else
          #Build from scratch, vmware: iso-->vmx-->ova, virtualbox: iso-->ovf-->box
-         $PACKER build --force --only=${BUILD_TYPE}-${temp_src_format}  --var-file=$CFG_FILE  --var "playbook=rackhd_prepare" ${PACKER_TEMP}   | tee packer-install.log            && \
-         $PACKER build --force --only=${BUILD_TYPE}-vmx  --var-file=$CFG_FILE  --var "playbook=${ANSIBLE_PLAYBOOK}_mini" ${PACKER_TEMP}    | tee packer-install.log
+         $PACKER build --force --only=${BUILD_TYPE}-iso  --var-file=$CFG_FILE  ${PACKER_TEMP}  | tee packer-install.log && \
+         $PACKER build --force --only=${BUILD_TYPE}-${temp_src_format}  --var-file=$CFG_FILE  --var "playbook=${ANSIBLE_PLAYBOOK}_mini" ${PACKER_TEMP}   | tee packer-install.log
     fi
 fi
 


### PR DESCRIPTION
**Why Skip CI**
current PR Gate can't verify packer build, so skip it.
will add PR Gate packer build sooner :-P


**Test**

pass unit-test 

when ```BUILD_STAGE=BUILD_ALL BUILD_TYPE=vmware  ./HWIMO-BUILD```
```
 packer build --force --only=vmware-iso --var-file=template.cfg template-ubuntu-14.04.json.tmp
 packer build --force --only=vmware-vmx --var-file=template.cfg --var playbook=rackhd_local_mini template-ubuntu-14.04.json.tmp
```
when ```BUILD_STAGE=BUILD_ALL BUILD_TYPE=virtualbox./HWIMO-BUILD```

```
+ packer2 build --force --only=virtualbox-iso --var-file=template.cfg template-ubuntu-14.04.json.tmp
+ packer2 build --force --only=virtualbox-ovf --var-file=template.cfg --var playbook=rackhd_local_mini template-ubuntu-14.04.json.tmp
```


**Reviewer**
@hohene  @anhou @iceiilin 


