### PR TITLE
RAC-5949 change docker-compose build default tag from latest to devel

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,1 +1,1 @@
-TAG=latest
+TAG=devel


### PR DESCRIPTION
With this modification, the community user will build and use docker images with devel tag.

@panpan0000 @PengTian0 