### PR TITLE
[Skip CI] RAC-5200 restore back OVA mem size from 1G to 4G

### DIFF
--- a/packer/template-ubuntu-14.04.json
+++ b/packer/template-ubuntu-14.04.json
@@ -166,7 +166,7 @@
         "ssh_wait_timeout": "10000s",
         "shutdown_command": "echo 'shutdown -P now' > /tmp/shutdown.sh; echo 'vagrant'|sudo -S sh '/tmp/shutdown.sh'",
         "vmx_data": {
-            "memsize": "1024",
+            "memsize": "4096",
             "numvcpus": "2",
             "ethernet0.networkName": "NAT",
 
@@ -177,7 +177,7 @@
         },
         "vmx_data_post":
         {
-            "memsize": "1024",
+            "memsize": "4096",
             "numvcpus": "2",
             "cpuid.coresPerSocket": "1",
 

--- a/packer/template-ubuntu-16.04.json
+++ b/packer/template-ubuntu-16.04.json
@@ -163,7 +163,7 @@
         "ssh_wait_timeout": "10000s",
         "shutdown_command": "echo 'shutdown -P now' > /tmp/shutdown.sh; echo 'vagrant'|sudo -S sh '/tmp/shutdown.sh'",
         "vmx_data": {
-            "memsize": "1024",
+            "memsize": "4096",
             "numvcpus": "2",
             "ethernet0.networkName": "NAT",
 
@@ -174,7 +174,7 @@
         },
         "vmx_data_post":
         {
-            "memsize": "1024",
+            "memsize": "4096",
             "numvcpus": "2",
             "cpuid.coresPerSocket": "1",
 


### PR DESCRIPTION
**Why skip CI**
current PR Gate won't involve the packer build step

**Why this change**
Originally modified with this PR: https://github.com/RackHD/RackHD/commit/51121591a200c78c66f98075143cc65677685967
But accidentally,  it was overwritten with this PR: https://github.com/RackHD/RackHD/commit/5ba383d4bce6695ef1767d6b7fd612c961ddea54 

@keedya  @iceiilin @anhou @PengTian0 