### PR TITLE
WIP: RackHD +InfraSIM: All in Single Docker (Demo/ Mini CI ?)

### DIFF
--- a/example/demo/Dockerfile
+++ b/example/demo/Dockerfile
@@ -1,0 +1,33 @@
+FROM rackhd/pipeline:latest
+
+#Install InfraSIM
+RUN  apt-get update \
+&&   apt-get install -y bridge-utils \ 
+&&   apt-get install -y libnuma-dev \ 
+&&   apt-get install -y python-pip libpython-dev libssl-dev \
+&&   sudo pip install --upgrade pip \
+&&   sudo pip install setuptools  \
+&&   sudo pip install infrasim-compute
+
+RUN pip install virtualenv
+
+RUN mkdir /RackHD
+RUN mkdir -p /opt/monorail
+COPY ./build-deps /RackHD/
+COPY ./monorail /opt/monorail
+COPY rackhd.yml /
+
+
+# config InfraSIM
+RUN sudo infrasim init
+COPY infrasim_config.yml  /root/.infrasim/.node_map/default.yml
+RUN sudo infrasim node destroy
+
+
+
+COPY ./docker-entrypoint.sh /docker-entrypoint.sh
+
+
+EXPOSE 27017 5672 15672 67/udp 9080 9090 8443 69/udp 514/udp 68/udp 4011
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/example/demo/README.md
+++ b/example/demo/README.md
@@ -1,0 +1,12 @@
+# Build and Run RackHD demo
+
+1. clone and build RackHD code into a local folder (named build-deps).(e.x. using RackHD/example/install_rackhd.sh )
+2. move the build-deps into this folder
+3. Build a new docker images with the RackHD code in build-deps folder
+    docker build -t $name_of_image .
+4. Run this docker images with privileged mode
+    docker run -idt --rm --name=demo  --privileged  $name_of_image  /bin/bash
+5. Watch the logs. it will start RackHD, start an InfraSIM then run FIT smoke-test .
+   docker logs demo --follow
+
+

--- a/example/demo/docker-entrypoint.sh
+++ b/example/demo/docker-entrypoint.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Copyright 2016, EMC, Inc.
+
+# set -x
+waitForAPI() {
+  netstat -ntlp
+  timeout=0
+  maxto=60
+  set +e
+  url=http://localhost:9090/api/2.0/nodes
+  while [ ${timeout} != ${maxto} ]; do
+    wget --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 1 --continue ${url}
+    if [ $? = 0 ]; then
+      break
+    fi
+    sleep 10
+    timeout=`expr ${timeout} + 1`
+  done
+  set -e
+  if [ ${timeout} == ${maxto} ]; then
+    echo "Timed out waiting for RackHD API service (duration=`expr $maxto \* 10`s)."
+    exit 1
+  fi
+}
+
+rm -f /var/lib/dhcp/dhchp.leases
+touch /var/lib/dhcp/dhcpd.leases
+chown root:root /var/lib/dhcp/dhcpd.leases
+chmod 666 /var/lib/dhcp/dhcpd.leases
+
+service isc-dhcp-server stop
+
+mongod &
+sleep 1
+service rabbitmq-server start
+sleep 1
+
+# Set up br0
+brctl addbr br0
+ifconfig br0 promisc
+ifconfig br0 172.31.128.1
+
+
+
+pm2 status
+pm2 logs > /var/log/rackhd.log &
+pm2 start /rackhd.yml
+sleep 15 && infrasim node start &
+dhcpd -f -cf /etc/dhcp/dhcpd.conf -lf /var/lib/dhcp/dhcpd.leases --no-pid &
+
+waitForAPI
+
+pushd /RackHD/RackHD/test
+rm -rf .venv/on-build-config
+./mkenv.sh on-build-config
+source myenv_on-build-config
+python run_tests.py -test deploy/rackhd_stack_init.py -stack docker_local_run -numvms 1 -rackhd_host localhost -port 9090 -xunit -v 9
+python run_tests.py -test tests -group smoke -stack docker_local_run -numvms 1 -rackhd_host localhost -port 9090 -xunit -v 9
+deactive
+popd

