### PR TITLE
Use port 8080 instead of 9080 for the image repo

### DIFF
--- a/test/config/install_centos65_minimum.json
+++ b/test/config/install_centos65_minimum.json
@@ -2,7 +2,7 @@
     {"name": "Graph.InstallCentOS",
         "options": {"defaults": {
         "version": "6.5",
-        "repo": "http://172.31.128.1:9080/repo/centos/6.5",
+        "repo": "http://172.31.128.1:8080/repo/centos/6.5",
         "rootPassword": "1234567",
         "hostname": "rackhdnode",
         "users": [{"name": "rackhduser",

--- a/test/config/install_centos70_minimum.json
+++ b/test/config/install_centos70_minimum.json
@@ -2,7 +2,7 @@
     {"name": "Graph.InstallCentOS",
         "options": {"defaults": {
         "version": "7",
-        "repo": "http://172.31.128.1:9080/repo/centos/7.0",
+        "repo": "http://172.31.128.1:8080/repo/centos/7.0",
         "rootPassword": "1234567",
         "hostname": "rackhdnode",
         "users": [{"name": "rackhduser",

--- a/test/config/install_coreos_minimum.json
+++ b/test/config/install_coreos_minimum.json
@@ -2,7 +2,7 @@
     {"name": "Graph.InstallCoreOS",
         "options": {"defaults": {
         "version": "899.17.0",
-        "repo": "http://172.31.128.1:9080/repo/coreos",
+        "repo": "http://172.31.128.1:8080/repo/coreos",
         "rootPassword": "1234567",
         "hostname": "rackhdnode",
         "users": [{"name": "rackhduser",

--- a/test/config/install_esxi5.5_minimum.json
+++ b/test/config/install_esxi5.5_minimum.json
@@ -2,7 +2,7 @@
     {"name": "Graph.InstallESXi",
         "options": {"defaults": {
         "version": "5.5",
-        "repo": "http://172.31.128.1:9080/repo/esxi/5.5",
+        "repo": "http://172.31.128.1:8080/repo/esxi/5.5",
         "rootPassword": "1234567",
         "hostname": "rackhdnode",
         "users": [{"name": "rackhduser",

--- a/test/config/install_esxi6.0_minimum.json
+++ b/test/config/install_esxi6.0_minimum.json
@@ -2,7 +2,7 @@
     {"name": "Graph.InstallESXi",
         "options": {"defaults": {
         "version": "6",
-        "repo": "http://172.31.128.1:9080/repo/esxi/6.0",
+        "repo": "http://172.31.128.1:8080/repo/esxi/6.0",
         "rootPassword": "1234567",
         "hostname": "rackhdnode",
         "users": [{"name": "rackhduser",

--- a/test/config/install_opensuse42.1_minimum.json
+++ b/test/config/install_opensuse42.1_minimum.json
@@ -2,7 +2,7 @@
     {"name": "Graph.InstallSUSE",
         "options": {"defaults": {
         "version": "42.1",
-        "repo": "http://172.31.128.1:9080/repo/suse/42.1",
+        "repo": "http://172.31.128.1:8080/repo/suse/42.1",
         "rootPassword": "1234567",
         "hostname": "rackhdnode",
         "users": [{"name": "rackhduser",

--- a/test/config/install_ubuntu14.04_minimum.json
+++ b/test/config/install_ubuntu14.04_minimum.json
@@ -2,9 +2,9 @@
     {"name": "Graph.InstallUbuntu",
         "options": {"defaults": {
         "version": "trusty",
-        "repo": "http://172.31.128.1:9080/repo/ubuntu",
+        "repo": "http://172.31.128.1:8080/repo/ubuntu",
         "baseUrl": "install/netboot/ubuntu-installer/amd64",
-        "kargs": {"live-installer/net-image": "http://172.31.128.1:9080/repo/ubuntu/ubuntu/install/filesystem.squashfs"},
+        "kargs": {"live-installer/net-image": "http://172.31.128.1:8080/repo/ubuntu/ubuntu/install/filesystem.squashfs"},
         "rootPassword": "1234567",
         "hostname": "rackhdnode",
         "users": [{"name": "rackhduser",


### PR DESCRIPTION
This PR is just to try running PR gates while accessing the image repo on port 8080 instead of port 9080.