### PR TITLE
Fix: Failed testing WorkflowTasksTests.test_workflowTasks_put

### DIFF
--- a/test/tests/api-cit/v2_0/workflowTasks_tests.py
+++ b/test/tests/api-cit/v2_0/workflowTasks_tests.py
@@ -71,8 +71,12 @@ class WorkflowTasksTests(fit_common.unittest.TestCase):
 
         # Validating the content is as expected
         rawj = loads(self.__client.last_response.data)
-        readWorkflowTask = rawj[len(rawj) - 1]
-        readFriendlyName = readWorkflowTask.get('friendlyName')
-        readInjectableName = readWorkflowTask.get('injectableName')
-        self.assertEqual(readFriendlyName, self.workflowTaskDict.get('friendlyName'))
-        self.assertEqual(readInjectableName, self.workflowTaskDict.get('injectableName'))
+        found = False
+        for i, val in enumerate(rawj):
+            if (self.workflowTaskDict.get('friendlyName') == str(rawj[i].get('friendlyName')) \
+            and self.workflowTaskDict.get('injectableName') == str(rawj[i].get('injectableName'))):
+                found = True
+                break
+
+        # Validating that the task has been added
+        self.assertTrue(found, 'Could not find new workflow task!')

--- a/test/tests/api/v2_0/workflowTasks_tests.py
+++ b/test/tests/api/v2_0/workflowTasks_tests.py
@@ -69,10 +69,13 @@ class WorkflowTasksTests(object):
         assert_equal(workflowTasksAfter,workflowTasksBefore+1)
 
         #Validating the content is as expected
-        rawj=  json.loads(self.__client.last_response.data)
-        listLen =len(json.loads(self.__client.last_response.data))
-        readWorkflowTask= rawj[len(rawj)-1]
-        readFriendlyName= readWorkflowTask.get('friendlyName')
-        readInjectableName  = readWorkflowTask.get('injectableName')
-        assert_equal(readFriendlyName,self.workflowTaskDict.get('friendlyName'))
-        assert_equal(readInjectableName,self.workflowTaskDict.get('injectableName'))
+        rawj = json.loads(self.__client.last_response.data)
+        found = False
+        for i, val in enumerate(rawj):
+            if (self.workflowTaskDict.get('friendlyName') == str(rawj[i].get('friendlyName')) \
+            and self.workflowTaskDict.get('injectableName') == str(rawj[i].get('injectableName'))):
+                found = True
+                break
+
+        # Validating that the task has been added
+        assert_true(found, message='Could not find new workflow task!')


### PR DESCRIPTION
The test job for "replacing vagrant with docker" is failed at case : "workflowTasks_tests.WorkflowTasksTests.test_workflowTasks_put".
The failure rate of the case is 1/155
Link of the failed link: http://rackhdci.lss.emc.com/job/DockerTest/150/

Root cause:
The test case adds a task to the database taskdefinitions, then get all the task definitions and check whether the last one is just the added one.
But the result of "getting all the task definitions" is not sorted, so sometimes the case failed.

@anhou @iceiilin @panpan0000  