### PR TITLE
add systemErase for simConfig.json

### DIFF
--- a/docker/dell/config/gateway.yml
+++ b/docker/dell/config/gateway.yml
@@ -1,3 +1,5 @@
+# Copyright 2017, Dell EMC, Inc.
+
 zuul:
   host:
     connect-timeout-millis: 100000
@@ -304,6 +306,9 @@ smi:
         -
           name: "configureBios"
           url: "/api/1.0/server/configuration/configureBios"
+        -
+          name: "systemErase"
+          url: "/api/1.0/server/configuration/systemErase"
       name: "configuration"
     -
       endpoint:


### PR DESCRIPTION
**Background**
Based on the previous investigation result, develop to port Graph.Dell.Racadm.ResetComponents and /Systems/{identifier}/Bios.ResetBios to use WSMAN API.
https://rackhd.atlassian.net/browse/RAC-6481

We use `/api/1.0/server/configuration/systemErase` from SMI services to reset components.

**Done**
add systemErase for simConfig.json



@rahmanmuhamad @RackHD/corecommitters @nortonluo 