### PR TITLE
RAC-5043 increase ESXi timeout to 45 min

### DIFF
--- a/test/tests/bootstrap/test_api20_esxi_bootstrap.py
+++ b/test/tests/bootstrap/test_api20_esxi_bootstrap.py
@@ -51,7 +51,7 @@ if config:
 
 
 # this routine polls a workflow task ID for completion
-def wait_for_workflow_complete(instanceid, start_time, waittime=1800, cycle=30):
+def wait_for_workflow_complete(instanceid, start_time, waittime=2700, cycle=30):
     log.info_5(" Workflow started at time: " + str(start_time))
     while time.time() - start_time < waittime:  # limit test to waittime seconds
         result = fit_common.rackhdapi("/api/2.0/workflows/" + instanceid)


### PR DESCRIPTION
This PR increased ESXi OS install timeout to 45 minutes from 30. After this is merged we need to retest #210.

@johren @patelb10 
