### PR TITLE
Use wget to download the files to speed up tests

### DIFF
--- a/test/tests/imageserver/test_image_service_system.py
+++ b/test/tests/imageserver/test_image_service_system.py
@@ -17,6 +17,7 @@ import fit_common
 import urllib2
 import pexpect
 import unittest
+import subprocess
 import test_api_utils
 from nose.plugins.attrib import attr
 logs = flogging.get_loggers()
@@ -212,7 +213,7 @@ class test_image_service_system(fit_common.unittest.TestCase):
             file_size = int(meta.getheaders("Content-Length")[0])
             logs.debug_3("Downloading: %s Bytes: %s" % (file_name, file_size))
             file_size_dl = 0
-            block_sz = 8192
+            block_sz = 2097152
             while True:
                 file_buffer = u.read(block_sz)
                 if not file_buffer:
@@ -227,6 +228,7 @@ class test_image_service_system(fit_common.unittest.TestCase):
             f.close()
         return file_name
 
+
     def _upload_all_microkernels(self):
         for microkernelrepo in fit_common.fitcfg()["image_service"]["microkernel"]:
             if microkernelrepo[:3] == "scp":
@@ -239,7 +241,7 @@ class test_image_service_system(fit_common.unittest.TestCase):
     def _release(self, file_name):
         try:
             logs.debug_3("rm " + file_name)
-            os.system("rm " + file_name)
+            subprocess.check_output("rm " + file_name, shell=True)
             return True
         except OSError:
             return False

--- a/test/tests/imageserver/test_microkernel_image_service.py
+++ b/test/tests/imageserver/test_microkernel_image_service.py
@@ -15,6 +15,7 @@ import flogging
 import pexpect
 import fit_common
 import unittest
+import subprocess
 from nose.plugins.attrib import attr
 logs = flogging.get_loggers()
 
@@ -38,7 +39,7 @@ class static_microkernel_image_service(fit_common.unittest.TestCase):
     def _release(self, file_name):
         try:
             logs.debug_3("rm " + file_name)
-            os.system("rm " + file_name)
+            subprocess.check_output("rm " + file_name, shell=True)
             return True
         except OSError:
             return False
@@ -53,7 +54,7 @@ class static_microkernel_image_service(fit_common.unittest.TestCase):
             file_size = int(meta.getheaders("Content-Length")[0])
             logs.debug_3("Downloading: %s Bytes: %s" % (file_name, file_size))
             file_size_dl = 0
-            block_sz = 8192
+            block_sz = 2097152
             while True:
                 file_buffer = u.read(block_sz)
                 if not file_buffer:

--- a/test/tests/imageserver/test_os_image_service.py
+++ b/test/tests/imageserver/test_os_image_service.py
@@ -38,10 +38,10 @@ class test_os_image_service(fit_common.unittest.TestCase):
         try:
             if os.path.exists(mountpoint) is False:
                 command = "mkdir " + mountpoint,
-                subprocess.check_output(command,shell=True)
+                subprocess.check_output(command, shell=True)
             # use fuseiso tool to mount without root privilege. user need install fuseiso before the test.
             command = "fuseiso " + file_name + " " + mountpoint
-            subprocess.check_output(command,shell=True)
+            subprocess.check_output(command, shell=True)
             return True
         except OSError:
             return False


### PR DESCRIPTION
Before the  code change, it took nearly half an hour to download on-http static files from the website. With the code change, the time is reduced to around 700s.  Also the cases with problem is fixed in the PR. @nortonluo   