### PR TITLE
RAC-5040 Removed UCS from 'vagrant' stack

### DIFF
--- a/test/config/stack_config.json
+++ b/test/config/stack_config.json
@@ -12,9 +12,6 @@
   "vagrant":{
     "rackhd_host": "localhost",
     "type": "vagrant",
-    "ucsm_ip" : "172.31.128.252",
-    "ucs_service_uri" : "https://localhost:7080",
-    "ucsm_config_file" : "./tests/ucs/ucsm_config.xml"
   },
   "vagrant_ucs":{
     "rackhd_host": "localhost",

--- a/test/config/stack_config.json
+++ b/test/config/stack_config.json
@@ -11,7 +11,7 @@
   },
   "vagrant":{
     "rackhd_host": "localhost",
-    "type": "vagrant",
+    "type": "vagrant"
   },
   "vagrant_ucs":{
     "rackhd_host": "localhost",


### PR DESCRIPTION
Removed UCS params from stack config to enable OS installs.

@johren @hohene @patelb10 