--- a/example/demo/infrasim_config.yml
+++ b/example/demo/infrasim_config.yml
@@ -1,0 +1,90 @@
+---
+#This file is used as InfraSIM configuration file
+name: default
+
+#Node type of your infrasim compute, this will determine the
+#bmc emulation data and bios binary to use.
+#Supported compute node names:
+#	quanta_d51
+#	quanta_t41
+#	dell_c6320
+#	dell_r630
+#	dell_r730
+#	dell_r730xd
+#	s2600kp
+#	s2600tp
+#	s2600wtt
+type: quanta_d51
+
+compute:
+
+    boot:
+        splash: /usr/local/infrasim/data/boot_logo.jpg
+    cpu:
+        #Set node cpu num, the default value is 2
+        #
+        quantities: 2
+
+        #Set node cpu type, the default value is Haswell
+        #Supported type:
+        #	core2duo:  Intel(R) Core(TM)2 Duo CPU     T7700  @ 2.40GHz
+        #	coreduo:   Genuine Intel(R) CPU           T2600  @ 2.16GHz
+        #	Nehalem:   Intel Core i7 9xx (Nehalem Class Core i7)
+        #	Westmere:  Westmere E56xx/L56xx/X56xx (Nehalem-C)
+        #	SandyBridge:  Intel Xeon E312xx (Sandy Bridge)
+        #	IvyBridge:  Intel Xeon E3-12xx v2 (Ivy Bridge)
+        #	Haswell:  Intel Core Processor (Haswell)
+        #	Broadwell:  Intel Core Processor (Broadwell)
+        #   host:  default, KVM processor with all supported host features
+        #          (only available in KVM mode)
+        #
+        type: Haswell
+
+    memory:
+        #Set node memory size, the unit is MB.
+        #The default vaule is 512MB
+        #
+        size: 1024
+
+    storage_backend:
+        #Set drive list and define drive attributes
+        -
+            type: ahci
+            max_drive_per_controller: 6 
+            drives:
+            
+            -
+                #Set node disk size, the unit is GB.
+                #The default value is 8GB
+                #
+                size: 8
+            
+
+    networks:
+        #Set network list and define drive attributes
+        #
+        
+        -
+            #Set node network mode for qemu. The options should be:
+            #	nat		--default
+            #	macvtap
+            #	bridge
+            #
+            network_mode: bridge
+
+            #If you use bridge mode, please specify this with bridge name
+            #
+            network_name: br0
+
+            #Set network device for qemu. The options should be:
+            #	vmxnet3 
+            #   e1000       --default
+            device: e1000
+
+            #Set MAC for this network, this MAC is generated with
+            #datetime as random seed, but you can specify yours
+            #
+        
+bmc:
+    interface: br0
+    # cdrom: /dev/sr0

