### PR TITLE
RAC-6412: fix original FIT test cases for ucs-service

### DIFF
--- a/test/config/stack_config.json
+++ b/test/config/stack_config.json
@@ -65,6 +65,8 @@
   "docker_local_run":{
     "rackhd_host": "localhost",
     "type": "linux",
+    "ucs_service_uri" : "https://localhost:7080",
+    "ucsm_config_file" : "./tests/ucs/ucsm_config.xml",
     "install-config": {
       "ports": {
         "mongo_port": 27017,

--- a/test/tests/ucs/test_ucs_api.py
+++ b/test/tests/ucs/test_ucs_api.py
@@ -24,7 +24,6 @@ UCSM_IP = fit_common.fitcfg().get('ucsm_ip')
 UCS_SERVICE_URI = fit_common.fitcfg().get('ucs_service_uri')
 UCSM_USER, UCSM_PASS = get_ucs_cred()
 
-
 @attr(all=True, regression=True, smoke=False, ucs=True)
 class ucs_api(unittest.TestCase):
 
@@ -142,7 +141,7 @@ class ucs_api(unittest.TestCase):
         total_elements = 0
         for elementTypes in api_data["json"]:
             for element in api_data["json"][str(elementTypes)]:
-                url, headers = self.ucs_url_factory("catalog", identifier=element["relative_path"].split("/")[-1])
+                url, headers = self.ucs_url_factory("catalog", identifier=element["relative_path"].strip("/"))
                 api_data_c = fit_common.restful(url, rest_headers=headers)
                 self.assertEqual(api_data_c['status'], 200,
                                  'Incorrect HTTP return code, expected 200, got:' + str(api_data_c['status']))


### PR DESCRIPTION
1. Add ucs option to "docker_local_run" which is the stack used to run FIT.
2. Fix error : the api /catalog?identifier=switch-B is not supported.


@pengz1 @anhou @geoff-reid @tannoa2 