### PR TITLE
RAC-4965 - add additional stack configurations for running pipelines

### DIFF
--- a/test/config/stack_config.json
+++ b/test/config/stack_config.json
@@ -16,13 +16,19 @@
     "ucs_service_uri" : "https://localhost:7080",
     "ucsm_config_file" : "./tests/ucs/ucsm_config.xml"
   },
+  "vagrant_ucs":{
+    "rackhd_host": "localhost",
+    "type": "vagrant",
+    "ucsm_ip" : "172.31.128.252",
+    "ucs_service_uri" : "https://localhost:7080",
+    "ucsm_config_file" : "./tests/ucs/ucsm_config.xml"
+  },
   "hop_stack":{
     "rackhd_host": "localhost",
     "type": "vagrant",
     "ucsm_ip" : "10.240.19.70",
     "ucs_service_uri" : "https://localhost:7080"
   },
-
   "vagrant_remote": {
     "rackhd_host": "127.0.0.1",
     "type": "vagrant",
@@ -42,6 +48,38 @@
         "https": 8443,
         "amqp_ssl": 5672,
         "amqp_nossl": 5671
+      }
+    }
+  },
+  "docker": {
+    "rackhd_host": "localhost",
+    "ucsm_ip" : "172.31.128.252",
+    "ucs_service_uri" : "https://localhost:7080",
+    "ucsm_config_file" : "./tests/ucs/ucsm_config.xml",
+    "install-config": {
+      "ports": {
+        "mongo_port": 37017,
+        "http": 9090,
+        "https": 9093,
+        "amqp_ssl": 9091,
+        "amqp_nossl": 5671,
+        "ssh": 2222
+      }
+    }
+  },
+  "ova": {
+    "rackhd_host": "localhost",
+    "ucsm_ip" : "172.31.128.252",
+    "ucs_service_uri" : "https://localhost:7080",
+    "ucsm_config_file" : "./tests/ucs/ucsm_config.xml",
+    "install-config": {
+      "ports": {
+        "mongo_port": 37017,
+        "http": 9090,
+        "https": 9093,
+        "amqp_ssl": 9091,
+        "amqp_nossl": 5671,
+        "ssh": 2222
       }
     }
   }

--- a/test/tests/rackhd20/test_rackhd20_api_notifications.py
+++ b/test/tests/rackhd20/test_rackhd20_api_notifications.py
@@ -77,7 +77,7 @@ class test_alert_notification(unittest.TestCase):
     def setUpClass(self):
         if fit_common.fitargs()['stack'] == 'vagrant_guest':
             IP = "127.0.0.1"
-        elif fit_common.fitargs()['stack'] == 'vagrant':
+        elif fit_common.fitargs()['stack'] in ['vagrant', 'vagrant_ucs']:
             IP = "10.0.2.2"
         else:
             logs.info(" Not running in a vagrant environment, skipping tests")

--- a/test/tests/rackhd20/test_rackhd20_api_notifications.py
+++ b/test/tests/rackhd20/test_rackhd20_api_notifications.py
@@ -25,14 +25,14 @@ amqp_queue = Queue.Queue(maxsize=0)
 from pymongo import MongoClient
 from bson.objectid import ObjectId
 
-
-AMQP_PORT = fit_common.fitports()['amqp_ssl']
-MONGO_PORT = fit_common.fitports()['mongo_port']
-HTTP_PORT = fit_common.fitports()['http']
+# Check the running test environment
 if fit_common.fitargs()['stack'] in ['vagrant_guest', 'vagrant']:
     env_vagrant = True
 else:
     env_vagrant = False
+AMQP_PORT = fit_common.fitports()['amqp_ssl']
+MONGO_PORT = fit_common.fitports()['mongo_port']
+HTTP_PORT = fit_common.fitports()['http']
 
 
 class AmqpWorker(threading.Thread):
@@ -82,7 +82,6 @@ class test_alert_notification(unittest.TestCase):
         else:
             logs.info(" Not running in a vagrant environment, skipping tests")
             return
-        
         logs.debug_1("MONGO_PORT: {0}, AMQP_PORT: {1}, HTTP_PORT:{2}".format(MONGO_PORT, AMQP_PORT, HTTP_PORT))
         self.CLIENT = MongoClient('localhost', MONGO_PORT)
         self.db = self.CLIENT.pxe

--- a/test/tests/rackhd20/test_rackhd20_api_notifications.py
+++ b/test/tests/rackhd20/test_rackhd20_api_notifications.py
@@ -26,7 +26,7 @@ from pymongo import MongoClient
 from bson.objectid import ObjectId
 
 # Check the running test environment
-if fit_common.fitargs()['stack'] in ['vagrant_guest', 'vagrant']:
+if fit_common.fitargs()['stack'] in ['vagrant_guest', 'vagrant', 'vagrant_ucs']:
     env_vagrant = True
 else:
     env_vagrant = False


### PR DESCRIPTION
Updated the stack-config.json file with additional stacks.
Added docker, ova, and vagrant_ucs test stacks.
This allows us to configure the test beds differently for the deployments and run tests using proper setup.
Also allows easier skipping of tests, if we need, if not running in an expected deployment.

updates to on-build-config in separate PRs.
