### PR TITLE
Rac 5182 mongo db role fix

### DIFF
--- a/packer/ansible/roles/mongodb/tasks/main.yml
+++ b/packer/ansible/roles/mongodb/tasks/main.yml
@@ -6,19 +6,12 @@
   sudo: yes
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_version == '14.02'
 
-- name: Install MongoDB 2.6.10
-  apt: pkg={{ item }} state=installed
-  with_items:
-    - mongodb=1:2.6.10-0ubuntu2
-  sudo: yes
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version == '16.04'
-
-- name: Install MongoDB 2.6.10
+- name: Install MongoDB Default
   apt: pkg={{ item }} state=installed
   with_items:
     - mongodb
   sudo: yes
-  when: ansible_distribution != 'Ubuntu'
+  when: ansible_distribution != 'Ubuntu' or ansible_distribution_version != '14.02'
 
 - name: Copy mongodb config file to home directory
   copy: src=mongodb.conf dest=/etc

--- a/packer/ansible/roles/mongodb/tasks/main.yml
+++ b/packer/ansible/roles/mongodb/tasks/main.yml
@@ -1,9 +1,24 @@
 ---
-- name: Install MongoDB
+- name: Install MongoDB 2.4.9
   apt: pkg={{ item }} state=installed
   with_items:
     - mongodb=1:2.4.9-1ubuntu2
   sudo: yes
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version == '14.02'
+
+- name: Install MongoDB 2.6.10
+  apt: pkg={{ item }} state=installed
+  with_items:
+    - mongodb=1:2.6.10-0ubuntu2
+  sudo: yes
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version == '16.04'
+
+- name: Install MongoDB 2.6.10
+  apt: pkg={{ item }} state=installed
+  with_items:
+    - mongodb
+  sudo: yes
+  when: ansible_distribution != 'Ubuntu'
 
 - name: Copy mongodb config file to home directory
   copy: src=mongodb.conf dest=/etc


### PR DESCRIPTION
Not the most elegant fix, but will probably do the job.  Just throwing this out there as a possible fix, take it or close it.  I will build off of my fork in the meantime until this bug is resolved.

It successfully installs MongoDB (default version 2.6.10) on Ubuntu 16.04 without failing.  I can't install the version desired because it is not available on 16.04.