### PR TITLE
HotFix for OVA Cache Build.

### DIFF
--- a/packer/build_ova.sh
+++ b/packer/build_ova.sh
@@ -345,4 +345,6 @@ cd $RACKHD_DIR/packer
 varDefine
 prepareMaterials
 packerBuildOVA
-postProcess
+if [ "$BUILD_STAGE" != "BUILD_TEMPLATE" ]; then
+    postProcess
+fi


### PR DESCRIPTION
if running OVA cache build, there's no output-vmware-vmx folder , so ovftool at the post-process function will fail.

this PR is a hot fix.


Test pass:

http://rackhd.ci.xxxxx/job/OVA_CACHE_BUILD/174