### PR TITLE
[RAC-5894] Fix the bug:vagrant without jq

### DIFF
--- a/example/Vagrantfile
+++ b/example/Vagrantfile
@@ -77,6 +77,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
         target.vm.provision "shell", inline: <<-SHELL
           sudo service isc-dhcp-server start
+          sudo apt-get install -y jq
         #   service rsyslog stop
         #   echo manual | sudo tee /etc/init/rsyslog.override
         SHELL

--- a/example/dev-env-setup/roles/build/tasks/main.yml
+++ b/example/dev-env-setup/roles/build/tasks/main.yml
@@ -7,4 +7,5 @@
    - g++
    - libkrb5-dev
    - unzip
+   - jq
   sudo: yes


### PR DESCRIPTION
**Background**
The manual's walkthrough of rackhd with a vagrant box makes extensive use of 'jq', which isn't actually installed. The jq package should be added in vagrant-based demo and dev environment.

**Reviewers**
@iceiilin @pengz1 @anhou 