### PR TITLE
RAC-5835 Add more debug info for workflow

### DIFF
--- a/test/common/fit_common.py
+++ b/test/common/fit_common.py
@@ -979,11 +979,11 @@ def check_active_workflows(nodeid):
 
 def cancel_active_workflows(nodeid):
     # cancel all active workflows on node
-    exitstatus = True
+    exitstatus = False
     apistatus = rackhdapi('/api/2.0/nodes/' + nodeid + '/workflows/action',
                           action='put', payload={"command": "cancel"})['status']
-    if apistatus != 202:
-        exitstatus = False
+    if apistatus == 202 or apistatus == 404:
+        exitstatus = True
     return exitstatus
 
 

--- a/test/tests/bootstrap/test_api20_esxi_bootstrap.py
+++ b/test/tests/bootstrap/test_api20_esxi_bootstrap.py
@@ -30,8 +30,10 @@ import fit_path  # NOQA: unused import
 from nose.plugins.attrib import attr
 import fit_common
 import flogging
+import json
 import random
 import time
+from datetime import datetime
 from nosedep import depends
 log = flogging.get_loggers()
 
@@ -50,9 +52,23 @@ if config:
     PAYLOAD = config
 
 
+# function to return the value of a field from the workflow response
+def findall(obj, key):
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if k == key:
+                log.error(" workflow error: %s", v)
+            findall(v, key)
+    elif isinstance(obj, list):
+        for item in obj:
+            findall(item, key)
+    else:
+        pass
+
+
 # this routine polls a workflow task ID for completion
 def wait_for_workflow_complete(instanceid, start_time, waittime=7200, cycle=30):
-    log.info_5(" Workflow started at time: " + str(start_time))
+    log.info_1(" Workflow started at time: " + str(datetime.fromtimestamp(start_time)))
     while time.time() - start_time < waittime:  # limit test to waittime seconds
         result = fit_common.rackhdapi("/api/2.0/workflows/" + instanceid)
         if result['status'] != 200:
@@ -62,13 +78,28 @@ def wait_for_workflow_complete(instanceid, start_time, waittime=7200, cycle=30):
             log.info_5("{} workflow status: {}".format(result['json']['injectableName'], result['json']['status']))
             fit_common.time.sleep(cycle)
         elif result['json']['status'] == 'succeeded':
-            log.info_5("{} workflow status: {}".format(result['json']['injectableName'], result['json']['status']))
-            log.info_5(" Workflow completed at time: " + str(time.time()))
+            log.info_1("{} workflow status: {}".format(result['json']['injectableName'], result['json']['status']))
+            end_time = time.time()
+            log.info_1(" Workflow completed at time: " + str(datetime.fromtimestamp(end_time)))
+            log.info_1(" Workflow duration: " + str(end_time - start_time))
             return True
         else:
-            log.error(" Workflow failed: status: %s text: %s", result['json']['status'], result['text'])
+            end_time = time.time()
+            log.info_1(" Workflow failed at time: " + str(datetime.fromtimestamp(end_time)))
+            log.info_1(" Workflow duration: " + str(end_time - start_time))
+            try:
+                res = json.loads(result['text'])
+                findall(res, "error")
+            except:
+                res = result['text']
+            log.error(" Workflow failed: status: %s", result['json']['status'])
+            log.error(" Data: %s", json.dumps(res, indent=4, separators=(',', ':')))
             return False
-    log.error(" Workflow Timeout: " + result['text'])
+    try:
+        res = json.loads(result['text'])
+    except:
+        res = result['text']
+    log.error(" Workflow Timeout: " + json.dumps(res, indent=4, separators=(',', ':')))
     return False
 
 
@@ -81,18 +112,39 @@ class api20_bootstrap_esxi(fit_common.unittest.TestCase):
     def setUpClass(cls):
         # Get the list of nodes
         NODECATALOG = fit_common.node_select()
+        assert (len(NODECATALOG) != 0), "There are no nodes currently discovered"
+
         # Select one node at random
         cls.__NODE = NODECATALOG[random.randint(0, len(NODECATALOG) - 1)]
+
+        # Print node Id, node BMC mac ,node type
+        nodeinfo = fit_common.rackhdapi('/api/2.0/nodes/' + cls.__NODE)['json']
+        nodesku = fit_common.rackhdapi(nodeinfo.get('sku'))['json']['name']
+        monurl = "/api/2.0/nodes/" + cls.__NODE + "/catalogs/bmc"
+        mondata = fit_common.rackhdapi(monurl, action="get")
+        catalog = mondata['json']
+        bmcresult = mondata['status']
+        if bmcresult != 200:
+            log.info_1(" Node ID: " + cls.__NODE)
+            log.info_1(" Error on catalog/bmc command")
+        else:
+            log.info_1(" Node ID: " + cls.__NODE)
+            log.info_1(" Node SKU: " + nodesku)
+            log.info_1(" Node BMC Mac: %s", catalog.get('data')['MAC Address'])
+            log.info_1(" Node BMC IP Addr: %s", catalog.get('data')['IP Address'])
+            log.info_1(" Node BMC IP Addr Src: %s", catalog.get('data')['IP Address Source'])
+
         # delete active workflows for specified node
-        fit_common.cancel_active_workflows(cls.__NODE)
+        result = fit_common.cancel_active_workflows(cls.__NODE)
+        assert (result is True), "There are still some active workflows running against the node"
 
     def test01_node_check(self):
         # Log node data
         nodeinfo = fit_common.rackhdapi('/api/2.0/nodes/' + self.__class__.__NODE)['json']
         nodesku = fit_common.rackhdapi(nodeinfo.get('sku'))['json']['name']
