### PR TITLE
RAC-4965 Turned back on test_rackhd20_api_notifications to smoke test

### DIFF
--- a/test/tests/rackhd20/test_rackhd20_api_notifications.py
+++ b/test/tests/rackhd20/test_rackhd20_api_notifications.py
@@ -66,7 +66,7 @@ class AmqpWorker(threading.Thread):
         self.channel.start_consuming()
 
 
-@attr(all=True, regression=False, smoke=False)
+@attr(all=True, regression=False, smoke=True)
 class test_alert_notification(unittest.TestCase):
     CLIENT = None
     CATALOGS_COUNT = None


### PR DESCRIPTION
This PR turned back on test_rackhd20_api_notifications test on vagrant base stack