### PR TITLE
RAC-5979 - updates to rackhd_stack_init.py

### DIFF
--- a/test/common/fit_common.py
+++ b/test/common/fit_common.py
@@ -817,6 +817,7 @@ def power_control_all_nodes(state):
 
     # Send power on/off to all of them
     for bmc in BMC_LIST:
+        print "Power " + state + " node: " + bmc['ip']
         return_code = remote_shell('ipmitool -I lanplus -H ' + bmc['ip'] +
                                    ' -U ' + bmc['user'] + ' -P ' +
                                    bmc['pw'] + ' -R 4 -N 3 chassis power ' + state)

--- a/test/deploy/rackhd_stack_init.py
+++ b/test/deploy/rackhd_stack_init.py
@@ -123,12 +123,19 @@ class rackhd_stack_init(unittest.TestCase):
         # no PDU case
         else:
             log.info_5('**** No supported PDU found, restarting nodes using IPMI.')
-            # Power cycle all nodes via IPMI, display warning if no nodes found
-            if fit_common.power_control_all_nodes("off") == 0:
-                log.info_5('**** No BMC IP addresses found in arp table, continuing without node restart.')
+            # Check if some nodes are already discovered
+            nodes = []
+            nodes = fit_common.node_select()
+            if nodes:
+                log.info_5(" Nodes already discovered, skipping ipmi power reset")
+                log.info_5(" %s", nodes)
             else:
-                # power on all nodes under any circumstances
-                fit_common.power_control_all_nodes("on")
+                # Power cycle all nodes via IPMI, display warning if no nodes found
+                if fit_common.power_control_all_nodes("off") == 0:
+                    log.info_5('**** No BMC IP addresses found in arp table, continuing without node restart.')
+                else:
+                    # power on all nodes under any circumstances
+                    fit_common.power_control_all_nodes("on")
 
     # Optionally install control switch node if present
     @unittest.skipUnless("control" in fit_common.fitcfg(), "")


### PR DESCRIPTION
Add update to test04_power_nodes_on.
If nodes are already present in the nodes list, don't perform a power cycle.
Assuming the nodes are then in a discovery process and following test will wait for the active workflows to complete.
paired with Derrick Ostertag.