### PR TITLE
RAC-5917 Added more debug info for workflow

### DIFF
--- a/test/tests/bootstrap/test_api20_linux_bootstrap.py
+++ b/test/tests/bootstrap/test_api20_linux_bootstrap.py
@@ -31,8 +31,10 @@ from nose.plugins.attrib import attr
 import fit_common
 import flogging
 import random
+import json
 import time
 from nosedep import depends
+from datetime import datetime
 log = flogging.get_loggers()
 
 # sample default base payload
@@ -50,9 +52,23 @@ if config:
     PAYLOAD = config
 
 
+# function to return the value of a field from the workflow response
+def findall(obj, key):
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if k == key:
+                log.error(" workflow error: %s", v)
+            findall(v, key)
+    elif isinstance(obj, list):
+        for item in obj:
+            findall(item, key)
+    else:
+        pass
+
+
 # this routine polls a workflow task ID for completion
 def wait_for_workflow_complete(instanceid, start_time, waittime=7200, cycle=30):
-    log.info_5(" Workflow started at time: " + str(start_time))
+    log.info_1(" Workflow started at time: " + str(datetime.fromtimestamp(start_time)))
     while time.time() - start_time < waittime:  # limit test to waittime seconds
         result = fit_common.rackhdapi("/api/2.0/workflows/" + instanceid)
         if result['status'] != 200:
@@ -62,13 +78,28 @@ def wait_for_workflow_complete(instanceid, start_time, waittime=7200, cycle=30):
             log.info_5("{} workflow status: {}".format(result['json']['injectableName'], result['json']['status']))
             fit_common.time.sleep(cycle)
         elif result['json']['status'] == 'succeeded':
-            log.info_5("{} workflow status: {}".format(result['json']['injectableName'], result['json']['status']))
-            log.info_5(" Workflow completed at time: " + str(time.time()))
+            log.info_1("{} workflow status: {}".format(result['json']['injectableName'], result['json']['status']))
+            end_time = time.time()
+            log.info_1(" Workflow completed at time: " + str(datetime.fromtimestamp(end_time)))
+            log.info_1(" Workflow duration: " + str(end_time - start_time))
             return True
         else:
-            log.error(" Workflow failed: status: %s text: %s", result['json']['status'], result['text'])
+            end_time = time.time()
+            log.info_1(" Workflow failed at time: " + str(datetime.fromtimestamp(end_time)))
+            log.info_1(" Workflow duration: " + str(end_time - start_time))
+            try:
+                res = json.loads(result['text'])
+                findall(res, "error")
+            except:
+                res = result['text']
+            log.error(" Workflow failed: status: %s", result['json']['status'])
+            log.error(" Data: %s", json.dumps(res, indent=4, separators=(',', ':')))
             return False
-    log.error(" Workflow Timeout: " + result['text'])
+    try:
+        res = json.loads(result['text'])
+    except:
+        res = result['text']
+    log.error(" Workflow Timeout: " + json.dumps(res, indent=4, separators=(',', ':')))
     return False
 
 
@@ -81,18 +112,39 @@ class api20_bootstrap_linux(fit_common.unittest.TestCase):
     def setUpClass(cls):
         # Get the list of nodes
         NODECATALOG = fit_common.node_select()
+        assert (len(NODECATALOG) != 0), "There are no nodes currently discovered"
+
         # Select one node at random
         cls.__NODE = NODECATALOG[random.randint(0, len(NODECATALOG) - 1)]
+
+        # Print node Id, node BMC mac ,node type
+        nodeinfo = fit_common.rackhdapi('/api/2.0/nodes/' + cls.__NODE)['json']
+        nodesku = fit_common.rackhdapi(nodeinfo.get('sku'))['json']['name']
+        monurl = "/api/2.0/nodes/" + cls.__NODE + "/catalogs/bmc"
+        mondata = fit_common.rackhdapi(monurl, action="get")
+        catalog = mondata['json']
+        bmcresult = mondata['status']
+        if bmcresult != 200:
+            log.info_1(" Node ID: " + cls.__NODE)
+            log.info_1(" Error on catalog/bmc command")
+        else:
+            log.info_1(" Node ID: " + cls.__NODE)
+            log.info_1(" Node SKU: " + nodesku)
+            log.info_1(" Node BMC Mac: %s", catalog.get('data')['MAC Address'])
+            log.info_1(" Node BMC IP Addr: %s", catalog.get('data')['IP Address'])
+            log.info_1(" Node BMC IP Addr Src: %s", catalog.get('data')['IP Address Source'])
+
         # delete active workflows for specified node
