### PR TITLE
RAC-5635: Add docker hub dummy credentials

### DIFF
--- a/test/config/credentials_default.json
+++ b/test/config/credentials_default.json
@@ -68,6 +68,12 @@
         "username": "onrack",
         "password": "onrack"
       }
+    ],
+    "docker_hub": [
+      {
+        "username": "dummy",
+        "password": "dummy"
+      }
     ]
   }
 }


### PR DESCRIPTION
Add docker hub dummy credentials in credentials_default.json
@manfrednde @jimturnquist 