### PR TITLE
RAC-5682 - Redfish Compliance, correct systems/ethernetinterface odata links for non-dell

### DIFF
--- a/test/tests/redfish10/test_redfish10_api_systems.py
+++ b/test/tests/redfish10/test_redfish10_api_systems.py
@@ -149,10 +149,7 @@ class redfish10_api_systems(fit_common.unittest.TestCase):
         # Only works for Dell servers with microservices
         for nodeid in NODECATALOG:
             api_data = fit_common.rackhdapi('/redfish/v1/Systems/' + nodeid + '/EthernetInterfaces')
-            if fit_common.is_dell_node(nodeid):
-                self.assertIn(api_data['status'], [200], 'Expected 200, got:' + str(api_data['status']))
-            else:
-                self.assertIn(api_data['status'], [404], 'Expected 404, got:' + str(api_data['status']))
+            self.assertIn(api_data['status'], [200], 'Expected 200, got:' + str(api_data['status']))
 
     def test_redfish_v1_systems_id_bios(self):
         # Only works for Dell servers with microservices

--- a/test/tests/redfish10/test_redfish10_api_systems.py
+++ b/test/tests/redfish10/test_redfish10_api_systems.py
@@ -146,7 +146,7 @@ class redfish10_api_systems(fit_common.unittest.TestCase):
                     self.assertNotEqual(item, "", 'Empty JSON Field')
 
     def test_redfish_v1_systems_id_ethernetinterfaces(self):
-        # Only works for Dell servers with microservices
+        # Will produce a list of available Ethernet interfaces
         for nodeid in NODECATALOG:
             api_data = fit_common.rackhdapi('/redfish/v1/Systems/' + nodeid + '/EthernetInterfaces')
             self.assertIn(api_data['status'], [200], 'Expected 200, got:' + str(api_data['status']))


### PR DESCRIPTION
* Correct tests to allow ethernetinterfaces for non-dell devices