-        fit_common.cancel_active_workflows(cls.__NODE)
+        result = fit_common.cancel_active_workflows(cls.__NODE)
+        assert (result is True), "There are still some active workflows running against the node"
 
     def test01_node_check(self):
         # Log node data
         nodeinfo = fit_common.rackhdapi('/api/2.0/nodes/' + self.__class__.__NODE)['json']
         nodesku = fit_common.rackhdapi(nodeinfo.get('sku'))['json']['name']
-        log.info_5(" Node ID: " + self.__class__.__NODE)
-        log.info_5(" Node SKU: " + nodesku)
-        log.info_5(" Graph Name: " + PAYLOAD['name'])
+        log.info_1(" Node ID: " + self.__class__.__NODE)
+        log.info_1(" Node SKU: " + nodesku)
+        log.info_1(" Graph Name: Graph.PowerOn.Node")
 
         # Ensure the compute node is powered on and reachable
         result = fit_common.rackhdapi('/api/2.0/nodes/' +
@@ -105,6 +157,14 @@ class api20_bootstrap_linux(fit_common.unittest.TestCase):
 
     @depends(after=test01_node_check)
     def test02_os_install(self):
+        # Log node data
+        nodeinfo = fit_common.rackhdapi('/api/2.0/nodes/' + self.__class__.__NODE)['json']
+        nodesku = fit_common.rackhdapi(nodeinfo.get('sku'))['json']['name']
+        log.info_1(" Node ID: " + self.__class__.__NODE)
+        log.info_1(" Node SKU: " + nodesku)
+        log.info_1(" Graph Name: Graph.InstallCentOS")
+        log.info_1(" Payload: " + fit_common.json.dumps(PAYLOAD))
+
         # launch workflow
         workflowid = None
         result = fit_common.rackhdapi('/api/2.0/nodes/' +
@@ -113,13 +173,11 @@ class api20_bootstrap_linux(fit_common.unittest.TestCase):
                                       action='post', payload=PAYLOAD)
         if result['status'] == 201:
             # workflow running
-            log.info_5(" InstanceID: " + result['json']['instanceId'])
-            log.info_5(" Payload: " + fit_common.json.dumps(PAYLOAD))
+            log.info_1(" InstanceID: " + result['json']['instanceId'])
             workflowid = result['json']['instanceId']
         else:
             # workflow failed with response code
             log.error(" InstanceID: " + result['text'])
-            log.error(" Payload: " + fit_common.json.dumps(PAYLOAD))
             self.fail("Workflow failed with response code: " + result['status'])
         self.assertTrue(wait_for_workflow_complete(workflowid, time.time()), "OS Install workflow failed, see logs.")
 


### PR DESCRIPTION
Error sample: 

(fit)ndetau@lab01:~/Dev/rack-5835-3/rackhd/test$ ./run_tests.py -stack 14 -config config-mn -test tests/bootstrap/test_api20_windows_bootstrap.py -nodeid 5988bd64df3287057100f6b6
*** Using config file path: config-mn
*** Created config file: config-mn/generated/fit-config-20170810-221041
*** Using config file: config-mn/generated/fit-config-20170810-221041
2017-08-10 22:10:42,859 INFO    this runs logging dir /emc/ndetau/Dev/rack-5835-3/rackhd/test/log_output/run_2017-08-10_22:10:42.d infra.run **.** 24873 MainProcess stream-monitor/flogging/infra_logging.py:__init__@148 gl-main [any tests]
2017-08-10 22:10:42,862 INFO     Start Of Test Block: 1                                                                    root 
*** Reloading config file: config-mn/generated/fit-config-20170810-221041
restful: Action =  post , URL =  https://stack14-ora.admin:443/login
/emc/ndetau/Dev/rack-5835-3/rackhd/test/.venv/fit/local/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py:791: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.org/en/latest/security.html
  InsecureRequestWarning)
