### PR TITLE
modify the image service test configuration to suite testing env

### DIFF
--- a/test/config/imageservice_config.json
+++ b/test/config/imageservice_config.json
@@ -9,10 +9,10 @@
       }
     ],
     "microkernel": [
-      "scp:///var/renasar/on-http/static/http/common/vmlinuz-3.16.0-25-generic",
-      "scp:///var/renasar/on-http/static/http/common/discovery.overlay.cpio.gz",
-      "scp:///var/renasar/on-http/static/http/common/initrd.img-3.16.0-25-generic",
-      "scp:///var/renasar/on-http/static/http/common/base.trusty.3.16.0-25-generic.squashfs.img"
+      "scp:///home/vagrant/src/on-http/static/http/common/vmlinuz-3.16.0-25-generic",
+      "scp:///home/vagrant/src/on-http/static/http/common/discovery.overlay.cpio.gz",
+      "scp:///home/vagrant/src/on-http/static/http/common/initrd.img-3.16.0-25-generic",
+      "scp:///home/vagrant/src/on-http/static/http/common/base.trusty.3.16.0-25-generic.squashfs.img"
     ],
     "usr": "onrack",
     "pwd": "onrack",


### PR DESCRIPTION
As PR-Gate and Master CI are using virtual machines instead of physical stack for testing, the directory where the static files are stores are /home/vagrant/src/on-http/common instead of /var/renasar/on-http/static/common, change the configuration code accordingly. Note: further change might be required when using docker or all-in-one solution. 