### PR TITLE
RAC-5603 update sel logs test to exclude empty 'message' field

### DIFF
--- a/test/tests/redfish10/test_redfish10_api_systems.py
+++ b/test/tests/redfish10/test_redfish10_api_systems.py
@@ -224,7 +224,10 @@ class redfish10_api_systems(fit_common.unittest.TestCase):
                     self.assertIn(item, nodeid, item + ' field not present')
                     if fit_common.VERBOSITY >= 3:
                         print ("\t {0}".format(nodeid[item]))
-                    self.assertGreater(len(nodeid[item]), 0, item + ' field empty')
+                    if len(nodeid[item]) == 0 and item == 'Message':
+                        print "empty message"
+                    else:
+                        self.assertGreater(len(nodeid[item]), 0, item + ' field empty')
                 for link in [ 'OriginOfCondition' ]:
 
                     if fit_common.VERBOSITY >= 2:
@@ -262,7 +265,10 @@ class redfish10_api_systems(fit_common.unittest.TestCase):
                     self.assertIn(item, seldata['json'], item + ' field not present')
                     if fit_common.VERBOSITY >= 3:
                         print ("\t {0}".format(seldata['json'][item]))
-                    self.assertGreater(len(seldata['json'][item]), 0, item + ' field empty')
+                    if len(seldata['json'][item]) == 0 and item == 'Message':
+                        print "message empty"
+                    else:
+                        self.assertGreater(len(seldata['json'][item]), 0, item + ' field empty')
 
                 for link in [ 'OriginOfCondition' ]:
                     if fit_common.VERBOSITY >= 2:

--- a/test/tests/redfish10/test_redfish10_api_systems.py
+++ b/test/tests/redfish10/test_redfish10_api_systems.py
@@ -227,7 +227,8 @@ class redfish10_api_systems(fit_common.unittest.TestCase):
                     if fit_common.VERBOSITY >= 3:
                         print ("\t {0}".format(nodeid[item]))
                     if len(nodeid[item]) == 0 and item == 'Message':
-                        log.info_5("Message field empty for SEL SensorType:" + nodeid['SensorType'] + " SensorNumber:" + str(nodeid['SensorNumber']))
+                        log.info_5("Message field empty for SEL SensorType:" + nodeid['SensorType'] +
+                                   " SensorNumber:" + str(nodeid['SensorNumber']))
                     else:
                         self.assertGreater(len(nodeid[item]), 0, item + ' field empty')
                 for link in [ 'OriginOfCondition' ]:
@@ -268,7 +269,8 @@ class redfish10_api_systems(fit_common.unittest.TestCase):
                     if fit_common.VERBOSITY >= 3:
                         print ("\t {0}".format(seldata['json'][item]))
                     if len(seldata['json'][item]) == 0 and item == 'Message':
-                        log.info_5("Message field empty for SEL SensorType:" + seldata['json']['SensorType'] + " SensorNumber:" + str(seldata['json']['SensorNumber']))
+                        log.info_5("Message field empty for SEL SensorType:" + seldata['json']['SensorType'] +
+                                   " SensorNumber:" + str(seldata['json']['SensorNumber']))
                     else:
                         self.assertGreater(len(seldata['json'][item]), 0, item + ' field empty')
 

--- a/test/tests/redfish10/test_redfish10_api_systems.py
+++ b/test/tests/redfish10/test_redfish10_api_systems.py
@@ -11,6 +11,8 @@ import os
 import sys
 import subprocess
 import fit_common
+import flogging
+log = flogging.get_loggers()
 
 
 # Local methods
@@ -225,7 +227,7 @@ class redfish10_api_systems(fit_common.unittest.TestCase):
                     if fit_common.VERBOSITY >= 3:
                         print ("\t {0}".format(nodeid[item]))
                     if len(nodeid[item]) == 0 and item == 'Message':
-                        print "empty message"
+                        log.info_5("Message field empty for SEL SensorType:" + nodeid['SensorType'] + " SensorNumber:" + str(nodeid['SensorNumber']))
                     else:
                         self.assertGreater(len(nodeid[item]), 0, item + ' field empty')
                 for link in [ 'OriginOfCondition' ]:
@@ -266,7 +268,7 @@ class redfish10_api_systems(fit_common.unittest.TestCase):
                     if fit_common.VERBOSITY >= 3:
                         print ("\t {0}".format(seldata['json'][item]))
                     if len(seldata['json'][item]) == 0 and item == 'Message':
-                        print "message empty"
+                        log.info_5("Message field empty for SEL SensorType:" + seldata['json']['SensorType'] + " SensorNumber:" + str(seldata['json']['SensorNumber']))
                     else:
                         self.assertGreater(len(seldata['json'][item]), 0, item + ' field empty')
 


### PR DESCRIPTION
We have determined that an empty SEL 'message' field is normal under certain circumstances. Test was asserting on an empty message, which is a false failure.

In the event of an empty SEL 'message' field, the test will now issue an INFO message containing SensorType and SensorNumber rather than an assert. 
