### PR TITLE
RAC-6415: get account of ucs manager and physical nodes from config

### DIFF
--- a/test/config/ucs.json
+++ b/test/config/ucs.json
@@ -1,0 +1,7 @@
+{
+    "ucsm_ip":"172.31.128.252",
+    "ucsm_user":"user",
+    "ucsm_pass":"password",
+    "physical_nodes_count": 4
+}
+

--- a/test/tests/ucs/ucs_common.py
+++ b/test/tests/ucs/ucs_common.py
@@ -22,9 +22,12 @@ INITIAL_NODES = {}
 INITIAL_OBMS = {}
 MAX_WAIT = 240
 UCSM_IP = fit_common.fitcfg().get('ucsm_ip')
-UCSM_USER, UCSM_PASS = get_ucs_cred()
-UCS_SERVICE_URI = fit_common.fitcfg().get('ucs_service_uri')
+UCSM_USER = fit_common.fitcfg().get('ucsm_user')
+UCSM_PASS = fit_common.fitcfg().get('ucsm_pass')
 EXPECTED_UCS_PHYSICAL_NODES = 22
+if fit_common.fitcfg().get('physical_nodes_count') is not None:
+    EXPECTED_UCS_PHYSICAL_NODES = int(fit_common.fitcfg().get('physical_nodes_count'))
+UCS_SERVICE_URI = fit_common.fitcfg().get('ucs_service_uri')
 
 
 def get_nodes_utility():


### PR DESCRIPTION
The PR reads user account and physical nodes count from config file.
Because these info of ucs baremetal are different with ucs simulator.

@anhou @keedya @geoff-reid 