### PR TITLE
re-enable UCS FIT Tests

### DIFF
--- a/test/config/stack_config.json
+++ b/test/config/stack_config.json
@@ -12,12 +12,14 @@
   "vagrant":{
     "rackhd_host": "localhost",
     "type": "vagrant",
+    "ucsm_ip" : "172.31.128.252",
     "ucs_service_uri" : "https://localhost:7080",
     "ucsm_config_file" : "./tests/ucs/ucsm_config.xml"
   },
   "hop_stack":{
     "rackhd_host": "localhost",
     "type": "vagrant",
+    "ucsm_ip" : "10.240.19.70",
     "ucs_service_uri" : "https://localhost:7080"
   },
 


### PR DESCRIPTION
Signed-off-by: Kranti Uppala <k.uppala@>
@RackHD/corecommitters @RackHD/veyron 

UCS tests pass on OVA and FIT builds in sandbox:  http://10.240.19.232:8080/blue/organizations/jenkins/MasterCI/detail/MasterCI/237/pipeline