### PR TITLE
RAC-5607 Ubuntu maximum OS install payload

### DIFF
--- a/test/config/install_ubuntu14.04_maximum_QuantaT41.json
+++ b/test/config/install_ubuntu14.04_maximum_QuantaT41.json
@@ -1,0 +1,41 @@
+{
+    "bootstrap-payload": {
+        "name": "Graph.InstallUbuntu",
+        "options": {
+        "defaults": {
+            "version": "trusty",
+            "repo": "http://172.31.128.1:9080/repo/ubuntu",
+            "baseUrl": "install/netboot/ubuntu-installer/amd64",
+            "kargs": {
+                    "live-installer/net-image": "http://172.31.128.1:9080/repo/ubuntu/ubuntu/install/filesystem.squashfs"
+                },
+            "rootPassword": "RackHDRocks!",
+            "hostname": "rackhd-node",
+            "domain": "example.com",
+            "users": [
+                {
+                    "name": "rackhd1",
+                    "password": "123456",
+                    "uid": 1010,
+                    "sshKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDJQ631/sw3D40h/6JfA+PFVy5Ofz6eu7caxbv0zdw4fTJsrFcOliHZTEtAvqx7Oa8gqSC6d7v61M0croQxtt1DGUcH2G4yhfdZOlK4pr5McwtX0T/APACdAr1HtP7Bt7u43mgHpUG4bHGc+NoY7cWCISkxl4apkYWbvcoJy/5bQn0uRgLuHUNXxK/XuLT5vG76xxY+1xRa5+OIoJ6l78nglNGrj2V+jH3+9yZxI43S9I3NOCl4BvX5Cp3CFMHyt80gk2yM1BJpQZZ4GHewkI/XOIFPU3rR5+toEYXHz7kzykZsqt1PtbaTwG3TX9GJI4C7aWyH9H+9Bt76vH/pLBIn rackhd@rackhd-demo"
+                },
+                {
+                    "name": "rackhd2",
+                    "password": "123456",
+                    "uid": 1011,
+                    "sshKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDJQ631/sw3D40h/6JfA+PFVy5Ofz6eu7caxbv0zdw4fTJsrFcOliHZTEtAvqx7Oa8gqSC6d7v61M0croQxtt1DGUcH2G4yhfdZOlK4pr5McwtX0T/APACdAr1HtP7Bt7u43mgHpUG4bHGc+NoY7cWCISkxl4apkYWbvcoJy/5bQn0uRgLuHUNXxK/XuLT5vG76xxY+1xRa5+OIoJ6l78nglNGrj2V+jH3+9yZxI43S9I3NOCl4BvX5Cp3CFMHyt80gk2yM1BJpQZZ4GHewkI/XOIFPU3rR5+toEYXHz7kzykZsqt1PtbaTwG3TX9GJI4C7aWyH9H+9Bt76vH/pLBIn rackhd@rackhd-demo"
+                }
+            ],
+            "rootSshKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDJQ631/sw3D40h/6JfA+PFVy5Ofz6eu7caxbv0zdw4fTJsrFcOliHZTEtAvqx7Oa8gqSC6d7v61M0croQxtt1DGUcH2G4yhfdZOlK4pr5McwtX0T/APACdAr1HtP7Bt7u43mgHpUG4bHGc+NoY7cWCISkxl4apkYWbvcoJy/5bQn0uRgLuHUNXxK/XuLT5vG76xxY+1xRa5+OIoJ6l78nglNGrj2V+jH3+9yZxI43S9I3NOCl4BvX5Cp3CFMHyt80gk2yM1BJpQZZ4GHewkI/XOIFPU3rR5+toEYXHz7kzykZsqt1PtbaTwG3TX9GJI4C7aWyH9H+9Bt76vH/pLBIn rackhd@rackhd-demo",
+            "dnsServers": [
+                "172.12.88.91",
+                "192.168.20.77"
+            ],
+            "installDisk": "/dev/sda",
+            "reboot": "ipmi-obm-service",
+            "set-boot-pxe": "ipmi-obm-service"
+        }
+     } 
+  }
+}
+


### PR DESCRIPTION
Submitting Ubuntu max payload with NIC parameters omitted. Found bug RAC-5684 in Ubuntu NIC parameters, so this is the maximum working payload as of submission date.

@jimturnquist @larry-dean