### PR TITLE
remove ucsm-ip to disable UCS tests

### DIFF
--- a/test/config/stack_config.json
+++ b/test/config/stack_config.json
@@ -12,14 +12,12 @@
   "vagrant":{
     "rackhd_host": "localhost",
     "type": "vagrant",
-    "ucsm_ip" : "172.31.128.252",
     "ucs_service_uri" : "https://localhost:7080",
     "ucsm_config_file" : "./tests/ucs/ucsm_config.xml"
   },
   "hop_stack":{
     "rackhd_host": "localhost",
     "type": "vagrant",
-    "ucsm_ip" : "10.240.19.70",
     "ucs_service_uri" : "https://localhost:7080"
   },
 


### PR DESCRIPTION
This is a temporary fix for https://rackhd.atlassian.net/browse/RAC-5184.  The Docker and OVA tests are failing the UCS tests because the UCS-service is not included in either of these builds.  This change will disable the UCS tests.  They will be re-enabled once the UCS-service is include in the RackHD Docker and OVA builds.  

@RackHD/corecommitters 