restful: Status code = 200 

restful: Action =  post , URL =  https://stack14-ora.admin:443/login
/emc/ndetau/Dev/rack-5835-3/rackhd/test/.venv/fit/local/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py:791: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.org/en/latest/security.html
  InsecureRequestWarning)
restful: Status code = 200 

restful: Action =  post , URL =  https://stack14-ora.admin:443/redfish/v1/SessionService/Sessions
/emc/ndetau/Dev/rack-5835-3/rackhd/test/.venv/fit/local/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py:791: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.org/en/latest/security.html
  InsecureRequestWarning)
restful: Status code = 200 

restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/nodes/5988bd64df3287057100f6b6
restful: Status code = 200 

restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/skus/f2f8b16a-ac6d-4ee5-bf26-571aae9a077d
restful: Status code = 200 

restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/nodes/5988bd64df3287057100f6b6/catalogs/bmc
restful: Status code = 200 

2017-08-10 22:10:49,063 INFO_1   Node ID: 5988bd64df3287057100f6b6                                                         test.run 
2017-08-10 22:10:49,064 INFO_1   Node SKU: Quanta D51 2U                                                                   test.run 
2017-08-10 22:10:49,065 INFO_1   Node BMC Mac: 2c:60:0c:83:74:be                                                           test.run 
2017-08-10 22:10:49,065 INFO_1   Node BMC IP Addr: 172.31.128.8                                                            test.run 
2017-08-10 22:10:49,066 INFO_1   Node BMC IP Addr Src: DHCP Address                                                        test.run 
restful: Action =  put , URL =  http://stack14-ora.admin:8080/api/2.0/nodes/5988bd64df3287057100f6b6/workflows/action
restful: Status code = 404 

2017-08-10 22:10:49,100 INFO    +1.01 - STARTING TEST: [test01_node_check (test_api20_windows_bootstrap.api20_bootstrap_windows)] root 
test01_node_check (test_api20_windows_bootstrap.api20_bootstrap_windows) ... restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/nodes/5988bd64df3287057100f6b6
restful: Status code = 200 

restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/skus/f2f8b16a-ac6d-4ee5-bf26-571aae9a077d
restful: Status code = 200 

2017-08-10 22:10:49,657 INFO_1   Node ID: 5988bd64df3287057100f6b6                                                         test.run 
2017-08-10 22:10:49,658 INFO_1   Node SKU: Quanta D51 2U                                                                   test.run 
2017-08-10 22:10:49,659 INFO_1   Graph Name: Graph.PowerOn.Node                                                            test.run 
restful: Action =  post , URL =  http://stack14-ora.admin:8080/api/2.0/nodes/5988bd64df3287057100f6b6/workflows
restful: Status code = 201 

2017-08-10 22:10:49,732 INFO_1   Workflow started at time: 2017-08-10 22:10:49.732330                                      test.run 
restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/workflows/d5fc0a87-c610-4cb1-9fe7-1ac31266175d
restful: Status code = 200 

2017-08-10 22:10:50,268 INFO_1  Graph.PowerOn.Node workflow status: succeeded                                              test.run >1.01 24873 MainProcess stream-monitor/flogging/infra_logging.py:wrapper@129 gl-main [test01_node_check (test_api20_windows_bootstrap.api20_bootstrap_windows)]
2017-08-10 22:10:50,268 INFO_1   Workflow completed at time: 2017-08-10 22:10:50.268895                                    test.run 
2017-08-10 22:10:50,269 INFO_1   Workflow duration: 0.536564826965                                                         test.run 
ok
2017-08-10 22:10:50,271 INFO    -1.01 - ENDING TEST: [test01_node_check (test_api20_windows_bootstrap.api20_bootstrap_windows)] root 
2017-08-10 22:10:50,275 INFO    +1.02 - STARTING TEST: [test02_os_install (test_api20_windows_bootstrap.api20_bootstrap_windows)] root 
test02_os_install (test_api20_windows_bootstrap.api20_bootstrap_windows) ... restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/nodes/5988bd64df3287057100f6b6
restful: Status code = 200 

restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/skus/f2f8b16a-ac6d-4ee5-bf26-571aae9a077d
restful: Status code = 200 

2017-08-10 22:10:50,327 INFO_1   Node ID: 5988bd64df3287057100f6b6                                                         test.run 
2017-08-10 22:10:50,328 INFO_1   Node SKU: Quanta D51 2U                                                                   test.run 
2017-08-10 22:10:50,329 INFO_1   Graph Name: Graph.InstallWindowsServer                                                    test.run 
2017-08-10 22:10:50,329 INFO_1   Payload: {"name": "Graph.InstallWindowsServer", "options": {"defaults": {"repo": "http://172.31.128.1:8080/repo/winpe", "username": "rackhduser", "smbUser": "vagrant", "version": "2012", "smbPassword": "vagrant", "productkey": "XXXXX-XXXXX-XXXXX-XXXXX-XXXXX", "password": "RackHDRocks", "smbRepo": "\\\\172.31.128.1\\windowsServer2012"}}} test.run 
restful: Action =  post , URL =  http://stack14-ora.admin:8080/api/2.0/nodes/5988bd64df3287057100f6b6/workflows
restful: Status code = 201 

2017-08-10 22:10:50,482 INFO_1   InstanceID: 88fdb297-322a-4599-814e-db908fdff679                                          test.run 
2017-08-10 22:10:50,483 INFO_1   Workflow started at time: 2017-08-10 22:10:50.483310                                      test.run 
restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/workflows/88fdb297-322a-4599-814e-db908fdff679
restful: Status code = 200 

2017-08-10 22:10:51,017 INFO_5  Graph.InstallWindowsServer workflow status: running                                        test.run >1.02 24873 MainProcess stream-monitor/flogging/infra_logging.py:wrapper@129 gl-main [test02_os_install (test_api20_windows_bootstrap.api20_bootstrap_windows)]
restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/workflows/88fdb297-322a-4599-814e-db908fdff679
restful: Status code = 200 

2017-08-10 22:11:21,094 INFO_5  Graph.InstallWindowsServer workflow status: running                                        test.run >1.02 24873 MainProcess stream-monitor/flogging/infra_logging.py:wrapper@129 gl-main [test02_os_install (test_api20_windows_bootstrap.api20_bootstrap_windows)]
restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/workflows/88fdb297-322a-4599-814e-db908fdff679
restful: Status code = 200 

2017-08-10 22:11:51,148 INFO_1   Workflow failed at time: 2017-08-10 22:11:51.148272                                       test.run 
2017-08-10 22:11:51,150 INFO_1   Workflow duration: 60.6649620533                                                          test.run 
2017-08-10 22:11:51,151 ERROR    workflow error: TaskCancellationError
    at Task.cancel (/var/renasar/on-taskgraph/node_modules/on-tasks/lib/task.js:388:26)
    at /var/renasar/on-taskgraph/lib/task-runner.js:198:51
    at tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)
    at InnerObserver.Rx.FlatMapObservable.InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2096:43)
    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)
    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)
    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)
    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)
    at InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:4587:14)
    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)
    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)
    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)
    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)
    at InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5669:29)
    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)
    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)
    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)
    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)
    at InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5283:14)
    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)
    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)
    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)
    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)
    at scheduleItem (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:3075:16)
    at JustSink.run (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:3083:9)
    at JustObservable.subscribeCore (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:3064:19)
    at JustObservable.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)
    at setDisposable (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2038:46)
    at JustObservable.Rx.ObservableBase.ObservableBase._subscribe (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2053:9)
    at JustObservable.Rx.Observable.observableProto.subscribe.observableProto.forEach (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1990:19)
    at MapObservable.subscribeCore (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5268:26)
    at MapObservable.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)
    at setDisposable (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2038:46)
    at MapObservable.Rx.ObservableBase.ObservableBase._subscribe (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2053:9) test.run 
