### PR TITLE
Change the southbound API port to 8060 and fix the CRLF

### DIFF
--- a/test/config/imageservice_config.json
+++ b/test/config/imageservice_config.json
@@ -18,7 +18,7 @@
     "pwd": "onrack",
     "control_port":7070,
     "imageserver":"localhost",
-    "file_port":9090,
+    "file_port":8060,
     "filetocompare": 100
   }
 }


### PR DESCRIPTION
The code change is made due to the fact that in image service code, the southbound port is changed to 8060 in avoidance with vagrant testing environment.

https://github.com/RackHD/image-service/pull/7
@iceiilin @nortonluo @changev @pengz1