### PR TITLE
Fix the issue of visiting SMI firmware update service

### DIFF
--- a/docker/dell/docker-compose.yml
+++ b/docker/dell/docker-compose.yml
@@ -1,3 +1,5 @@
+# Copyright 2017, Dell EMC, Inc.
+
 version: '2'
 
 services:
@@ -17,6 +19,8 @@ services:
     - "8400:8400"
     - "8500:8500"
     - "53:53"
+    extra_hosts:
+    - "service-registry:${REGISTRY_IP}"
     # uncoment the line below to persist/reuse data after container is destroyed
     #volumes:
     #- /var/consul/data:/consul/data


### PR DESCRIPTION
**Background**
smi-service API could be invoked through each individual smi-service or smi-service-gateway which could be controlled by config file. During development of previous stories, we found it was failed to invoke API through gateway but successful through individual smi-services. We need to resolve this problem.
https://rackhd.atlassian.net/browse/RAC-6424

**Done**
Add extra_hosts: service-registry for consul.

**Reviewers**
@rahmanmuhamad  @RackHD/corecommitters @nortonluo 