### PR TITLE
RAC-4091 Add autoCreateObm:true to all instances of config.json

### DIFF
--- a/docker/monorail/config.json
+++ b/docker/monorail/config.json
@@ -7,6 +7,7 @@
     "authTokenExpireIn": 86400,
     "authTokenSecret": "RackHDRocks!",
     "authUsername": "admin",
+    "autoCreateObm": "true",
     "dhcpLeasesPath": "/var/lib/dhcp/dhcpd.leases",
     "dhcpGateway": "172.31.128.1",
     "dhcpProxyBindAddress": "0.0.0.0",

--- a/packer/ansible/roles/monorail/files/config.json
+++ b/packer/ansible/roles/monorail/files/config.json
@@ -55,6 +55,7 @@
     "authPasswordSalt": "zlxkgxjvcFwm0M8sWaGojh25qNYO8tuNWUMN4xKPH93PidwkCAvaX2JItLA3p7BSCWIzkw4GwWuezoMvKf3UXg==",
     "authTokenSecret": "RackHDRocks!",
     "authTokenExpireIn": 86400,
+    "autoCreateObm": "true",
     "mongo": "mongodb://localhost/pxe",
     "sharedKey": "qxfO2D3tIJsZACu7UA6Fbw0avowo8r79ALzn+WeuC8M=",
     "statsd": "127.0.0.1:8125",

--- a/test/config/rackhd_default.json
+++ b/test/config/rackhd_default.json
@@ -3,6 +3,7 @@
     "amqp": "amqp://localhost",
     "apiServerAddress": "172.31.128.1",
     "apiServerPort": 9080,
+    "autoCreateObm": "true",
     "dhcpPollerActive": false,
     "dhcpGateway": "172.31.128.1",
     "dhcpProxyBindAddress": "172.31.128.1",


### PR DESCRIPTION
Add autoCreateObm:true to config.json to utilize the modern OBM generation routine.

After this is merged, then the 'appy OBM settings' routine will be removed from stack init.

Paired with Beena

@jimturnquist @patelb10 @hohene