--- a/example/demo/monorail/config.json
+++ b/example/demo/monorail/config.json
@@ -1,0 +1,65 @@
+{
+    "CIDRNet": "172.31.128.0/22",
+    "amqp": "amqp://localhost",
+    "apiServerAddress": "172.31.128.1",
+    "apiServerPort": 9080,
+    "broadcastaddr": "172.31.131.255",
+    "dhcpGateway": "172.31.128.1",
+    "dhcpProxyBindAddress": "172.31.128.1",
+    "dhcpProxyBindPort": 4011,
+    "dhcpSubnetMask": "255.255.252.0",
+    "gatewayaddr": "172.31.128.1",
+    "httpEndpoints": [
+        {
+            "address": "0.0.0.0",
+            "port": 9090,
+            "httpsEnabled": false,
+            "proxiesEnabled": true,
+            "authEnabled": false,
+            "httpsCert": "data/dev-cert.pem",
+            "httpsKey": "data/dev-key.pem",
+            "routers": "northbound-api-router"
+        },
+        {
+            "address": "0.0.0.0",
+            "port": 8443,
+            "httpsEnabled": true,
+            "proxiesEnabled": true,
+            "authEnabled": true,
+            "routers": "northbound-api-router"
+        },
+        {
+            "address": "172.31.128.1",
+            "port": 9080,
+            "httpsEnabled": false,
+            "proxiesEnabled": true,
+            "authEnabled": false,
+            "routers": "southbound-api-router"
+        }
+    ],
+    "httpDocsRoot": "./build/apidoc",
+    "httpFileServiceRoot": "./static/files",
+    "httpFileServiceType": "FileSystem",
+    "httpProxies": [{
+        "localPath": "/repo/",
+        "server": "http://10.240.19.193",
+        "remotePath": "/repo/"
+    }],
+    "httpStaticRoot": "/opt/monorail/static/http",
+    "authUsername": "admin",
+    "authPasswordHash": "KcBN9YobNV0wdux8h0fKNqi4uoKCgGl/j8c6YGlG7iA0PB3P9ojbmANGhDlcSBE0iOTIsYsGbtSsbqP4wvsVcw==",
+    "authPasswordSalt": "zlxkgxjvcFwm0M8sWaGojh25qNYO8tuNWUMN4xKPH93PidwkCAvaX2JItLA3p7BSCWIzkw4GwWuezoMvKf3UXg==",
+    "authTokenSecret": "RackHDRocks!",
+    "authTokenExpireIn": 86400,
+    "autoCreateObm": "true",
+    "mongo": "mongodb://localhost/pxe",
+    "sharedKey": "qxfO2D3tIJsZACu7UA6Fbw0avowo8r79ALzn+WeuC8M=",
+    "statsd": "127.0.0.1:8125",
+    "subnetmask": "255.255.252.0",
+    "syslogBindAddress": "172.31.128.1",
+    "syslogBindPort": 514,
+    "tftpBindAddress": "172.31.128.1",
+    "tftpBindPort": 69,
+    "tftpRoot": "./static/tftp",
+    "minLogLevel": 0
+}

--- a/example/demo/rackhd.yml
+++ b/example/demo/rackhd.yml
@@ -1,0 +1,16 @@
+apps:
+  - script: index.js
+    name: on-taskgraph
+    cwd: /RackHD/on-taskgraph
+  - script: index.js
+    name: on-http
+    cwd: /RackHD/on-http
+  - script: index.js
+    name: on-dhcp-proxy
+    cwd: /RackHD/on-dhcp-proxy
+  - script: index.js
+    name: on-syslog
+    cwd: /RackHD/on-syslog
+  - script: index.js
+    name: on-tftp
+    cwd: /RackHD/on-tftp


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14049268/30419907-96f91824-996a-11e7-8488-1387f2604841.png)


![image](https://user-images.githubusercontent.com/14049268/30419864-75a7d476-996a-11e7-974d-ac80f9a3f2b2.png)

![image](https://user-images.githubusercontent.com/14049268/30419848-66daa7c0-996a-11e7-8c64-704d398e1da9.png)


---------------------------
demo usage:
(1) if it's a pre-build docker images (RackHD src code included)
- User just need to install docker, and start it. all set .
- per suggestion: the FIT should not be inlcuded in the entry-point.sh, but can be run via "docker exec" out of band more flexiable.

(2) if user mount RackHD src code via volume,
- user clone/build rackhd src
- start the docker images with above rackhd code mounted

---------------------------
several options to inlcude RackHD src code:
(1) provide a shell script to clone/build RackHD from src code, and docker-build to include the codes
(2) add this docker image as a output of Sprint Release, so user don't need to clone+build src code.

-----------------------


WIP. Don't merge.

Why:
this is to provide a contained based CI or Demo solution.
the outcome of the docker build image will be a single docker image, run RackHD + InfraSIM + FIT.

more usage , please refer to the README.md

Note: 
there're issues in InfraSIM/RackHD which FIT smoke/os-install will fail. refer to  [RAC-5891](https://rackhd.atlassian.net/browse/RAC-5891?filter=-1) for more detail.


ToDo:
- make FIT an optional.
- polish the code.
- can build rackhd code during docker-build

