### PR TITLE
RAC-5000 Windows OS Install test script

### DIFF
--- a/test/tests/bootstrap/test_api20_windows_bootstrap.py
+++ b/test/tests/bootstrap/test_api20_windows_bootstrap.py
@@ -1,0 +1,137 @@
+'''
+Copyright 2017 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+This script tests arbitrary payload of the RackHD API 2.0 OS bootstrap workflows.
+The default case is running a minimum payload Windows OS install.
+Other Windows-type OS install cases can be specified by creating a payload file and specifiying it using the '-extra' argument.
+This test takes 30-45 minutes to run.
+
+Example payload file (installed in configuration dir):
+
+{"bootstrap-payload":
+    {"name": "Graph.InstallWindowsServer",
+           "options": {"defaults": {"version": "2012",
+                                    "repo": "http://172.31.128.1:8080/repo/winpe",
+                                    "smbRepo": "\\\\172.31.128.1\\windowsServer2012",
+                                    "productkey": "XXXXX-XXXXX-XXXXX-XXXXX-XXXXX",
+                                    "username": "rackhduser",
+                                    "password": "RackHDRocks",
+                                    "smbUser": "vagrant",
+                                    "smbPassword": "vagrant"}}}
+}
+
+Example command line using external payload file:
+
+python run_tests.py -stack 4 -test tests/bootstrap/test_api20_windows_bootstrap.py -extra base_windows_2012_install.json
+
+RackHD Windows installation workflow requires special configuration of the RackHD server:
+- A customized WinPE environment installed on RackHD server as documented here:
+        https://github.com/RackHD/on-tools/tree/master/winpe
+- Samba installed on the RackHD server and configured as documented here:
+        http://rackhd.readthedocs.io/en/latest/rackhd/install_os.html?highlight=os%20install
+- Windows 2012 installation distro installed on RackHD server or equivalent NFS mount.
+- Windows 2012 activation key in the installation payload file.
+
+'''
+
+import fit_path  # NOQA: unused import
+from nose.plugins.attrib import attr
+import fit_common
+import flogging
+import random
+import time
+from nosedep import depends
+log = flogging.get_loggers()
+
+# sample default base payload
+PAYLOAD = {"name": "Graph.InstallWindowsServer",
+           "options": {"defaults": {"version": "2012",
+                                    "repo": "http://172.31.128.1:8080/repo/winpe",
+                                    "smbRepo": "\\\\172.31.128.1\\windowsServer2012",
+                                    "productkey": "XXXXX-XXXXX-XXXXX-XXXXX-XXXXX",
+                                    "username": "rackhduser",
+                                    "password": "RackHDRocks",
+                                    "smbUser": "vagrant",
+                                    "smbPassword": "vagrant"}}}
+# if an external payload file is specified, use that
+config = fit_common.fitcfg().get('bootstrap-payload', None)
+if config:
+    PAYLOAD = config
+
+
+# this routine polls a workflow task ID for completion
+def wait_for_workflow_complete(instanceid, start_time, waittime=3200, cycle=30):
+    log.info_5(" Workflow started at time: " + str(start_time))
+    while time.time() - start_time < waittime:  # limit test to waittime seconds
+        result = fit_common.rackhdapi("/api/2.0/workflows/" + instanceid)
+        if result['status'] != 200:
+            log.error(" HTTP error: " + result['text'])
+            return False
+        if result['json']['status'] in ['running', 'pending']:
+            log.info_5("{} workflow status: {}".format(result['json']['injectableName'], result['json']['status']))
+            fit_common.time.sleep(cycle)
+        elif result['json']['status'] == 'succeeded':
+            log.info_5("{} workflow status: {}".format(result['json']['injectableName'], result['json']['status']))
+            log.info_5(" Workflow completed at time: " + str(time.time()))
+            return True
+        else:
+            log.error(" Workflow failed: status: %s text: %s", result['json']['status'], result['text'])
+            return False
+    log.error(" Workflow Timeout: " + result['text'])
+    return False
+
+
+# ------------------------ Tests -------------------------------------
+
+
+@attr(all=False)
+class api20_bootstrap_windows(fit_common.unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Get the list of nodes
+        NODECATALOG = fit_common.node_select()
+        # Select one node at random
+        cls.__NODE = NODECATALOG[random.randint(0, len(NODECATALOG) - 1)]
+        # delete active workflows for specified node
+        fit_common.cancel_active_workflows(cls.__NODE)
+
+    def test01_node_check(self):
+        # Log node data
+        nodeinfo = fit_common.rackhdapi('/api/2.0/nodes/' + self.__class__.__NODE)['json']
+        nodesku = fit_common.rackhdapi(nodeinfo.get('sku'))['json']['name']
+        log.info_5(" Node ID: " + self.__class__.__NODE)
+        log.info_5(" Node SKU: " + nodesku)
+        log.info_5(" Graph Name: " + PAYLOAD['name'])
+
+        # Ensure the compute node is powered on and reachable
+        result = fit_common.rackhdapi('/api/2.0/nodes/' +
+                                      self.__class__.__NODE +
+                                      '/workflows',
+                                      action='post', payload={"name": "Graph.PowerOn.Node"})
+        self.assertEqual(result['status'], 201, "Node Power on workflow API failed, see logs.")
+        self.assertTrue(wait_for_workflow_complete(result['json']['instanceId'], time.time(), 50, 5),
+                        "Node Power on workflow failed, see logs.")
+
+    @depends(after=test01_node_check)
+    def test02_os_install(self):
+        # launch workflow
+        workflowid = None
+        result = fit_common.rackhdapi('/api/2.0/nodes/' +
+                                      self.__class__.__NODE +
+                                      '/workflows',
+                                      action='post', payload=PAYLOAD)
+        if result['status'] == 201:
+            # workflow running
+            log.info_5(" InstanceID: " + result['json']['instanceId'])
+            log.info_5(" Payload: " + fit_common.json.dumps(PAYLOAD))
+            workflowid = result['json']['instanceId']
+        else:
+            # workflow failed with response code
+            log.error(" InstanceID: " + result['text'])
+            log.error(" Payload: " + fit_common.json.dumps(PAYLOAD))
+            self.fail("Workflow failed with response code: " + result['status'])
+        self.assertTrue(wait_for_workflow_complete(workflowid, time.time()), "OS Install workflow failed, see logs.")
+
+
+if __name__ == '__main__':
+    fit_common.unittest.main()

--- a/test/tests/bootstrap/test_api20_windows_bootstrap.py
+++ b/test/tests/bootstrap/test_api20_windows_bootstrap.py
@@ -61,23 +61,23 @@ if config:
 
 # this routine polls a workflow task ID for completion
 def wait_for_workflow_complete(instanceid, start_time, waittime=3200, cycle=30):
-    log.info_5(" Workflow started at time: " + str(start_time))
+    log.info_5(" Workflow started at time: %s ", str(start_time))
     while time.time() - start_time < waittime:  # limit test to waittime seconds
         result = fit_common.rackhdapi("/api/2.0/workflows/" + instanceid)
         if result['status'] != 200:
-            log.error(" HTTP error: " + result['text'])
+            log.error(" HTTP error: %s ", result['text'])
             return False
         if result['json']['status'] in ['running', 'pending']:
             log.info_5("{} workflow status: {}".format(result['json']['injectableName'], result['json']['status']))
             fit_common.time.sleep(cycle)
         elif result['json']['status'] == 'succeeded':
             log.info_5("{} workflow status: {}".format(result['json']['injectableName'], result['json']['status']))
-            log.info_5(" Workflow completed at time: " + str(time.time()))
+            log.info_5(" Workflow completed at time: %s ", str(time.time()))
             return True
         else:
             log.error(" Workflow failed: status: %s text: %s", result['json']['status'], result['text'])
             return False
-    log.error(" Workflow Timeout: " + result['text'])
+    log.error(" Workflow Timeout: %s ", result['text'])
     return False
 
 
@@ -99,9 +99,9 @@ class api20_bootstrap_windows(fit_common.unittest.TestCase):
         # Log node data
         nodeinfo = fit_common.rackhdapi('/api/2.0/nodes/' + self.__class__.__NODE)['json']
         nodesku = fit_common.rackhdapi(nodeinfo.get('sku'))['json']['name']
-        log.info_5(" Node ID: " + self.__class__.__NODE)
-        log.info_5(" Node SKU: " + nodesku)
-        log.info_5(" Graph Name: " + PAYLOAD['name'])
+        log.info_5(" Node ID: %s ", self.__class__.__NODE)
+        log.info_5(" Node SKU: %s ", nodesku)
+        log.info_5(" Graph Name: %s ", PAYLOAD['name'])
 
         # Ensure the compute node is powered on and reachable
         result = fit_common.rackhdapi('/api/2.0/nodes/' +
@@ -122,15 +122,15 @@ class api20_bootstrap_windows(fit_common.unittest.TestCase):
                                       action='post', payload=PAYLOAD)
         if result['status'] == 201:
             # workflow running
-            log.info_5(" InstanceID: " + result['json']['instanceId'])
-            log.info_5(" Payload: " + fit_common.json.dumps(PAYLOAD))
+            log.info_5(" InstanceID: %s ", result['json']['instanceId'])
+            log.info_5(" Payload: %s ", fit_common.json.dumps(PAYLOAD))
             workflowid = result['json']['instanceId']
         else:
             # workflow failed with response code
-            log.error(" InstanceID: " + result['text'])
-            log.error(" Payload: " + fit_common.json.dumps(PAYLOAD))
+            log.error(" InstanceID: %s ", result['text'])
+            log.error(" Payload: %s ", fit_common.json.dumps(PAYLOAD))
             self.fail("Workflow failed with response code: " + result['status'])
-        self.assertTrue(wait_for_workflow_complete(workflowid, time.time()), "OS Install workflow failed, see logs.")
+        self.assertTrue(wait_for_workflow_complete(workflowid, time.time()), "Windows OS Install workflow failed, see logs.")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Windows OS Install FIT test script for arbitrary payloads.

The Windows OS install requires additional configuration of the RackHD server as outlined in the header notes.

Payload can be specified by loading a file using the -extra parameter. Examples in the file header comments.

There is a default payload for Windows 2012 but the repo spec is, as always, site specific. There is no generic repo spec that will work in all situations unless some conventions are adopted.

The default payload contains a dummy activation key. We cannot publish this script with a valid activation key. If the default payload is used, Windows Install will ask for a valid key on the console, which will continue if entered manually.. If fully automated operation is required, then a valid activation key must be included in an external payload file. 

The Windows Install workflow execution time varies from 1800 to 2900 seconds in the several runs we made. We set the timeout at 3200. We presume this will be enough for regression testing but may need to be increased if its really slow in the production environment.

This is the base test script. It is intended to be enhanced with additional tests to verify payload parameters in future stories.

Paired with Vaidehi   Pathak

@hohene @johren @larry-dean 