2017-08-10 22:11:51,154 ERROR    Workflow failed: status: cancelled                                                        test.run 
2017-08-10 22:11:51,155 ERROR    Data: {
    "node":"5988bd64df3287057100f6b6",
    "status":"cancelled",
    "domain":"default",
    "tasks":[
        {
            "terminalOnStates":[
                "timeout",
                "cancelled",
                "failed"
            ],
            "waitingOn":{
                "f6793da7-dcb0-45e1-848d-35b3dfbc19df":"succeeded"
            },
            "instanceId":"2920b748-e555-4d8f-906d-b925eab1a7c0",
            "taskStartTime":"2017-08-10T22:10:51.470Z",
            "state":"cancelled",
            "label":"install-os",
            "runJob":"Job.Os.Install",
            "error":"TaskCancellationError\n    at Task.cancel (/var/renasar/on-taskgraph/node_modules/on-tasks/lib/task.js:388:26)\n    at /var/renasar/on-taskgraph/lib/task-runner.js:198:51\n    at tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at InnerObserver.Rx.FlatMapObservable.InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2096:43)\n    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)\n    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:4587:14)\n    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)\n    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5669:29)\n    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)\n    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5283:14)\n    at InnerObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at InnerObserver.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at AutoDetachObserverPrototype.next (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5793:51)\n    at AutoDetachObserver.Rx.internals.AbstractObserver.AbstractObserver.onNext (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1721:31)\n    at scheduleItem (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:3075:16)\n    at JustSink.run (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:3083:9)\n    at JustObservable.subscribeCore (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:3064:19)\n    at JustObservable.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at setDisposable (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2038:46)\n    at JustObservable.Rx.ObservableBase.ObservableBase._subscribe (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2053:9)\n    at JustObservable.Rx.Observable.observableProto.subscribe.observableProto.forEach (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:1990:19)\n    at MapObservable.subscribeCore (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:5268:26)\n    at MapObservable.tryCatcher (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:63:31)\n    at setDisposable (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2038:46)\n    at MapObservable.Rx.ObservableBase.ObservableBase._subscribe (/var/renasar/on-taskgraph/node_modules/on-core/node_modules/rx/dist/rx.js:2053:9)",
            "options":{
                "profile":"windows.ipxe",
                "username":"rackhduser",
                "domain":"rackhd",
                "firewallDisable":false,
                "smbPassword":"REDACTED",
                "productkey":"XXXXX-XXXXX-XXXXX-XXXXX-XXXXX",
                "_taskTimeout":86400000,
                "hostname":"localhost",
                "repo":"http://172.31.128.1:8080/repo/winpe",
                "smbUser":"vagrant",
                "progressMilestones":{
                    "requestProfile":{
                        "description":"Enter ipxe and request OS installation profile",
                        "value":1
                    },
                    "startSetup":{
                        "description":"Net use Windows Server 2012 and start setup.exe",
                        "value":4
                    },
                    "startInstaller":{
                        "description":"Boot WinPE",
                        "value":3
                    },
                    "completed":{
                        "description":"Finished OS installation",
                        "value":5
                    },
                    "enterProfile":{
                        "description":"Enter profile, start to download WinPE",
                        "value":2
                    }
                },
                "version":"2012",
                "osType":"windows",
                "password":"REDACTED",
                "smbRepo":"\\\\172.31.128.1\\windowsServer2012"
            }
        },
        {
            "terminalOnStates":[],
            "instanceId":"7da0c417-8ec3-4741-9b51-cf723d30d8da",
            "waitingOn":{},
            "state":"succeeded",
            "label":"set-boot-pxe",
            "runJob":"Job.Obm.Node",
            "taskStartTime":"2017-08-10T22:10:50.486Z",
            "options":{
                "username":"rackhduser",
                "smbPassword":"REDACTED",
                "smbUser":"vagrant",
                "_taskTimeout":86400000,
                "repo":"http://172.31.128.1:8080/repo/winpe",
                "productkey":"XXXXX-XXXXX-XXXXX-XXXXX-XXXXX",
                "version":"2012",
                "action":"setBootPxe",
                "password":"REDACTED",
                "smbRepo":"\\\\172.31.128.1\\windowsServer2012"
            }
        },
        {
            "terminalOnStates":[
                "succeeded",
                "timeout",
                "cancelled",
                "failed"
            ],
            "instanceId":"f52bd8aa-ec32-402d-b39e-58dde87a6693",
            "state":"cancelled",
            "label":"firstboot-callback-notification-wait",
            "runJob":"Job.Wait.Notification",
            "waitingOn":{
                "2920b748-e555-4d8f-906d-b925eab1a7c0":"succeeded"
            },
            "options":{
                "_taskTimeout":86400000
            }
        },
        {
            "terminalOnStates":[
                "timeout",
                "cancelled",
                "failed"
            ],
            "instanceId":"f6793da7-dcb0-45e1-848d-35b3dfbc19df",
            "waitingOn":{
                "7da0c417-8ec3-4741-9b51-cf723d30d8da":[
                    "finished"
                ]
            },
            "state":"succeeded",
            "label":"reboot",
            "runJob":"Job.Obm.Node",
            "taskStartTime":"2017-08-10T22:10:50.630Z",
            "options":{
                "username":"rackhduser",
                "smbPassword":"REDACTED",
                "smbUser":"vagrant",
                "_taskTimeout":86400000,
                "repo":"http://172.31.128.1:8080/repo/winpe",
                "productkey":"XXXXX-XXXXX-XXXXX-XXXXX-XXXXX",
                "version":"2012",
                "action":"reboot",
                "password":"REDACTED",
                "smbRepo":"\\\\172.31.128.1\\windowsServer2012"
            }
        }
    ],
    "name":"Install Windows Server 2012",
    "definition":"/api/2.0/workflows/graphs/Graph.InstallWindowsServer",
    "injectableName":"Graph.InstallWindowsServer",
    "serviceGraph":"",
    "instanceId":"88fdb297-322a-4599-814e-db908fdff679",
    "logContext":{
        "graphInstance":"88fdb297-322a-4599-814e-db908fdff679",
        "graphName":"Install Windows Server 2012",
        "id":"5988bd64df3287057100f6b6"
    },
    "context":{
        "graphName":"Graph.InstallWindowsServer",
        "graphId":"88fdb297-322a-4599-814e-db908fdff679",
        "target":"5988bd64df3287057100f6b6"
    },
    "id":"598cd9ea9f6324d6581291d4"
} test.run 
2017-08-10 22:11:51,168 WARNING ------start captured data for FAIL in test02_os_install (test_api20_windows_bootstrap.api20_bootstrap_windows) root 
2017-08-10 22:11:51,169 WARNING stdout: restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/nodes/5988bd64df3287057100f6b6
restful: Status code = 200 

restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/skus/f2f8b16a-ac6d-4ee5-bf26-571aae9a077d
restful: Status code = 200 

restful: Action =  post , URL =  http://stack14-ora.admin:8080/api/2.0/nodes/5988bd64df3287057100f6b6/workflows
restful: Status code = 201 

restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/workflows/88fdb297-322a-4599-814e-db908fdff679
restful: Status code = 200 

restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/workflows/88fdb297-322a-4599-814e-db908fdff679
restful: Status code = 200 

restful: Action =  get , URL =  http://stack14-ora.admin:8080/api/2.0/workflows/88fdb297-322a-4599-814e-db908fdff679
restful: Status code = 200 

 root >1.02 24873 MainProcess stream-monitor/stream_sources/log_type.py:__capture_to_log@129 gl-main [test02_os_install (test_api20_windows_bootstrap.api20_bootstrap_windows)]
2017-08-10 22:11:51,169 WARNING stderr:                                                                                    root >1.02 24873 MainProcess stream-monitor/stream_sources/log_type.py:__capture_to_log@130 gl-main [test02_os_install (test_api20_windows_bootstrap.api20_bootstrap_windows)]
2017-08-10 22:11:51,170 WARNING traceback:   File "/usr/lib/python2.7/unittest/case.py", line 331, in run
    testMethod()
  File "/emc/ndetau/Dev/rack-5835-3/rackhd/test/.venv/fit/local/lib/python2.7/site-packages/nosedep.py", line 126, in inner
    return func(*args, **kwargs)
  File "/emc/ndetau/Dev/rack-5835-3/rackhd/test/tests/bootstrap/test_api20_windows_bootstrap.py", line 192, in test02_os_install
    self.assertTrue(wait_for_workflow_complete(workflowid, time.time()), "OS Install workflow failed, see logs.")
