### PR TITLE
fix WSMAN powerthermal poller issue

### DIFF
--- a/docker/dell/config/gateway.yml
+++ b/docker/dell/config/gateway.yml
@@ -46,7 +46,7 @@ zuul:
       serviceId: SERVER-OS-DEPLOYMENT
       stripPrefix: false
     POWER-THERMAL-MONITORING:
-      path: /api/1.0/powerthermal/**
+      path: /api/1.0/server/powerthermal/**
       serviceId: POWER-THERMAL-MONITORING
       stripPrefix: false
     SWAGGER-AGGREGATOR:


### PR DESCRIPTION
WSMAN powerthermal poller could not get correct poller data which is partially fixed in the PR https://github.com/RackHD/RackHD/pull/925.
Here is to update the path in SMI gateway routes.

https://rackhd.atlassian.net/browse/RAC-6694

@RackHD/corecommitters @iceiilin @nortonluo 