-        log.info_5(" Node ID: " + self.__class__.__NODE)
-        log.info_5(" Node SKU: " + nodesku)
-        log.info_5(" Graph Name: " + PAYLOAD['name'])
+        log.info_1(" Node ID: " + self.__class__.__NODE)
+        log.info_1(" Node SKU: " + nodesku)
+        log.info_1(" Graph Name: Graph.PowerOn.Node")
 
         # Ensure the compute node is powered on and reachable
         result = fit_common.rackhdapi('/api/2.0/nodes/' +
@@ -105,6 +157,14 @@ class api20_bootstrap_esxi(fit_common.unittest.TestCase):
 
     @depends(after=test01_node_check)
     def test02_os_install(self):
+        # Log node data
+        nodeinfo = fit_common.rackhdapi('/api/2.0/nodes/' + self.__class__.__NODE)['json']
+        nodesku = fit_common.rackhdapi(nodeinfo.get('sku'))['json']['name']
+        log.info_1(" Node ID: " + self.__class__.__NODE)
+        log.info_1(" Node SKU: " + nodesku)
+        log.info_1(" Graph Name: Graph.InstallESXi")
+        log.info_1(" Payload: " + fit_common.json.dumps(PAYLOAD))
+
         # launch workflow
         workflowid = None
         result = fit_common.rackhdapi('/api/2.0/nodes/' +
@@ -113,13 +173,11 @@ class api20_bootstrap_esxi(fit_common.unittest.TestCase):
                                       action='post', payload=PAYLOAD)
         if result['status'] == 201:
             # workflow running
-            log.info_5(" InstanceID: " + result['json']['instanceId'])
-            log.info_5(" Payload: " + fit_common.json.dumps(PAYLOAD))
+            log.info_1(" InstanceID: " + result['json']['instanceId'])
             workflowid = result['json']['instanceId']
         else:
             # workflow failed with response code
             log.error(" InstanceID: " + result['text'])
-            log.error(" Payload: " + fit_common.json.dumps(PAYLOAD))
             self.fail("Workflow failed with response code: " + result['status'])
         self.assertTrue(wait_for_workflow_complete(workflowid, time.time()), "OS Install workflow failed, see logs.")
 


### PR DESCRIPTION

Here is sample output with the added debug info:
```
(fit)ndetau@lab01:~/Dev/rac-5835/RackHD/test$ ./run_tests.py -stack 14 -config config-mn -test tests/bootstrap/test_api20_esxi_bootstrap.py -nodeid 5988bd64df3287057100f6b6 
*** Using config file path: config-mn
*** Created config file: config-mn/generated/fit-config-20170810-183007
*** Using config file: config-mn/generated/fit-config-20170810-183007
2017-08-10 18:30:08,940 INFO    removing previous logging dir /emc/ndetau/Dev/rac-5835/RackHD/test/log_output/run_2017-08-10_16:53:59.d infra.run **.** 19499 MainProcess stream-monitor/flogging/infra_logging.py:__init__@148 gl-main [any tests]
2017-08-10 18:30:08,941 INFO    this runs logging dir /emc/ndetau/Dev/rac-5835/RackHD/test/log_output/run_2017-08-10_18:30:08.d infra.run **.** 19499 MainProcess stream-monitor/flogging/infra_logging.py:__init__@148 gl-main [any tests]
2017-08-10 18:30:08,942 INFO     Start Of Test Block: 1                                                                    root 
*** Reloading config file: config-mn/generated/fit-config-20170810-183007
restful: Action =  post , URL =  https://stack14-ora.admin:443/login
/emc/ndetau/Dev/rac-5835/RackHD/test/.venv/fit/local/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py:791: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.org/en/latest/security.html
  InsecureRequestWarning)
restful: Status code = 200 

restful: Action =  post , URL =  https://stack14-ora.admin:443/login
/emc/ndetau/Dev/rac-5835/RackHD/test/.venv/fit/local/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py:791: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.org/en/latest/security.html
  InsecureRequestWarning)
restful: Status code = 200 

restful: Action =  post , URL =  https://stack14-ora.admin:443/redfish/v1/SessionService/Sessions
/emc/ndetau/Dev/rac-5835/RackHD/test/.venv/fit/local/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py:791: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.org/en/latest/security.html
  InsecureRequestWarning)
restful: Status code = 200 

restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/nodes/5988bd64df3287057100f6b6
restful: Status code = 200 

restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/skus/f2f8b16a-ac6d-4ee5-bf26-571aae9a077d
restful: Status code = 200 

restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/nodes/5988bd64df3287057100f6b6/catalogs/bmc
restful: Status code = 200 

2017-08-10 18:30:15,187 INFO_1   Node ID: 5988bd64df3287057100f6b6                                                         test.run 
2017-08-10 18:30:15,188 INFO_1   Node SKU: Quanta D51 2U                                                                   test.run 
2017-08-10 18:30:15,188 INFO_1   Node BMC Mac: 2c:60:0c:83:74:be                                                           test.run 
2017-08-10 18:30:15,189 INFO_1   Node BMC IP Addr: 172.31.128.8                                                            test.run 
2017-08-10 18:30:15,189 INFO_1   Node BMC IP Addr Src: DHCP Address                                                        test.run 
restful: Action =  put , URL =  http://stack14-ora.admin:8080/api/2.0/nodes/5988bd64df3287057100f6b6/workflows/action
restful: Status code = 404 

2017-08-10 18:30:15,238 INFO    +1.01 - STARTING TEST: [test01_node_check (test_api20_esxi_bootstrap.api20_bootstrap_esxi)] root 
test01_node_check (test_api20_esxi_bootstrap.api20_bootstrap_esxi) ... restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/nodes/5988bd64df3287057100f6b6
restful: Status code = 200 

restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/skus/f2f8b16a-ac6d-4ee5-bf26-571aae9a077d
restful: Status code = 200 

2017-08-10 18:30:15,797 INFO_1   Node ID: 5988bd64df3287057100f6b6                                                         test.run 
2017-08-10 18:30:15,797 INFO_1   Node SKU: Quanta D51 2U                                                                   test.run 
2017-08-10 18:30:15,798 INFO_1   Graph Name: Graph.PowerOn.Node                                                            test.run 
restful: Action =  post , URL =  http://stack14-ora.admin:8080/api/2.0/nodes/5988bd64df3287057100f6b6/workflows
restful: Status code = 201 

2017-08-10 18:30:15,888 INFO_1   Workflow started at time: 2017-08-10 18:30:15.887962                                      test.run 
restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/workflows/0890b174-1d73-414e-a4fc-73c6d40bbcdb
restful: Status code = 200 

2017-08-10 18:30:16,419 INFO_1  Graph.PowerOn.Node workflow status: succeeded                                              test.run >1.01 19499 MainProcess stream-monitor/flogging/infra_logging.py:wrapper@129 gl-main [test01_node_check (test_api20_esxi_bootstrap.api20_bootstrap_esxi)]
2017-08-10 18:30:16,419 INFO_1   Workflow completed at time: 2017-08-10 18:30:16.419679                                    test.run 
2017-08-10 18:30:16,419 INFO_1   Workflow duration: 0.531716823578                                                         test.run 
ok
2017-08-10 18:30:16,420 INFO    -1.01 - ENDING TEST: [test01_node_check (test_api20_esxi_bootstrap.api20_bootstrap_esxi)]  root 
2017-08-10 18:30:16,422 INFO    +1.02 - STARTING TEST: [test02_os_install (test_api20_esxi_bootstrap.api20_bootstrap_esxi)] root 
test02_os_install (test_api20_esxi_bootstrap.api20_bootstrap_esxi) ... restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/nodes/5988bd64df3287057100f6b6
restful: Status code = 200 

restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/skus/f2f8b16a-ac6d-4ee5-bf26-571aae9a077d
restful: Status code = 200 

2017-08-10 18:30:16,474 INFO_1   Node ID: 5988bd64df3287057100f6b6                                                         test.run 
2017-08-10 18:30:16,475 INFO_1   Node SKU: Quanta D51 2U                                                                   test.run 
2017-08-10 18:30:16,475 INFO_1   Graph Name: Graph.InstallESXi                                                             test.run 
2017-08-10 18:30:16,476 INFO_1   Payload: {"name": "Graph.InstallESXi", "options": {"defaults": {"repo": "http://172.31.128.1:8080/ESXi/6.0", "users": [{"password": "RackHDRocks!", "name": "rackhduser", "uid": 1010}], "version": "6", "hostname": "rackhdnode", "rootPassword": "1234567"}}} test.run 
restful: Action =  post , URL =  http://stack14-ora.admin:8080/api/2.0/nodes/5988bd64df3287057100f6b6/workflows
restful: Status code = 201 

2017-08-10 18:30:16,917 INFO_1   InstanceID: 5b11417a-a846-4250-979d-c4c4978cc7aa                                          test.run 
2017-08-10 18:30:16,918 INFO_1   Workflow started at time: 2017-08-10 18:30:16.918030                                      test.run 
restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/workflows/5b11417a-a846-4250-979d-c4c4978cc7aa
restful: Status code = 200 

2017-08-10 18:30:17,447 INFO_5  Graph.InstallESXi workflow status: running                                                 test.run >1.02 19499 MainProcess stream-monitor/flogging/infra_logging.py:wrapper@129 gl-main [test02_os_install (test_api20_esxi_bootstrap.api20_bootstrap_esxi)]
restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/workflows/5b11417a-a846-4250-979d-c4c4978cc7aa
restful: Status code = 200 

2017-08-10 18:30:47,535 INFO_1   Workflow failed at time: 2017-08-10 18:30:47.534955                                       test.run 
2017-08-10 18:30:47,537 INFO_1   Workflow duration: 30.6169250011                                                          test.run 
2017-08-10 18:30:47,538 ERROR    workflow error: TaskCancellationError
    at Task.cancel (/var/renasar/on-taskgraph/node_modules/on-tasks/lib/task.js:388:26)
    at /var/renasar/on-taskgraph/lib/task-runner.js:198:51
    at tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)
    at InnerObserver.Rx.FlatMapObservable.InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2096:43)
    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)
    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)
    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)
    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)
    at InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:4587:14)
    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)
    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)
    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)
    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)
    at InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5669:29)
    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)
    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)
    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)
    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)
    at InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5283:14)
    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)
    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)
    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)
    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)
    at scheduleItem (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:3075:16)
    at JustSink.run (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:3083:9)
    at JustObservable.subscribeCore (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:3064:19)
    at JustObservable.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)
    at setDisposable (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2038:46)
    at JustObservable.Rx.ObservableBase.ObservableBase._subscribe (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2053:9)
    at JustObservable.Rx.Observable.observableProto.subscribe.observableProto.forEach (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1990:19)
    at MapObservable.subscribeCore (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5268:26)
    at MapObservable.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)
    at setDisposable (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2038:46)
    at MapObservable.Rx.ObservableBase.ObservableBase._subscribe (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2053:9) test.run 
2017-08-10 18:30:47,540 ERROR    Workflow failed: status: cancelled                                                        test.run 
2017-08-10 18:30:47,541 ERROR    Data: {
    "node":"5988bd64df3287057100f6b6",
    "status":"cancelled",
    "domain":"default",
    "tasks":[
        {
            "terminalOnStates":[
                "timeout",
                "cancelled",
                "failed"
            ],
            "instanceId":"0d90219e-0055-4a81-9cca-6c4c542099a4",
            "state":"cancelled",
            "label":"install-os",
            "runJob":"Job.Os.Install",
            "waitingOn":{
                "a2014b47-360a-45e0-b51d-024cc71212cc":"succeeded"
            },
            "options":{
                "profile":"install-esx.ipxe",
                "rackhdCallbackScript":"esx.rackhdcallback",
                "logPort":"com1",
                "_taskTimeout":3600000,
                "installScriptUri":"http://172.31.128.1:9080/api/current/templates/esx-ks?nodeId=5988bd64df3287057100f6b6",
                "hostname":"rackhdnode",
                "comportaddress":"0x3f8",
                "comport":"com1",
                "repo":"http://172.31.128.1:8080/ESXi/6.0",
                "installScript":"esx-ks",
                "esxBootConfigTemplateUri":"http://172.31.128.1:9080/api/current/templates/esx-boot-cfg?nodeId=5988bd64df3287057100f6b6",
                "gdbPort":"default",
                "users":[
                    {
                        "password":"REDACTED",
                        "name":"rackhduser",
                        "uid":1010
                    }
                ],
                "version":"6",
                "rootPassword":"REDACTED",
                "osType":"esx",
                "esxBootConfigTemplate":"esx-boot-cfg",
                "debugLogToSerial":"1",
                "progressMilestones":{
                    "preConfig":{
                        "description":"Enter Pre OS configuration",
                        "value":4
                    },
                    "requestProfile":{
                        "description":"Enter ipxe and request OS installation profile",
                        "value":1
                    },
                    "startInstaller":{
                        "description":"Start installer and prepare installation",
                        "value":3
                    },
                    "enterProfile":{
                        "description":"Enter profile, start to download installer",
                        "value":2
                    },
                    "postConfig":{
                        "description":"Enter Post OS configuration",
                        "value":5
                    },
                    "completed":{
                        "description":"Finished OS installation",
                        "value":6
                    }
                },
                "kargs":{}
            }
        },
        {
            "terminalOnStates":[
                "timeout",
                "cancelled",
                "failed"
            ],
            "instanceId":"554defa3-d4f0-4097-9970-ea98c3ce87a9",
            "state":"cancelled",
            "label":"firstboot-callback-notification-wait",
            "runJob":"Job.Wait.Notification",
            "waitingOn":{
                "0d90219e-0055-4a81-9cca-6c4c542099a4":"succeeded"
            },
            "options":{
                "_taskTimeout":1200000
            }
        },
        {
            "terminalOnStates":[
                "timeout",
                "cancelled",
                "failed"
            ],
            "waitingOn":{
                "d6e73ef7-8f46-4cd5-a4d9-3622cbf7809a":[
                    "finished"
                ]
            },
            "instanceId":"a2014b47-360a-45e0-b51d-024cc71212cc",
            "taskStartTime":"2017-08-10T18:30:17.206Z",
            "state":"cancelled",
            "label":"reboot",
            "runJob":"Job.Obm.Node",
            "error":"TaskCancellationError\n    at Task.cancel (/var/renasar/on-taskgraph/node_modules/on-tasks/lib/task.js:388:26)\n    at /var/renasar/on-taskgraph/lib/task-runner.js:198:51\n    at tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at InnerObserver.Rx.FlatMapObservable.InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2096:43)\n    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)\n    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:4587:14)\n    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)\n    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5669:29)\n    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)\n    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5283:14)\n    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)\n    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at scheduleItem (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:3075:16)\n    at JustSink.run (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:3083:9)\n    at JustObservable.subscribeCore (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:3064:19)\n    at JustObservable.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at setDisposable (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2038:46)\n    at JustObservable.Rx.ObservableBase.ObservableBase._subscribe (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2053:9)\n    at JustObservable.Rx.Observable.observableProto.subscribe.observableProto.forEach (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1990:19)\n    at MapObservable.subscribeCore (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5268:26)\n    at MapObservable.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at setDisposable (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2038:46)\n    at MapObservable.Rx.ObservableBase.ObservableBase._subscribe (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2053:9)",
            "options":{
                "users":[
                    {
                        "password":"REDACTED",
                        "name":"rackhduser",
                        "uid":1010
                    }
                ],
                "_taskTimeout":86400000,
                "hostname":"rackhdnode",
                "repo":"http://172.31.128.1:8080/ESXi/6.0",
                "version":"6",
                "rootPassword":"REDACTED",
                "action":"reboot"
            }
        },
        {
            "terminalOnStates":[
                "succeeded",
                "timeout",
                "cancelled",
                "failed"
            ],
            "instanceId":"a93d2c53-4d7e-4398-acf1-6ca13b5bf714",
            "state":"cancelled",
            "label":"installed-callback-notification-wait",
            "runJob":"Job.Wait.Notification",
            "waitingOn":{
                "554defa3-d4f0-4097-9970-ea98c3ce87a9":"succeeded"
            },
            "options":{
                "_taskTimeout":1200000
            }
        },
        {
            "terminalOnStates":[],
            "instanceId":"d6e73ef7-8f46-4cd5-a4d9-3622cbf7809a",
            "waitingOn":{
                "db27b07c-e8e6-4a95-8be6-c6499bd7d0b5":"succeeded"
            },
            "state":"succeeded",
            "label":"set-boot-pxe",
            "runJob":"Job.Obm.Node",
            "taskStartTime":"2017-08-10T18:30:17.023Z",
            "options":{
                "users":[
                    {
                        "password":"REDACTED",
                        "name":"rackhduser",
                        "uid":1010
                    }
                ],
                "_taskTimeout":86400000,
                "hostname":"rackhdnode",
                "repo":"http://172.31.128.1:8080/ESXi/6.0",
                "version":"6",
                "rootPassword":"REDACTED",
                "action":"setBootPxe"
            }
        },
        {
            "terminalOnStates":[
                "timeout",
                "cancelled",
                "failed"
            ],
            "instanceId":"db27b07c-e8e6-4a95-8be6-c6499bd7d0b5",
            "waitingOn":{},
            "state":"succeeded",
            "label":"analyze-repo",
            "runJob":"Job.Os.Analyze.Repo",
            "taskStartTime":"2017-08-10T18:30:16.933Z",
            "options":{
                "users":[
                    {
                        "password":"REDACTED",
                        "name":"rackhduser",
                        "uid":1010
                    }
                ],
                "_taskTimeout":86400000,
                "hostname":"rackhdnode",
                "osName":"ESXi",
                "repo":"http://172.31.128.1:8080/ESXi/6.0",
                "version":"6",
                "rootPassword":"REDACTED"
            }
        }
    ],
    "name":"Install ESXi",
    "definition":"/api/2.0/workflows/graphs/Graph.InstallESXi",
    "injectableName":"Graph.InstallESXi",
    "serviceGraph":"",
    "instanceId":"5b11417a-a846-4250-979d-c4c4978cc7aa",
    "logContext":{
        "graphInstance":"5b11417a-a846-4250-979d-c4c4978cc7aa",
        "graphName":"Install ESXi",
        "id":"5988bd64df3287057100f6b6"
    },
    "context":{
        "graphName":"Graph.InstallESXi",
        "graphId":"5b11417a-a846-4250-979d-c4c4978cc7aa",
        "repoOptions":{
            "repo":"http://172.31.128.1:8080/ESXi/6.0",
            "mbootFile":"mboot.c32",
            "moduleFiles":"b.b00 --- jumpstrt.gz --- useropts.gz --- k.b00 --- chardevs.b00 --- a.b00 --- user.b00 --- uc_intel.b00 --- uc_amd.b00 --- sb.v00 --- s.v00 --- mtip32xx.v00 --- ata_pata.v00 --- ata_pata.v01 --- ata_pata.v02 --- ata_pata.v03 --- ata_pata.v04 --- ata_pata.v05 --- ata_pata.v06 --- ata_pata.v07 --- block_cc.v00 --- ehci_ehc.v00 --- elxnet.v00 --- emulex_e.v00 --- weaselin.t00 --- esx_dvfi.v00 --- ima_qla4.v00 --- ipmi_ipm.v00 --- ipmi_ipm.v01 --- ipmi_ipm.v02 --- lpfc.v00 --- lsi_mr3.v00 --- lsi_msgp.v00 --- lsu_hp_h.v00 --- lsu_lsi_.v00 --- lsu_lsi_.v01 --- lsu_lsi_.v02 --- lsu_lsi_.v03 --- lsu_lsi_.v04 --- misc_cni.v00 --- misc_dri.v00 --- net_bnx2.v00 --- net_bnx2.v01 --- net_cnic.v00 --- net_e100.v00 --- net_e100.v01 --- net_enic.v00 --- net_forc.v00 --- net_igb.v00 --- net_ixgb.v00 --- net_mlx4.v00 --- net_mlx4.v01 --- net_nx_n.v00 --- net_tg3.v00 --- net_vmxn.v00 --- nmlx4_co.v00 --- nmlx4_en.v00 --- nmlx4_rd.v00 --- nvme.v00 --- ohci_usb.v00 --- qlnative.v00 --- rste.v00 --- sata_ahc.v00 --- sata_ata.v00 --- sata_sat.v00 --- sata_sat.v01 --- sata_sat.v02 --- sata_sat.v03 --- sata_sat.v04 --- scsi_aac.v00 --- scsi_adp.v00 --- scsi_aic.v00 --- scsi_bnx.v00 --- scsi_bnx.v01 --- scsi_fni.v00 --- scsi_hps.v00 --- scsi_ips.v00 --- scsi_meg.v00 --- scsi_meg.v01 --- scsi_meg.v02 --- scsi_mpt.v00 --- scsi_mpt.v01 --- scsi_mpt.v02 --- scsi_qla.v00 --- uhci_usb.v00 --- xhci_xhc.v00 --- tools.t00 --- xorg.v00 --- imgdb.tgz --- imgpayld.tgz",
            "tbootFile":"tboot.b00"
        },
        "target":"5988bd64df3287057100f6b6"
    },
    "id":"598ca6389f6324d6581291cc"
} test.run 
2017-08-10 18:30:47,551 WARNING ------start captured data for FAIL in test02_os_install (test_api20_esxi_bootstrap.api20_bootstrap_esxi) root 
2017-08-10 18:30:47,551 WARNING stdout: restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/nodes/5988bd64df3287057100f6b6
restful: Status code = 200 

restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/skus/f2f8b16a-ac6d-4ee5-bf26-571aae9a077d
restful: Status code = 200 

restful: Action =  post , URL =  http://stack14-ora.admin:8080/api/2.0/nodes/5988bd64df3287057100f6b6/workflows
restful: Status code = 201 

restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/workflows/5b11417a-a846-4250-979d-c4c4978cc7aa
restful: Status code = 200 

restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/workflows/5b11417a-a846-4250-979d-c4c4978cc7aa
restful: Status code = 200 

 root >1.02 19499 MainProcess stream-monitor/stream_sources/log_type.py:__capture_to_log@129 gl-main [test02_os_install (test_api20_esxi_bootstrap.api20_bootstrap_esxi)]
2017-08-10 18:30:47,552 WARNING stderr:                                                                                    root >1.02 19499 MainProcess stream-monitor/stream_sources/log_type.py:__capture_to_log@130 gl-main [test02_os_install (test_api20_esxi_bootstrap.api20_bootstrap_esxi)]
2017-08-10 18:30:47,552 WARNING traceback:   File "/usr/lib/python2.7/unittest/case.py", line 331, in run
    testMethod()
  File "/emc/ndetau/Dev/rac-5835/RackHD/test/.venv/fit/local/lib/python2.7/site-packages/nosedep.py", line 126, in inner
    return func(*args, **kwargs)
  File "/emc/ndetau/Dev/rac-5835/RackHD/test/tests/bootstrap/test_api20_esxi_bootstrap.py", line 182, in test02_os_install
    self.assertTrue(wait_for_workflow_complete(workflowid, time.time()), "OS Install workflow failed, see logs.")
  File "/usr/lib/python2.7/unittest/case.py", line 424, in assertTrue
    raise self.failureException(msg)
'OS Install workflow failed, see logs.\n-------------------- >> begin captured logging << --------------------\ninfra.run: DEBUG: relaying set_test((None,)) to all trackers {}\ntest.run: DEBUG: handle_after_test pluggin progression for <stream_sources.amqp_source.AMQPStreamMonitor object at 0x7f35d45b7f10> test=test01_node_check (test_api20_esxi_bootstrap.api20_bootstrap_esxi)\ntest.run: DEBUG: handle_after_test pluggin progression for <stream_sources.self_test_source.SelfTestStreamMonitor object at 0x7f35d881abd0> test=test01_node_check (test_api20_esxi_bootstrap.api20_bootstrap_esxi)\nroot: INFO: +1.02 - STARTING TEST: [test02_os_install (test_api20_esxi_bootstrap.api20_bootstrap_esxi)]\ninfra.run: DEBUG: relaying set_test((Test(<test_api20_esxi_bootstrap.api20_bootstrap_esxi testMethod=test02_os_install>),)) to all trackers {}\ntest.run: DEBUG: handle_start_test pluggin progression for <stream_sources.amqp_source.AMQPStreamMonitor object at 0x7f35d45b7f10> test=test02_os_install (test_api20_esxi_bootstrap.api20_bootstrap_esxi)\ntest.run: DEBUG: handle_start_test pluggin progression for <stream_sources.self_test_source.SelfTestStreamMonitor object at 0x7f35d881abd0> test=test02_os_install (test_api20_esxi_bootstrap.api20_bootstrap_esxi)\ntest.run: INFO_1:  Node ID: 5988bd64df3287057100f6b6\ntest.run: INFO_1:  Node SKU: Quanta D51 2U\ntest.run: INFO_1:  Graph Name: Graph.InstallESXi\ntest.run: INFO_1:  Payload: {"name": "Graph.InstallESXi", "options": {"defaults": {"repo": "http://172.31.128.1:8080/ESXi/6.0", "users": [{"password": "RackHDRocks!", "name": "rackhduser", "uid": 1010}], "version": "6", "hostname": "rackhdnode", "rootPassword": "1234567"}}}\ntest.run: INFO_1:  InstanceID: 5b11417a-a846-4250-979d-c4c4978cc7aa\ntest.run: INFO_1:  Workflow started at time: 2017-08-10 18:30:16.918030\ntest.run: INFO_5: Graph.InstallESXi workflow status: running\ntest.run: INFO_1:  Workflow failed at time: 2017-08-10 18:30:47.534955\ntest.run: INFO_1:  Workflow duration: 30.6169250011\ntest.run: ERROR:  workflow error: TaskCancellationError\n    at Task.cancel (/var/renasar/on-taskgraph/node_modules/on-tasks/lib/task.js:388:26)\n    at /var/renasar/on-taskgraph/lib/task-runner.js:198:51\n    at tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at InnerObserver.Rx.FlatMapObservable.InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2096:43)\n    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)\n    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:4587:14)\n    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)\n    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5669:29)\n    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)\n    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5283:14)\n    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)\n    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at scheduleItem (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:3075:16)\n    at JustSink.run (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:3083:9)\n    at JustObservable.subscribeCore (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:3064:19)\n    at JustObservable.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at setDisposable (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2038:46)\n    at JustObservable.Rx.ObservableBase.ObservableBase._subscribe (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2053:9)\n    at JustObservable.Rx.Observable.observableProto.subscribe.observableProto.forEach (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1990:19)\n    at MapObservable.subscribeCore (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5268:26)\n    at MapObservable.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at setDisposable (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2038:46)\n    at MapObservable.Rx.ObservableBase.ObservableBase._subscribe (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2053:9)\ntest.run: ERROR:  Workflow failed: status: cancelled\ntest.run: ERROR:  Data: {\n    "node":"5988bd64df3287057100f6b6",\n    "status":"cancelled",\n    "domain":"default",\n    "tasks":[\n        {\n            "terminalOnStates":[\n                "timeout",\n                "cancelled",\n                "failed"\n            ],\n            "instanceId":"0d90219e-0055-4a81-9cca-6c4c542099a4",\n            "state":"cancelled",\n            "label":"install-os",\n            "runJob":"Job.Os.Install",\n            "waitingOn":{\n                "a2014b47-360a-45e0-b51d-024cc71212cc":"succeeded"\n            },\n            "options":{\n                "profile":"install-esx.ipxe",\n                "rackhdCallbackScript":"esx.rackhdcallback",\n                "logPort":"com1",\n                "_taskTimeout":3600000,\n                "installScriptUri":"http://172.31.128.1:9080/api/current/templates/esx-ks?nodeId=5988bd64df3287057100f6b6",\n                "hostname":"rackhdnode",\n                "comportaddress":"0x3f8",\n                "comport":"com1",\n                "repo":"http://172.31.128.1:8080/ESXi/6.0",\n                "installScript":"esx-ks",\n                "esxBootConfigTemplateUri":"http://172.31.128.1:9080/api/current/templates/esx-boot-cfg?nodeId=5988bd64df3287057100f6b6",\n                "gdbPort":"default",\n                "users":[\n                    {\n                        "password":"REDACTED",\n                        "name":"rackhduser",\n                        "uid":1010\n                    }\n                ],\n                "version":"6",\n                "rootPassword":"REDACTED",\n                "osType":"esx",\n                "esxBootConfigTemplate":"esx-boot-cfg",\n                "debugLogToSerial":"1",\n                "progressMilestones":{\n                    "preConfig":{\n                        "description":"Enter Pre OS configuration",\n                        "value":4\n                    },\n                    "requestProfile":{\n                        "description":"Enter ipxe and request OS installation profile",\n                        "value":1\n                    },\n                    "startInstaller":{\n                        "description":"Start installer and prepare installation",\n                        "value":3\n                    },\n                    "enterProfile":{\n                        "description":"Enter profile, start to download installer",\n                        "value":2\n                    },\n                    "postConfig":{\n                        "description":"Enter Post OS configuration",\n                        "value":5\n                    },\n                    "completed":{\n                        "description":"Finished OS installation",\n                        "value":6\n                    }\n                },\n                "kargs":{}\n            }\n        },\n        {\n            "terminalOnStates":[\n                "timeout",\n                "cancelled",\n                "failed"\n            ],\n            "instanceId":"554defa3-d4f0-4097-9970-ea98c3ce87a9",\n            "state":"cancelled",\n            "label":"firstboot-callback-notification-wait",\n            "runJob":"Job.Wait.Notification",\n            "waitingOn":{\n                "0d90219e-0055-4a81-9cca-6c4c542099a4":"succeeded"\n            },\n            "options":{\n                "_taskTimeout":1200000\n            }\n        },\n        {\n            "terminalOnStates":[\n                "timeout",\n                "cancelled",\n                "failed"\n            ],\n            "waitingOn":{\n                "d6e73ef7-8f46-4cd5-a4d9-3622cbf7809a":[\n                    "finished"\n                ]\n            },\n            "instanceId":"a2014b47-360a-45e0-b51d-024cc71212cc",\n            "taskStartTime":"2017-08-10T18:30:17.206Z",\n            "state":"cancelled",\n            "label":"reboot",\n            "runJob":"Job.Obm.Node",\n            "error":"TaskCancellationError\\n    at Task.cancel (/var/renasar/on-taskgraph/node_modules/on-tasks/lib/task.js:388:26)\\n    at /var/renasar/on-taskgraph/lib/task-runner.js:198:51\\n    at tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\\n    at InnerObserver.Rx.FlatMapObservable.InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2096:43)\\n    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\\n    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\\n    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)\\n    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\\n    at InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:4587:14)\\n    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\\n    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\\n    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)\\n    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\\n    at InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5669:29)\\n    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\\n    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\\n    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)\\n    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\\n    at InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5283:14)\\n    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\\n    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\\n    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)\\n    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\\n    at scheduleItem (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:3075:16)\\n    at JustSink.run (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:3083:9)\\n    at JustObservable.subscribeCore (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:3064:19)\\n    at JustObservable.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\\n    at setDisposable (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2038:46)\\n    at JustObservable.Rx.ObservableBase.ObservableBase._subscribe (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2053:9)\\n    at JustObservable.Rx.Observable.observableProto.subscribe.observableProto.forEach (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1990:19)\\n    at MapObservable.subscribeCore (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5268:26)\\n    at MapObservable.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\\n    at setDisposable (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2038:46)\\n    at MapObservable.Rx.ObservableBase.ObservableBase._subscribe (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2053:9)",\n            "options":{\n                "users":[\n                    {\n                        "password":"REDACTED",\n                        "name":"rackhduser",\n                        "uid":1010\n                    }\n                ],\n                "_taskTimeout":86400000,\n                "hostname":"rackhdnode",\n                "repo":"http://172.31.128.1:8080/ESXi/6.0",\n                "version":"6",\n                "rootPassword":"REDACTED",\n                "action":"reboot"\n            }\n        },\n        {\n            "terminalOnStates":[\n                "succeeded",\n                "timeout",\n                "cancelled",\n                "failed"\n            ],\n            "instanceId":"a93d2c53-4d7e-4398-acf1-6ca13b5bf714",\n            "state":"cancelled",\n            "label":"installed-callback-notification-wait",\n            "runJob":"Job.Wait.Notification",\n            "waitingOn":{\n                "554defa3-d4f0-4097-9970-ea98c3ce87a9":"succeeded"\n            },\n            "options":{\n                "_taskTimeout":1200000\n            }\n        },\n        {\n            "terminalOnStates":[],\n            "instanceId":"d6e73ef7-8f46-4cd5-a4d9-3622cbf7809a",\n            "waitingOn":{\n                "db27b07c-e8e6-4a95-8be6-c6499bd7d0b5":"succeeded"\n            },\n            "state":"succeeded",\n            "label":"set-boot-pxe",\n            "runJob":"Job.Obm.Node",\n            "taskStartTime":"2017-08-10T18:30:17.023Z",\n            "options":{\n                "users":[\n                    {\n                        "password":"REDACTED",\n                        "name":"rackhduser",\n                        "uid":1010\n                    }\n                ],\n                "_taskTimeout":86400000,\n                "hostname":"rackhdnode",\n                "repo":"http://172.31.128.1:8080/ESXi/6.0",\n                "version":"6",\n                "rootPassword":"REDACTED",\n                "action":"setBootPxe"\n            }\n        },\n        {\n            "terminalOnStates":[\n                "timeout",\n                "cancelled",\n                "failed"\n            ],\n            "instanceId":"db27b07c-e8e6-4a95-8be6-c6499bd7d0b5",\n            "waitingOn":{},\n            "state":"succeeded",\n            "label":"analyze-repo",\n            "runJob":"Job.Os.Analyze.Repo",\n            "taskStartTime":"2017-08-10T18:30:16.933Z",\n            "options":{\n                "users":[\n                    {\n                        "password":"REDACTED",\n                        "name":"rackhduser",\n                        "uid":1010\n                    }\n                ],\n                "_taskTimeout":86400000,\n                "hostname":"rackhdnode",\n                "osName":"ESXi",\n                "repo":"http://172.31.128.1:8080/ESXi/6.0",\n                "version":"6",\n                "rootPassword":"REDACTED"\n            }\n        }\n    ],\n    "name":"Install ESXi",\n    "definition":"/api/2.0/workflows/graphs/Graph.InstallESXi",\n    "injectableName":"Graph.InstallESXi",\n    "serviceGraph":"",\n    "instanceId":"5b11417a-a846-4250-979d-c4c4978cc7aa",\n    "logContext":{\n        "graphInstance":"5b11417a-a846-4250-979d-c4c4978cc7aa",\n        "graphName":"Install ESXi",\n        "id":"5988bd64df3287057100f6b6"\n    },\n    "context":{\n        "graphName":"Graph.InstallESXi",\n        "graphId":"5b11417a-a846-4250-979d-c4c4978cc7aa",\n        "repoOptions":{\n            "repo":"http://172.31.128.1:8080/ESXi/6.0",\n            "mbootFile":"mboot.c32",\n            "moduleFiles":"b.b00 --- jumpstrt.gz --- useropts.gz --- k.b00 --- chardevs.b00 --- a.b00 --- user.b00 --- uc_intel.b00 --- uc_amd.b00 --- sb.v00 --- s.v00 --- mtip32xx.v00 --- ata_pata.v00 --- ata_pata.v01 --- ata_pata.v02 --- ata_pata.v03 --- ata_pata.v04 --- ata_pata.v05 --- ata_pata.v06 --- ata_pata.v07 --- block_cc.v00 --- ehci_ehc.v00 --- elxnet.v00 --- emulex_e.v00 --- weaselin.t00 --- esx_dvfi.v00 --- ima_qla4.v00 --- ipmi_ipm.v00 --- ipmi_ipm.v01 --- ipmi_ipm.v02 --- lpfc.v00 --- lsi_mr3.v00 --- lsi_msgp.v00 --- lsu_hp_h.v00 --- lsu_lsi_.v00 --- lsu_lsi_.v01 --- lsu_lsi_.v02 --- lsu_lsi_.v03 --- lsu_lsi_.v04 --- misc_cni.v00 --- misc_dri.v00 --- net_bnx2.v00 --- net_bnx2.v01 --- net_cnic.v00 --- net_e100.v00 --- net_e100.v01 --- net_enic.v00 --- net_forc.v00 --- net_igb.v00 --- net_ixgb.v00 --- net_mlx4.v00 --- net_mlx4.v01 --- net_nx_n.v00 --- net_tg3.v00 --- net_vmxn.v00 --- nmlx4_co.v00 --- nmlx4_en.v00 --- nmlx4_rd.v00 --- nvme.v00 --- ohci_usb.v00 --- qlnative.v00 --- rste.v00 --- sata_ahc.v00 --- sata_ata.v00 --- sata_sat.v00 --- sata_sat.v01 --- sata_sat.v02 --- sata_sat.v03 --- sata_sat.v04 --- scsi_aac.v00 --- scsi_adp.v00 --- scsi_aic.v00 --- scsi_bnx.v00 --- scsi_bnx.v01 --- scsi_fni.v00 --- scsi_hps.v00 --- scsi_ips.v00 --- scsi_meg.v00 --- scsi_meg.v01 --- scsi_meg.v02 --- scsi_mpt.v00 --- scsi_mpt.v01 --- scsi_mpt.v02 --- scsi_qla.v00 --- uhci_usb.v00 --- xhci_xhc.v00 --- tools.t00 --- xorg.v00 --- imgdb.tgz --- imgpayld.tgz",\n            "tbootFile":"tboot.b00"\n        },\n        "target":"5988bd64df3287057100f6b6"\n    },\n    "id":"598ca6389f6324d6581291cc"\n}\n--------------------- >> end captured logging << ---------------------' root >1.02 19499 MainProcess stream-monitor/stream_sources/log_type.py:__capture_to_log@131 gl-main [test02_os_install (test_api20_esxi_bootstrap.api20_bootstrap_esxi)]
2017-08-10 18:30:47,553 WARNING ------end captured data for FAIL in test02_os_install (test_api20_esxi_bootstrap.api20_bootstrap_esxi) root 
FAIL
2017-08-10 18:30:47,554 INFO    -1.02 - ENDING TEST: [test02_os_install (test_api20_esxi_bootstrap.api20_bootstrap_esxi)]  root 

======================================================================
FAIL: test02_os_install (test_api20_esxi_bootstrap.api20_bootstrap_esxi)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/emc/ndetau/Dev/rac-5835/RackHD/test/.venv/fit/local/lib/python2.7/site-packages/nosedep.py", line 126, in inner
    return func(*args, **kwargs)
  File "/emc/ndetau/Dev/rac-5835/RackHD/test/tests/bootstrap/test_api20_esxi_bootstrap.py", line 182, in test02_os_install
    self.assertTrue(wait_for_workflow_complete(workflowid, time.time()), "OS Install workflow failed, see logs.")
AssertionError: OS Install workflow failed, see logs.
-------------------- >> begin captured logging << --------------------
infra.run: DEBUG: relaying set_test((None,)) to all trackers {}
test.run: DEBUG: handle_after_test pluggin progression for <stream_sources.amqp_source.AMQPStreamMonitor object at 0x7f35d45b7f10> test=test01_node_check (test_api20_esxi_bootstrap.api20_bootstrap_esxi)
test.run: DEBUG: handle_after_test pluggin progression for <stream_sources.self_test_source.SelfTestStreamMonitor object at 0x7f35d881abd0> test=test01_node_check (test_api20_esxi_bootstrap.api20_bootstrap_esxi)
root: INFO: +1.02 - STARTING TEST: [test02_os_install (test_api20_esxi_bootstrap.api20_bootstrap_esxi)]
infra.run: DEBUG: relaying set_test((Test(<test_api20_esxi_bootstrap.api20_bootstrap_esxi testMethod=test02_os_install>),)) to all trackers {}
test.run: DEBUG: handle_start_test pluggin progression for <stream_sources.amqp_source.AMQPStreamMonitor object at 0x7f35d45b7f10> test=test02_os_install (test_api20_esxi_bootstrap.api20_bootstrap_esxi)
test.run: DEBUG: handle_start_test pluggin progression for <stream_sources.self_test_source.SelfTestStreamMonitor object at 0x7f35d881abd0> test=test02_os_install (test_api20_esxi_bootstrap.api20_bootstrap_esxi)
test.run: INFO_1:  Node ID: 5988bd64df3287057100f6b6
test.run: INFO_1:  Node SKU: Quanta D51 2U
test.run: INFO_1:  Graph Name: Graph.InstallESXi
test.run: INFO_1:  Payload: {"name": "Graph.InstallESXi", "options": {"defaults": {"repo": "http://172.31.128.1:8080/ESXi/6.0", "users": [{"password": "RackHDRocks!", "name": "rackhduser", "uid": 1010}], "version": "6", "hostname": "rackhdnode", "rootPassword": "1234567"}}}
test.run: INFO_1:  InstanceID: 5b11417a-a846-4250-979d-c4c4978cc7aa
test.run: INFO_1:  Workflow started at time: 2017-08-10 18:30:16.918030
test.run: INFO_5: Graph.InstallESXi workflow status: running
test.run: INFO_1:  Workflow failed at time: 2017-08-10 18:30:47.534955
test.run: INFO_1:  Workflow duration: 30.6169250011
test.run: ERROR:  workflow error: TaskCancellationError
    at Task.cancel (/var/renasar/on-taskgraph/node_modules/on-tasks/lib/task.js:388:26)
    at /var/renasar/on-taskgraph/lib/task-runner.js:198:51
    at tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)
    at InnerObserver.Rx.FlatMapObservable.InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2096:43)
    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)
    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)
    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)
    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)
    at InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:4587:14)
    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)
    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)
    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)
    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)
    at InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5669:29)
    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)
    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)
    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)
    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)
    at InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5283:14)
    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)
    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)
    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)
    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)
    at scheduleItem (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:3075:16)
    at JustSink.run (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:3083:9)
    at JustObservable.subscribeCore (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:3064:19)
    at JustObservable.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)
    at setDisposable (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2038:46)
    at JustObservable.Rx.ObservableBase.ObservableBase._subscribe (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2053:9)
    at JustObservable.Rx.Observable.observableProto.subscribe.observableProto.forEach (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1990:19)
    at MapObservable.subscribeCore (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5268:26)
    at MapObservable.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)
    at setDisposable (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2038:46)
    at MapObservable.Rx.ObservableBase.ObservableBase._subscribe (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2053:9)
test.run: ERROR:  Workflow failed: status: cancelled
test.run: ERROR:  Data: {
    "node":"5988bd64df3287057100f6b6",
    "status":"cancelled",
    "domain":"default",
    "tasks":[
        {
            "terminalOnStates":[
                "timeout",
                "cancelled",
                "failed"
            ],
            "instanceId":"0d90219e-0055-4a81-9cca-6c4c542099a4",
            "state":"cancelled",
            "label":"install-os",
            "runJob":"Job.Os.Install",
            "waitingOn":{
                "a2014b47-360a-45e0-b51d-024cc71212cc":"succeeded"
            },
            "options":{
                "profile":"install-esx.ipxe",
                "rackhdCallbackScript":"esx.rackhdcallback",
                "logPort":"com1",
                "_taskTimeout":3600000,
                "installScriptUri":"http://172.31.128.1:9080/api/current/templates/esx-ks?nodeId=5988bd64df3287057100f6b6",
                "hostname":"rackhdnode",
                "comportaddress":"0x3f8",
                "comport":"com1",
                "repo":"http://172.31.128.1:8080/ESXi/6.0",
                "installScript":"esx-ks",
                "esxBootConfigTemplateUri":"http://172.31.128.1:9080/api/current/templates/esx-boot-cfg?nodeId=5988bd64df3287057100f6b6",
                "gdbPort":"default",
                "users":[
                    {
                        "password":"REDACTED",
                        "name":"rackhduser",
                        "uid":1010
                    }
                ],
                "version":"6",
                "rootPassword":"REDACTED",
                "osType":"esx",
                "esxBootConfigTemplate":"esx-boot-cfg",
                "debugLogToSerial":"1",
                "progressMilestones":{
                    "preConfig":{
                        "description":"Enter Pre OS configuration",
                        "value":4
                    },
                    "requestProfile":{
                        "description":"Enter ipxe and request OS installation profile",
                        "value":1
                    },
                    "startInstaller":{
                        "description":"Start installer and prepare installation",
                        "value":3
                    },
                    "enterProfile":{
                        "description":"Enter profile, start to download installer",
                        "value":2
                    },
                    "postConfig":{
                        "description":"Enter Post OS configuration",
                        "value":5
                    },
                    "completed":{
                        "description":"Finished OS installation",
                        "value":6
                    }
                },
                "kargs":{}
            }
        },
        {
            "terminalOnStates":[
                "timeout",
                "cancelled",
                "failed"
            ],
            "instanceId":"554defa3-d4f0-4097-9970-ea98c3ce87a9",
            "state":"cancelled",
            "label":"firstboot-callback-notification-wait",
            "runJob":"Job.Wait.Notification",
            "waitingOn":{
                "0d90219e-0055-4a81-9cca-6c4c542099a4":"succeeded"
            },
            "options":{
                "_taskTimeout":1200000
            }
        },
        {
            "terminalOnStates":[
                "timeout",
                "cancelled",
                "failed"
            ],
            "waitingOn":{
                "d6e73ef7-8f46-4cd5-a4d9-3622cbf7809a":[
                    "finished"
                ]
            },
            "instanceId":"a2014b47-360a-45e0-b51d-024cc71212cc",
            "taskStartTime":"2017-08-10T18:30:17.206Z",
            "state":"cancelled",
            "label":"reboot",
            "runJob":"Job.Obm.Node",
            "error":"TaskCancellationError\n    at Task.cancel (/var/renasar/on-taskgraph/node_modules/on-tasks/lib/task.js:388:26)\n    at /var/renasar/on-taskgraph/lib/task-runner.js:198:51\n    at tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at InnerObserver.Rx.FlatMapObservable.InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2096:43)\n    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)\n    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:4587:14)\n    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)\n    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5669:29)\n    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)\n    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5283:14)\n    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)\n    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at scheduleItem (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:3075:16)\n    at JustSink.run (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:3083:9)\n    at JustObservable.subscribeCore (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:3064:19)\n    at JustObservable.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at setDisposable (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2038:46)\n    at JustObservable.Rx.ObservableBase.ObservableBase._subscribe (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2053:9)\n    at JustObservable.Rx.Observable.observableProto.subscribe.observableProto.forEach (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1990:19)\n    at MapObservable.subscribeCore (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5268:26)\n    at MapObservable.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at setDisposable (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2038:46)\n    at MapObservable.Rx.ObservableBase.ObservableBase._subscribe (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2053:9)",
            "options":{
                "users":[
                    {
                        "password":"REDACTED",
                        "name":"rackhduser",
                        "uid":1010
                    }
                ],
                "_taskTimeout":86400000,
                "hostname":"rackhdnode",
                "repo":"http://172.31.128.1:8080/ESXi/6.0",
                "version":"6",
                "rootPassword":"REDACTED",
                "action":"reboot"
            }
        },
        {
            "terminalOnStates":[
                "succeeded",
                "timeout",
                "cancelled",
                "failed"
            ],
            "instanceId":"a93d2c53-4d7e-4398-acf1-6ca13b5bf714",
            "state":"cancelled",
            "label":"installed-callback-notification-wait",
            "runJob":"Job.Wait.Notification",
            "waitingOn":{
                "554defa3-d4f0-4097-9970-ea98c3ce87a9":"succeeded"
            },
            "options":{
                "_taskTimeout":1200000
            }
        },
        {
            "terminalOnStates":[],
            "instanceId":"d6e73ef7-8f46-4cd5-a4d9-3622cbf7809a",
            "waitingOn":{
                "db27b07c-e8e6-4a95-8be6-c6499bd7d0b5":"succeeded"
            },
            "state":"succeeded",
            "label":"set-boot-pxe",
            "runJob":"Job.Obm.Node",
            "taskStartTime":"2017-08-10T18:30:17.023Z",
            "options":{
                "users":[
                    {
                        "password":"REDACTED",
                        "name":"rackhduser",
                        "uid":1010
                    }
                ],
                "_taskTimeout":86400000,
                "hostname":"rackhdnode",
                "repo":"http://172.31.128.1:8080/ESXi/6.0",
                "version":"6",
                "rootPassword":"REDACTED",
                "action":"setBootPxe"
            }
        },
        {
            "terminalOnStates":[
                "timeout",
                "cancelled",
                "failed"
            ],
            "instanceId":"db27b07c-e8e6-4a95-8be6-c6499bd7d0b5",
            "waitingOn":{},
            "state":"succeeded",
            "label":"analyze-repo",
            "runJob":"Job.Os.Analyze.Repo",
            "taskStartTime":"2017-08-10T18:30:16.933Z",
            "options":{
                "users":[
                    {
                        "password":"REDACTED",
                        "name":"rackhduser",
                        "uid":1010
                    }
                ],
                "_taskTimeout":86400000,
                "hostname":"rackhdnode",
                "osName":"ESXi",
                "repo":"http://172.31.128.1:8080/ESXi/6.0",
                "version":"6",
                "rootPassword":"REDACTED"
            }
        }
    ],
    "name":"Install ESXi",
    "definition":"/api/2.0/workflows/graphs/Graph.InstallESXi",
    "injectableName":"Graph.InstallESXi",
    "serviceGraph":"",
    "instanceId":"5b11417a-a846-4250-979d-c4c4978cc7aa",
    "logContext":{
        "graphInstance":"5b11417a-a846-4250-979d-c4c4978cc7aa",
        "graphName":"Install ESXi",
        "id":"5988bd64df3287057100f6b6"
    },
    "context":{
        "graphName":"Graph.InstallESXi",
        "graphId":"5b11417a-a846-4250-979d-c4c4978cc7aa",
        "repoOptions":{
            "repo":"http://172.31.128.1:8080/ESXi/6.0",
            "mbootFile":"mboot.c32",
            "moduleFiles":"b.b00 --- jumpstrt.gz --- useropts.gz --- k.b00 --- chardevs.b00 --- a.b00 --- user.b00 --- uc_intel.b00 --- uc_amd.b00 --- sb.v00 --- s.v00 --- mtip32xx.v00 --- ata_pata.v00 --- ata_pata.v01 --- ata_pata.v02 --- ata_pata.v03 --- ata_pata.v04 --- ata_pata.v05 --- ata_pata.v06 --- ata_pata.v07 --- block_cc.v00 --- ehci_ehc.v00 --- elxnet.v00 --- emulex_e.v00 --- weaselin.t00 --- esx_dvfi.v00 --- ima_qla4.v00 --- ipmi_ipm.v00 --- ipmi_ipm.v01 --- ipmi_ipm.v02 --- lpfc.v00 --- lsi_mr3.v00 --- lsi_msgp.v00 --- lsu_hp_h.v00 --- lsu_lsi_.v00 --- lsu_lsi_.v01 --- lsu_lsi_.v02 --- lsu_lsi_.v03 --- lsu_lsi_.v04 --- misc_cni.v00 --- misc_dri.v00 --- net_bnx2.v00 --- net_bnx2.v01 --- net_cnic.v00 --- net_e100.v00 --- net_e100.v01 --- net_enic.v00 --- net_forc.v00 --- net_igb.v00 --- net_ixgb.v00 --- net_mlx4.v00 --- net_mlx4.v01 --- net_nx_n.v00 --- net_tg3.v00 --- net_vmxn.v00 --- nmlx4_co.v00 --- nmlx4_en.v00 --- nmlx4_rd.v00 --- nvme.v00 --- ohci_usb.v00 --- qlnative.v00 --- rste.v00 --- sata_ahc.v00 --- sata_ata.v00 --- sata_sat.v00 --- sata_sat.v01 --- sata_sat.v02 --- sata_sat.v03 --- sata_sat.v04 --- scsi_aac.v00 --- scsi_adp.v00 --- scsi_aic.v00 --- scsi_bnx.v00 --- scsi_bnx.v01 --- scsi_fni.v00 --- scsi_hps.v00 --- scsi_ips.v00 --- scsi_meg.v00 --- scsi_meg.v01 --- scsi_meg.v02 --- scsi_mpt.v00 --- scsi_mpt.v01 --- scsi_mpt.v02 --- scsi_qla.v00 --- uhci_usb.v00 --- xhci_xhc.v00 --- tools.t00 --- xorg.v00 --- imgdb.tgz --- imgpayld.tgz",
            "tbootFile":"tboot.b00"
        },
        "target":"5988bd64df3287057100f6b6"
    },
    "id":"598ca6389f6324d6581291cc"
}
--------------------- >> end captured logging << ---------------------

----------------------------------------------------------------------
Ran 2 tests in 34.138s

FAILED (failures=1)

```