### PR TITLE
restore apiServerPort back to 9080 to use on-http southbound interface

### DIFF
--- a/docker/monorail/config.json
+++ b/docker/monorail/config.json
@@ -1,7 +1,7 @@
 {
     "amqp": "amqp://127.0.0.1",
     "apiServerAddress": "172.31.128.1",
-    "apiServerPort": 9030,
+    "apiServerPort": 9080,
     "authPasswordHash": "KcBN9YobNV0wdux8h0fKNqi4uoKCgGl/j8c6YGlG7iA0PB3P9ojbmANGhDlcSBE0iOTIsYsGbtSsbqP4wvsVcw==",
     "authPasswordSalt": "zlxkgxjvcFwm0M8sWaGojh25qNYO8tuNWUMN4xKPH93PidwkCAvaX2JItLA3p7BSCWIzkw4GwWuezoMvKf3UXg==",
     "authTokenExpireIn": 86400,

--- a/packer/ansible/roles/monorail/files/config.json
+++ b/packer/ansible/roles/monorail/files/config.json
@@ -2,7 +2,7 @@
     "amqp": "amqp://localhost",
     "apiServerAddress": "172.31.128.1",
     "rackhdPublicIp": null, 
-    "apiServerPort": 9030,
+    "apiServerPort": 9080,
     "dhcpGateway": "172.31.128.1",
     "dhcpProxyBindAddress": "172.31.128.1",
     "dhcpProxyBindPort": 4011,

--- a/test/config/rackhd_default.json
+++ b/test/config/rackhd_default.json
@@ -2,7 +2,7 @@
   "rackhd-config": {
     "amqp": "amqp://localhost",
     "apiServerAddress": "172.31.128.1",
-    "apiServerPort": 9030,
+    "apiServerPort": 9080,
     "autoCreateObm": "true",
     "dhcpPollerActive": false,
     "dhcpGateway": "172.31.128.1",


### PR DESCRIPTION
This PR will switch the apiiServerPort back to 9080, which is the southbound port for on-http. 
@RackHD/committers 